### PR TITLE
⚡ Bolt: Optimize formatter config lookup with findFirstUp

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-01-25 - Cache Compiled RegExp in Hot Paths
 **Learning:** Recompiling regexes in utility functions called in loops (like `Wildcard.match`) is expensive (measured ~18x overhead).
 **Action:** Use a simple module-level `Map` cache for compiled `RegExp` objects when patterns are repetitive.
+
+## 2026-02-14 - Optimize File Lookup
+**Learning:** `Filesystem.findUp` in this codebase returns *all* matches up the directory tree (for config aggregation). Using it just to check if a file exists or to find the closest one is inefficient O(depth).
+**Action:** Use `Filesystem.findFirstUp` when you only need the closest match or to check existence.

--- a/packages/agent-core/src/format/formatter.ts
+++ b/packages/agent-core/src/format/formatter.ts
@@ -131,8 +131,8 @@ export const biome: Info = {
   async enabled() {
     const configs = ["biome.json", "biome.jsonc"]
     for (const config of configs) {
-      const found = await Filesystem.findUp(config, Instance.directory, Instance.worktree)
-      if (found.length > 0) {
+      const found = await Filesystem.findFirstUp(config, Instance.directory, Instance.worktree)
+      if (found) {
         return true
       }
     }
@@ -154,8 +154,8 @@ export const clang: Info = {
   command: ["clang-format", "-i", "$FILE"],
   extensions: [".c", ".cc", ".cpp", ".cxx", ".c++", ".h", ".hh", ".hpp", ".hxx", ".h++", ".ino", ".C", ".H"],
   async enabled() {
-    const items = await Filesystem.findUp(".clang-format", Instance.directory, Instance.worktree)
-    return items.length > 0
+    const items = await Filesystem.findFirstUp(".clang-format", Instance.directory, Instance.worktree)
+    return !!items
   },
 }
 
@@ -176,10 +176,10 @@ export const ruff: Info = {
     if (!Bun.which("ruff")) return false
     const configs = ["pyproject.toml", "ruff.toml", ".ruff.toml"]
     for (const config of configs) {
-      const found = await Filesystem.findUp(config, Instance.directory, Instance.worktree)
-      if (found.length > 0) {
+      const found = await Filesystem.findFirstUp(config, Instance.directory, Instance.worktree)
+      if (found) {
         if (config === "pyproject.toml") {
-          const content = await Bun.file(found[0]).text()
+          const content = await Bun.file(found).text()
           if (content.includes("[tool.ruff]")) return true
         } else {
           return true
@@ -188,9 +188,9 @@ export const ruff: Info = {
     }
     const deps = ["requirements.txt", "pyproject.toml", "Pipfile"]
     for (const dep of deps) {
-      const found = await Filesystem.findUp(dep, Instance.directory, Instance.worktree)
-      if (found.length > 0) {
-        const content = await Bun.file(found[0]).text()
+      const found = await Filesystem.findFirstUp(dep, Instance.directory, Instance.worktree)
+      if (found) {
+        const content = await Bun.file(found).text()
         if (content.includes("ruff")) return true
       }
     }
@@ -282,8 +282,8 @@ export const ocamlformat: Info = {
   extensions: [".ml", ".mli"],
   async enabled() {
     if (!Bun.which("ocamlformat")) return false
-    const items = await Filesystem.findUp(".ocamlformat", Instance.directory, Instance.worktree)
-    return items.length > 0
+    const items = await Filesystem.findFirstUp(".ocamlformat", Instance.directory, Instance.worktree)
+    return !!items
   },
 }
 

--- a/packages/agent-core/src/util/filesystem.ts
+++ b/packages/agent-core/src/util/filesystem.ts
@@ -82,6 +82,19 @@ export namespace Filesystem {
     return result
   }
 
+  export async function findFirstUp(target: string, start: string, stop?: string): Promise<string | undefined> {
+    let current = start
+    while (true) {
+      const search = join(current, target)
+      if (await exists(search)) return search
+      if (stop === current) break
+      const parent = dirname(current)
+      if (parent === current) break
+      current = parent
+    }
+    return undefined
+  }
+
   export async function* up(options: { targets: string[]; start: string; stop?: string }) {
     const { targets, start, stop } = options
     let current = start

--- a/packages/agent-core/test/util/filesystem.test.ts
+++ b/packages/agent-core/test/util/filesystem.test.ts
@@ -36,4 +36,32 @@ describe("util.filesystem", () => {
 
     await rm(tmp, { recursive: true, force: true })
   })
+
+  test("findFirstUp() returns the closest match", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "opencode-filesystem-"))
+    const dir = path.join(tmp, "dir", "subdir")
+    await mkdir(dir, { recursive: true })
+
+    const file1 = path.join(tmp, "file.txt")
+    const file2 = path.join(tmp, "dir", "file.txt")
+
+    await Bun.write(file1, "root")
+    await Bun.write(file2, "nested")
+
+    const found = await Filesystem.findFirstUp("file.txt", dir, tmp)
+    expect(found).toBe(file2)
+
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  test("findFirstUp() returns undefined if not found", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "opencode-filesystem-"))
+    const dir = path.join(tmp, "dir")
+    await mkdir(dir, { recursive: true })
+
+    const found = await Filesystem.findFirstUp("missing.txt", dir, tmp)
+    expect(found).toBeUndefined()
+
+    await rm(tmp, { recursive: true, force: true })
+  })
 })


### PR DESCRIPTION
💡 What: Implemented `Filesystem.findFirstUp` and used it in `formatter.ts`.
🎯 Why: `Filesystem.findUp` scans the entire directory tree to the root to find all occurrences, which is inefficient when only checking for existence or the closest match.
📊 Impact: Reduces unnecessary file system `stat` calls during formatter detection, especially in deep hierarchies.
🔬 Measurement: Verified with new tests in `filesystem.test.ts` and existing tests passed (ignoring unrelated timeouts/failures).

---
*PR created automatically by Jules for task [8329414175353178197](https://jules.google.com/task/8329414175353178197) started by @dolagoartur*