### PR TITLE
🎨 Palette: Auto-expanding chat input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-23 - Accessibility of Icon-Only Buttons
 **Learning:** The `IconButton` component in this SolidJS-based UI library relies on `Kobalte` but does not enforce or automatically generate accessible names. Developers must manually add `aria-label` or `title` to ensure screen reader accessibility.
 **Action:** When using `IconButton` (or any icon-only interactive element), always verify that an `aria-label` is provided. In the future, we could add a prop type check or a linter rule to enforce this.
+
+## 2025-10-27 - Auto-expanding Textareas and Lit Refs
+**Learning:** Chat inputs that don't auto-expand are a common UX pain point. Implementing this in Lit requires imperative DOM manipulation. Using the `ref` directive allows executing logic on every render/update, which is crucial for handling external state resets (like clearing the draft after sending). Binding `style` attributes conditionally can be flaky if the attribute is removed by Lit, so direct DOM manipulation via `ref` is more robust for persistent visual state.
+**Action:** Use `ref` for auto-resize logic in Lit components to ensure the UI stays in sync with state, especially for "reset" scenarios.

--- a/packages/personas/zee/ui/src/ui/views/chat.ts
+++ b/packages/personas/zee/ui/src/ui/views/chat.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { SessionsListResult } from "../types";
 import type { ChatQueueItem } from "../ui-types";
@@ -67,6 +68,12 @@ export type ChatProps = {
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
+
+function autoResize(el?: Element) {
+  if (!(el instanceof HTMLTextAreaElement)) return;
+  el.style.height = "auto";
+  el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+}
 
 function renderCompactionIndicator(status: CompactionIndicatorStatus | null | undefined) {
   if (!status) return nothing;
@@ -238,6 +245,9 @@ export function renderChat(props: ChatProps) {
         <label class="field chat-compose__field">
           <span>Message</span>
           <textarea
+            ${ref((el) => autoResize(el))}
+            aria-label="Message"
+            rows="1"
             .value=${props.draft}
             ?disabled=${!props.connected}
             @keydown=${(e: KeyboardEvent) => {
@@ -248,8 +258,11 @@ export function renderChat(props: ChatProps) {
               e.preventDefault();
               if (canCompose) props.onSend();
             }}
-            @input=${(e: Event) =>
-              props.onDraftChange((e.target as HTMLTextAreaElement).value)}
+            @input=${(e: Event) => {
+              const target = e.target as HTMLTextAreaElement;
+              props.onDraftChange(target.value);
+              autoResize(target);
+            }}
             placeholder=${composePlaceholder}
           ></textarea>
         </label>


### PR DESCRIPTION
🎨 Palette: Auto-expanding chat input

💡 What: The chat input textarea now automatically expands as you type, up to a maximum height. It also resets gracefully when the message is sent. Added `aria-label="Message"` to the textarea.

🎯 Why: To improve the user experience when typing long messages and fix an accessibility gap where the textarea lacked a label.

♿ Accessibility: Added `aria-label="Message"` to the textarea, which was previously relying on a hidden span that screen readers might ignore depending on styles.

📸 Before/After: Textarea was fixed height (scrollable) -> Now grows with content.

---
*PR created automatically by Jules for task [16036200005337044515](https://jules.google.com/task/16036200005337044515) started by @dolagoartur*