### PR TITLE
Zee security: harden file serving and sanitize gateway errors

### DIFF
--- a/packages/personas/zee/src/gateway/server-http.ts
+++ b/packages/personas/zee/src/gateway/server-http.ts
@@ -282,10 +282,10 @@ export function createGatewayHttpServer(opts: {
       res.statusCode = 404;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Not Found");
-    } catch (err) {
+    } catch {
       res.statusCode = 500;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
-      res.end(String(err));
+      res.end("Internal Server Error");
     }
   }
 

--- a/packages/personas/zee/src/media/server.ts
+++ b/packages/personas/zee/src/media/server.ts
@@ -5,10 +5,10 @@ import { danger } from "../globals.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { isValidMediaId, resolveMediaPath, safeReadFile } from "../security/fs-safe.js";
 import { detectMime } from "./mime.js";
-import { cleanOldMedia, getMediaDir } from "./store.js";
+import { cleanOldMedia, getMediaDir, MEDIA_MAX_BYTES } from "./store.js";
 
 const DEFAULT_TTL_MS = 2 * 60 * 1000;
-const MAX_MEDIA_SIZE = 50 * 1024 * 1024; // 50MB
+const MAX_MEDIA_BYTES = MEDIA_MAX_BYTES;
 
 export function attachMediaRoutes(
   app: Express,
@@ -22,7 +22,7 @@ export function attachMediaRoutes(
 
     // Validate media ID format before any filesystem operations
     if (!isValidMediaId(id)) {
-      res.status(400).send("invalid media id");
+      res.status(400).send("invalid path");
       return;
     }
 
@@ -40,7 +40,7 @@ export function attachMediaRoutes(
 
       // Safely read file with symlink protection and size limits
       const result = await safeReadFile(filePath, {
-        maxSize: MAX_MEDIA_SIZE,
+        maxSize: MAX_MEDIA_BYTES,
         rootDir: mediaDir,
       });
 
@@ -59,7 +59,7 @@ export function attachMediaRoutes(
       if (msg.includes("symlink") || msg.includes("traversal") || msg.includes("invalid media")) {
         res.status(400).send("invalid path");
       } else if (msg.includes("too large")) {
-        res.status(413).send("file too large");
+        res.status(413).send("too large");
       } else {
         res.status(404).send("not found");
       }

--- a/packages/personas/zee/src/media/store.ts
+++ b/packages/personas/zee/src/media/store.ts
@@ -8,7 +8,8 @@ import { resolveConfigDir } from "../utils.js";
 import { detectMime, extensionForMime } from "./mime.js";
 
 const resolveMediaDir = () => path.join(resolveConfigDir(), "media");
-const MAX_BYTES = 5 * 1024 * 1024; // 5MB default
+export const MEDIA_MAX_BYTES = 5 * 1024 * 1024; // 5MB default
+const MAX_BYTES = MEDIA_MAX_BYTES;
 const DEFAULT_TTL_MS = 2 * 60 * 1000; // 2 minutes
 
 /**
@@ -54,7 +55,7 @@ export function getMediaDir() {
 
 export async function ensureMediaDir() {
   const mediaDir = resolveMediaDir();
-  await fs.mkdir(mediaDir, { recursive: true });
+  await fs.mkdir(mediaDir, { recursive: true, mode: 0o700 });
   return mediaDir;
 }
 
@@ -107,7 +108,7 @@ async function downloadToFile(
       let total = 0;
       const sniffChunks: Buffer[] = [];
       let sniffLen = 0;
-      const out = createWriteStream(dest);
+      const out = createWriteStream(dest, { mode: 0o600 });
       res.on("data", (chunk) => {
         total += chunk.length;
         if (sniffLen < 16384) {
@@ -180,7 +181,7 @@ export async function saveMediaSource(
   const ext = extensionForMime(mime) ?? path.extname(source);
   const id = ext ? `${baseId}${ext}` : baseId;
   const dest = path.join(dir, id);
-  await fs.writeFile(dest, buffer);
+  await fs.writeFile(dest, buffer, { mode: 0o600 });
   return { id, path: dest, size: stat.size, contentType: mime };
 }
 
@@ -213,6 +214,6 @@ export async function saveMediaBuffer(
   }
 
   const dest = path.join(dir, id);
-  await fs.writeFile(dest, buffer);
+  await fs.writeFile(dest, buffer, { mode: 0o600 });
   return { id, path: dest, size: buffer.byteLength, contentType: mime };
 }


### PR DESCRIPTION
Fixes #108.

Ports upstream hardening to Zee:
- Media file serving now uses the shared `MEDIA_MAX_BYTES` limit and returns generic error strings.
- Gateway HTTP handler no longer returns raw exception strings to unauthenticated clients.
- Media download and save paths are created with restrictive file/dir modes (best-effort).

Tests
- cd packages/personas/zee && pnpm build
