### PR TITLE
TUI QuestionPrompt: fix mouse click selection and textarea sizing

### DIFF
--- a/packages/agent-core/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/agent-core/src/cli/cmd/tui/routes/session/question.tsx
@@ -274,6 +274,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                     paddingLeft={1}
                     paddingRight={1}
                     backgroundColor={isActive() ? theme.accent : theme.backgroundElement}
+                    onMouseDown={() => selectTab(index())}
                     onMouseUp={() => selectTab(index())}
                   >
                     <text fg={isActive() ? selectedForeground(theme, theme.accent) : isAnswered() ? theme.text : theme.textMuted}>
@@ -287,6 +288,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
               paddingLeft={1}
               paddingRight={1}
               backgroundColor={confirm() ? theme.accent : theme.backgroundElement}
+              onMouseDown={() => selectTab(questions().length)}
               onMouseUp={() => selectTab(questions().length)}
             >
               <text fg={confirm() ? selectedForeground(theme, theme.accent) : theme.textMuted}>Confirm</text>


### PR DESCRIPTION
Fixes #99.

Adds `onMouseDown` handlers for question tabs so tab clicks work reliably even when the terminal isn't focused, matching the existing option-row behavior. (Textarea height clamp + active-tab contrast are already in place.)

Tests
- bun run --cwd packages/agent-core typecheck
