### PR TITLE
ModelsDev: ensure models.dev base URL is configurable

### DIFF
--- a/packages/agent-core/test/provider/models-macro.test.ts
+++ b/packages/agent-core/test/provider/models-macro.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+
+import { data } from "../../src/provider/models-macro"
+
+test("models.dev base URL can be overridden via env", async () => {
+  const originalModelsDevApiJson = process.env.MODELS_DEV_API_JSON
+  const originalModelsUrl = process.env.AGENT_CORE_MODELS_URL
+  const originalFetch = globalThis.fetch
+
+  // Force the fetch path (no local JSON override).
+  delete process.env.MODELS_DEV_API_JSON
+  process.env.AGENT_CORE_MODELS_URL = "https://example.invalid"
+
+  const requests: string[] = []
+  globalThis.fetch = async (input, init) => {
+    requests.push(String(input))
+    // Ensure callers can use .text() / .json() interchangeably.
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }
+
+  try {
+    await data()
+    expect(requests).toEqual(["https://example.invalid/api.json"])
+  } finally {
+    // Restore env + fetch to avoid cross-test pollution.
+    if (originalModelsDevApiJson === undefined) delete process.env.MODELS_DEV_API_JSON
+    else process.env.MODELS_DEV_API_JSON = originalModelsDevApiJson
+    if (originalModelsUrl === undefined) delete process.env.AGENT_CORE_MODELS_URL
+    else process.env.AGENT_CORE_MODELS_URL = originalModelsUrl
+    globalThis.fetch = originalFetch
+  }
+})
+

--- a/packages/agent-core/test/provider/models-macro.test.ts
+++ b/packages/agent-core/test/provider/models-macro.test.ts
@@ -12,14 +12,17 @@ test("models.dev base URL can be overridden via env", async () => {
   process.env.AGENT_CORE_MODELS_URL = "https://example.invalid"
 
   const requests: string[] = []
-  globalThis.fetch = async (input, init) => {
+  const mockFetch: typeof fetch = (async (input: any, init: any) => {
     requests.push(String(input))
     // Ensure callers can use .text() / .json() interchangeably.
     return new Response(JSON.stringify({}), {
       status: 200,
       headers: { "content-type": "application/json" },
     })
-  }
+  }) as any
+  // Bun's fetch has extra properties (e.g. fetch.preconnect); preserve them for typing.
+  ;(mockFetch as any).preconnect = (originalFetch as any).preconnect
+  globalThis.fetch = mockFetch
 
   try {
     await data()
@@ -33,4 +36,3 @@ test("models.dev base URL can be overridden via env", async () => {
     globalThis.fetch = originalFetch
   }
 })
-


### PR DESCRIPTION
Fixes #94.

Adds a regression test to verify AGENT_CORE_MODELS_URL overrides the default models.dev origin used to fetch api.json.

Tests
- cd packages/agent-core && bun test test/provider/models-macro.test.ts
