### PR TITLE
Zee security: gateway auth defaults and exposure hardening

### DIFF
--- a/.agent-core/tool/pim-canvas.ts
+++ b/.agent-core/tool/pim-canvas.ts
@@ -1,0 +1,510 @@
+/**
+ * PIM Canvas Tools - Launch PIM tools in WezTerm panes
+ *
+ * Spawns interactive PIM applications (neomutt, ikhal, khard) in new WezTerm panes,
+ * building on the canvas infrastructure.
+ */
+
+import { tool } from "@opencode-ai/plugin"
+import { execFile } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+type PimApp = "email" | "calendar" | "contacts" | "sync"
+
+type PimPaneState = {
+  version: 1
+  panes: Record<
+    string,
+    {
+      paneId: string
+      app: PimApp
+      createdAt: number
+    }
+  >
+}
+
+const PIM_COMMANDS: Record<PimApp, { cmd: string; args: string[]; title: string }> = {
+  email: { cmd: "neomutt", args: [], title: "Email - neomutt" },
+  calendar: { cmd: "ikhal", args: ["-1"], title: "Calendar - ikhal" },
+  contacts: { cmd: "khard", args: [], title: "Contacts - khard" },
+  sync: { cmd: "pim-sync", args: [], title: "PIM Sync" },
+}
+
+function getStateDir(): string {
+  const xdg = process.env.XDG_STATE_HOME?.trim()
+  if (xdg) return path.join(xdg, "agent-core")
+  return path.join(os.homedir(), ".local", "state", "agent-core")
+}
+
+function getPimStateDir(): string {
+  return path.join(getStateDir(), "pim-canvas")
+}
+
+function getPimStatePath(): string {
+  return path.join(getPimStateDir(), "state.json")
+}
+
+async function ensurePimStateDir(): Promise<void> {
+  await mkdir(getPimStateDir(), { recursive: true })
+}
+
+async function loadPimState(): Promise<PimPaneState> {
+  const statePath = getPimStatePath()
+  if (!existsSync(statePath)) {
+    return { version: 1, panes: {} }
+  }
+  try {
+    const raw = await readFile(statePath, "utf-8")
+    const parsed = JSON.parse(raw) as Partial<PimPaneState>
+    if (parsed.version !== 1 || !parsed.panes) return { version: 1, panes: {} }
+    return { version: 1, panes: parsed.panes }
+  } catch {
+    return { version: 1, panes: {} }
+  }
+}
+
+async function savePimState(state: PimPaneState): Promise<void> {
+  await ensurePimStateDir()
+  await writeFile(getPimStatePath(), JSON.stringify(state, null, 2), "utf-8")
+}
+
+function getRuntimeDir(): string | undefined {
+  const configured = process.env.XDG_RUNTIME_DIR?.trim()
+  if (configured) return configured
+  if (typeof process.getuid === "function") return `/run/user/${process.getuid()}`
+  return undefined
+}
+
+async function resolveWeztermUnixSocket(): Promise<string | undefined> {
+  const existing = process.env.WEZTERM_UNIX_SOCKET?.trim()
+  if (existing) return existing
+
+  const runtimeDir = getRuntimeDir()
+  if (!runtimeDir) return undefined
+
+  const weztermDir = path.join(runtimeDir, "wezterm")
+  if (!existsSync(weztermDir)) return undefined
+
+  try {
+    const entries = await readdir(weztermDir, { withFileTypes: true })
+
+    const wellKnown = entries.find((e) => e.isSymbolicLink() && e.name.endsWith("org.wezfurlong.wezterm"))
+    if (wellKnown) return path.join(weztermDir, wellKnown.name)
+
+    const guiSockets = entries
+      .filter((e) => e.name.startsWith("gui-sock-"))
+      .map((e) => path.join(weztermDir, e.name))
+
+    let best: { p: string; mtimeMs: number } | undefined
+    for (const p of guiSockets) {
+      try {
+        const s = await stat(p)
+        const mtimeMs = s.mtimeMs ?? 0
+        if (!best || mtimeMs > best.mtimeMs) best = { p, mtimeMs }
+      } catch {
+        // ignore
+      }
+    }
+
+    return best?.p
+  } catch {
+    return undefined
+  }
+}
+
+async function weztermEnv(): Promise<NodeJS.ProcessEnv> {
+  const env = { ...process.env }
+
+  const socket = await resolveWeztermUnixSocket()
+  if (!socket) {
+    throw new Error("WEZTERM_UNIX_SOCKET not set and no WezTerm GUI socket found")
+  }
+  env.WEZTERM_UNIX_SOCKET = socket
+
+  const runtimeDir = getRuntimeDir()
+  if (runtimeDir && !env.XDG_RUNTIME_DIR) env.XDG_RUNTIME_DIR = runtimeDir
+
+  return env
+}
+
+async function weztermCli(args: string[], options: { timeoutMs?: number } = {}): Promise<{ stdout: string; stderr: string }> {
+  const timeoutMs = options.timeoutMs ?? 5000
+  const { stdout, stderr } = await execFileAsync("wezterm", ["cli", ...args], {
+    timeout: timeoutMs,
+    maxBuffer: 10 * 1024 * 1024,
+    env: await weztermEnv(),
+  })
+  return { stdout: String(stdout ?? ""), stderr: String(stderr ?? "") }
+}
+
+type WeztermListEntry = {
+  pane_id?: number
+  paneId?: number
+  paneID?: number
+  pane?: number
+  tab_id?: number
+  is_active?: boolean
+  cwd?: string
+}
+
+async function getWeztermList(): Promise<WeztermListEntry[]> {
+  const { stdout } = await weztermCli(["list", "--format", "json"], { timeoutMs: 2500 })
+  const data = JSON.parse(stdout) as unknown
+  if (!Array.isArray(data)) return []
+  return data as WeztermListEntry[]
+}
+
+async function getWeztermPaneIds(): Promise<Set<string>> {
+  const data = await getWeztermList()
+  const ids = new Set<string>()
+  for (const entry of data) {
+    const paneId = entry?.pane_id ?? entry?.paneId ?? entry?.paneID ?? entry?.pane
+    if (paneId === undefined || paneId === null) continue
+    ids.add(String(paneId))
+  }
+  return ids
+}
+
+function weztermEnabled(): boolean {
+  const raw = process.env.AGENT_CORE_CANVAS_WEZTERM?.trim().toLowerCase()
+  if (!raw) return true
+  return !["0", "false", "off", "no"].includes(raw)
+}
+
+async function weztermAvailable(): Promise<boolean> {
+  if (!weztermEnabled()) return false
+  try {
+    await getWeztermPaneIds()
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function paneExists(paneId: string): Promise<boolean> {
+  try {
+    const ids = await getWeztermPaneIds()
+    return ids.has(paneId)
+  } catch {
+    return false
+  }
+}
+
+function getPaneId(entry: WeztermListEntry): string | undefined {
+  const paneId = entry?.pane_id ?? entry?.paneId ?? entry?.paneID ?? entry?.pane
+  return paneId === undefined || paneId === null ? undefined : String(paneId)
+}
+
+async function resolveTargetPaneId(): Promise<string | undefined> {
+  const configured = process.env.AGENT_CORE_CANVAS_PANE_ID?.trim()
+  if (configured) return configured
+
+  const envPane = process.env.WEZTERM_PANE?.trim()
+  if (envPane) return envPane
+
+  const list = await getWeztermList()
+  const active = list.find((x) => x.is_active) ?? list[0]
+  return getPaneId(active)
+}
+
+async function commandExists(cmd: string): Promise<boolean> {
+  try {
+    await execFileAsync("which", [cmd], { timeout: 2000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function spawnPimPane(app: PimApp, newWindow: boolean): Promise<{ paneId: string; created: boolean }> {
+  const state = await loadPimState()
+  const existing = state.panes[app]
+  if (existing && (await paneExists(existing.paneId))) {
+    // Focus the existing pane
+    try {
+      await weztermCli(["activate-pane", "--pane-id", existing.paneId], { timeoutMs: 2500 })
+    } catch {
+      // ignore
+    }
+    return { paneId: existing.paneId, created: false }
+  }
+
+  const config = PIM_COMMANDS[app]
+  const cmdExists = await commandExists(config.cmd)
+  if (!cmdExists) {
+    throw new Error(`Command '${config.cmd}' not found. Install it first.`)
+  }
+
+  const fullCmd = [config.cmd, ...config.args].join(" ")
+
+  let paneId: string
+
+  if (newWindow) {
+    // Spawn a new window with the command
+    const { stdout } = await weztermCli(
+      ["spawn", "--new-window", "--", "sh", "-c", fullCmd],
+      { timeoutMs: 10000 }
+    )
+    paneId = stdout.trim()
+  } else {
+    // Split the current pane
+    const targetPaneId = await resolveTargetPaneId()
+    const splitArgs = ["split-pane", "--right", "--percent", "50"]
+    if (targetPaneId) splitArgs.push("--pane-id", targetPaneId)
+    splitArgs.push("--", "sh", "-c", fullCmd)
+    const { stdout } = await weztermCli(splitArgs, { timeoutMs: 10000 })
+    paneId = stdout.trim()
+
+    // Return focus to original pane
+    if (targetPaneId) {
+      try {
+        await weztermCli(["activate-pane", "--pane-id", targetPaneId], { timeoutMs: 2500 })
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  if (!paneId) throw new Error("wezterm did not return a pane id")
+
+  // Set pane title
+  try {
+    const escapeSequence = `\x1b]0;${config.title}\x07`
+    await weztermCli(["send-text", "--pane-id", paneId, "--no-paste", escapeSequence], { timeoutMs: 2500 })
+  } catch {
+    // ignore title setting errors
+  }
+
+  state.panes[app] = { paneId, app, createdAt: Date.now() }
+  await savePimState(state)
+
+  return { paneId, created: true }
+}
+
+// PIM Open tool - open email, calendar, or contacts
+export const pimOpen = tool({
+  description: `Open PIM (Personal Information Manager) tools in WezTerm panes.
+
+Available apps:
+- email: Opens neomutt for email management
+- calendar: Opens ikhal for calendar view
+- contacts: Opens khard for contacts management
+- sync: Runs pim-sync to sync all PIM data
+
+Options:
+- newWindow: If true, opens in a new WezTerm window instead of splitting current pane
+
+Examples:
+- Open email: { app: "email" }
+- Open calendar in new window: { app: "calendar", newWindow: true }
+- Sync all PIM data: { app: "sync" }`,
+  args: {
+    app: tool.schema
+      .enum(["email", "calendar", "contacts", "sync"])
+      .describe("Which PIM app to open"),
+    newWindow: tool.schema
+      .boolean()
+      .optional()
+      .describe("Open in new window instead of splitting pane (default: true)"),
+  },
+  async execute(args) {
+    const app = args.app as PimApp
+    const newWindow = args.newWindow !== false // default to true
+
+    if (!(await weztermAvailable())) {
+      return `WezTerm not available. Cannot open ${app}.
+
+To use manually, run:
+- email: neomutt
+- calendar: ikhal -1
+- contacts: khard
+- sync: pim-sync`
+    }
+
+    try {
+      const { paneId, created } = await spawnPimPane(app, newWindow)
+      const config = PIM_COMMANDS[app]
+      if (created) {
+        return `Opened ${config.title} in ${newWindow ? "new window" : "split pane"} (pane ${paneId}).`
+      } else {
+        return `${config.title} is already open (pane ${paneId}). Focused existing pane.`
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      return `Failed to open ${app}: ${msg}`
+    }
+  },
+})
+
+// PIM Close tool - close a PIM pane
+export const pimClose = tool({
+  description: `Close a PIM app pane.`,
+  args: {
+    app: tool.schema
+      .enum(["email", "calendar", "contacts", "sync"])
+      .describe("Which PIM app to close"),
+  },
+  async execute(args) {
+    const app = args.app as PimApp
+
+    if (!(await weztermAvailable())) {
+      return `WezTerm not available.`
+    }
+
+    const state = await loadPimState()
+    const existing = state.panes[app]
+    if (!existing) return `${app} is not open.`
+
+    try {
+      await weztermCli(["kill-pane", "--pane-id", existing.paneId], { timeoutMs: 5000 })
+    } catch {
+      // pane may already be closed
+    }
+
+    delete state.panes[app]
+    await savePimState(state)
+    return `Closed ${app} pane.`
+  },
+})
+
+// PIM List tool - list open PIM panes
+export const pimList = tool({
+  description: `List all open PIM app panes.`,
+  args: {},
+  async execute() {
+    const state = await loadPimState()
+    const apps = Object.keys(state.panes) as PimApp[]
+    if (apps.length === 0) return "No PIM apps open."
+
+    const live: Array<{ app: PimApp; paneId: string }> = []
+    for (const app of apps) {
+      const pane = state.panes[app]
+      if (!pane) continue
+      if (await paneExists(pane.paneId)) {
+        live.push({ app, paneId: pane.paneId })
+      } else {
+        delete state.panes[app]
+      }
+    }
+    await savePimState(state)
+
+    if (live.length === 0) return "No PIM apps open."
+
+    const lines = live.map((p) => {
+      const config = PIM_COMMANDS[p.app]
+      return `- ${config.title} (pane ${p.paneId})`
+    })
+
+    return `${live.length} PIM app(s) open:\n${lines.join("\n")}`
+  },
+})
+
+// PIM Focus tool - focus a PIM pane
+export const pimFocus = tool({
+  description: `Focus (bring to front) a PIM app pane.`,
+  args: {
+    app: tool.schema
+      .enum(["email", "calendar", "contacts", "sync"])
+      .describe("Which PIM app to focus"),
+  },
+  async execute(args) {
+    const app = args.app as PimApp
+
+    if (!(await weztermAvailable())) {
+      return `WezTerm not available.`
+    }
+
+    const state = await loadPimState()
+    const existing = state.panes[app]
+    if (!existing) return `${app} is not open. Use pimOpen first.`
+
+    if (!(await paneExists(existing.paneId))) {
+      delete state.panes[app]
+      await savePimState(state)
+      return `${app} pane no longer exists. Use pimOpen to reopen.`
+    }
+
+    try {
+      await weztermCli(["activate-pane", "--pane-id", existing.paneId], { timeoutMs: 2500 })
+      return `Focused ${PIM_COMMANDS[app].title} (pane ${existing.paneId}).`
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      return `Failed to focus ${app}: ${msg}`
+    }
+  },
+})
+
+// PIM Dashboard - open all PIM tools at once
+export const pimDashboard = tool({
+  description: `Open a full PIM dashboard with email, calendar, and contacts in separate WezTerm panes.
+
+This creates a new window with three panes arranged for PIM work:
+- Left: Email (neomutt)
+- Top-right: Calendar (ikhal)
+- Bottom-right: Contacts (khard)`,
+  args: {},
+  async execute() {
+    if (!(await weztermAvailable())) {
+      return `WezTerm not available. Cannot open PIM dashboard.
+
+To use manually:
+- neomutt (email)
+- ikhal -1 (calendar)
+- khard (contacts)
+- pim-sync (sync all)`
+    }
+
+    const results: string[] = []
+
+    // Open email in new window first
+    try {
+      const { paneId: emailPaneId, created: emailCreated } = await spawnPimPane("email", true)
+      results.push(emailCreated ? `Email opened in new window (pane ${emailPaneId})` : `Email already open (pane ${emailPaneId})`)
+
+      // Wait a moment for window to be ready
+      await new Promise((r) => setTimeout(r, 500))
+
+      // Now split for calendar (right side)
+      const state = await loadPimState()
+      const emailPane = state.panes.email
+      if (emailPane) {
+        // Split right for calendar
+        const calendarCmd = [PIM_COMMANDS.calendar.cmd, ...PIM_COMMANDS.calendar.args].join(" ")
+        const { stdout: calPaneId } = await weztermCli(
+          ["split-pane", "--right", "--percent", "50", "--pane-id", emailPane.paneId, "--", "sh", "-c", calendarCmd],
+          { timeoutMs: 10000 }
+        )
+        if (calPaneId.trim()) {
+          state.panes.calendar = { paneId: calPaneId.trim(), app: "calendar", createdAt: Date.now() }
+          results.push(`Calendar opened (pane ${calPaneId.trim()})`)
+
+          // Split calendar pane bottom for contacts
+          const contactsCmd = [PIM_COMMANDS.contacts.cmd, ...PIM_COMMANDS.contacts.args].join(" ")
+          const { stdout: contactsPaneId } = await weztermCli(
+            ["split-pane", "--bottom", "--percent", "50", "--pane-id", calPaneId.trim(), "--", "sh", "-c", contactsCmd],
+            { timeoutMs: 10000 }
+          )
+          if (contactsPaneId.trim()) {
+            state.panes.contacts = { paneId: contactsPaneId.trim(), app: "contacts", createdAt: Date.now() }
+            results.push(`Contacts opened (pane ${contactsPaneId.trim()})`)
+          }
+        }
+        await savePimState(state)
+
+        // Focus back to email
+        await weztermCli(["activate-pane", "--pane-id", emailPane.paneId], { timeoutMs: 2500 })
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      results.push(`Error: ${msg}`)
+    }
+
+    return `PIM Dashboard:\n${results.join("\n")}`
+  },
+})

--- a/packages/personas/zee/src/commands/doctor-dependencies.ts
+++ b/packages/personas/zee/src/commands/doctor-dependencies.ts
@@ -1,0 +1,404 @@
+/**
+ * Doctor Dependencies - Check and auto-install skill dependencies
+ *
+ * Detects missing dependencies for skills and optionally installs them
+ * using the appropriate package manager for the current platform.
+ */
+
+import { exec, execSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { ZeeConfig } from "../config/config.js";
+import { note } from "../terminal/note.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+
+const execAsync = promisify(exec);
+
+type Platform = "arch" | "debian" | "ubuntu" | "fedora" | "rhel" | "macos" | "unknown";
+type InstallKind = "brew" | "node" | "go" | "uv" | "download" | "pacman" | "cargo" | "apt" | "dnf" | "yay";
+
+interface SkillInstallSpec {
+  id?: string;
+  kind: InstallKind;
+  label?: string;
+  bins?: string[];
+  os?: string[];
+  formula?: string;
+  package?: string;
+  packages?: string[];
+  module?: string;
+  url?: string;
+  archive?: string;
+  extract?: boolean;
+  stripComponents?: number;
+  targetDir?: string;
+  crate?: string;
+}
+
+interface SkillFrontmatter {
+  name?: string;
+  description?: string;
+  install?: SkillInstallSpec[];
+}
+
+interface MissingDependency {
+  skillName: string;
+  skillPath: string;
+  binary: string;
+  installSpecs: SkillInstallSpec[];
+}
+
+interface CheckSkillDependenciesOptions {
+  cfg: ZeeConfig;
+  prompter: DoctorPrompter;
+  fix: boolean;
+}
+
+/**
+ * Detect the current platform/distro
+ */
+function detectPlatform(): Platform {
+  if (process.platform === "darwin") return "macos";
+  if (process.platform !== "linux") return "unknown";
+
+  // Check for Linux distro
+  try {
+    if (existsSync("/etc/os-release")) {
+      const osRelease = readFileSync("/etc/os-release", "utf-8");
+      const idMatch = osRelease.match(/^ID=(.*)$/m);
+      const id = idMatch?.[1]?.replace(/"/g, "").toLowerCase() ?? "";
+
+      if (id === "arch" || id === "manjaro" || id === "endeavouros") return "arch";
+      if (id === "debian") return "debian";
+      if (id === "ubuntu" || id === "linuxmint" || id === "pop") return "ubuntu";
+      if (id === "fedora") return "fedora";
+      if (id === "rhel" || id === "centos" || id === "rocky" || id === "almalinux") return "rhel";
+    }
+  } catch {
+    // ignore
+  }
+
+  // Check for package managers as fallback
+  if (existsSync("/usr/bin/pacman")) return "arch";
+  if (existsSync("/usr/bin/apt")) return "debian";
+  if (existsSync("/usr/bin/dnf")) return "fedora";
+
+  return "unknown";
+}
+
+/**
+ * Check if a binary exists in PATH
+ */
+function hasBinary(bin: string): boolean {
+  try {
+    execSync(`which ${bin}`, { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse skill frontmatter from SKILL.md
+ */
+function parseSkillFrontmatter(content: string): SkillFrontmatter | undefined {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return undefined;
+
+  const yaml = match[1];
+  const result: SkillFrontmatter = {};
+
+  // Simple YAML parsing for our use case
+  const lines = yaml.split("\n");
+  let inInstall = false;
+  let currentInstall: Partial<SkillInstallSpec> | undefined;
+  const installs: SkillInstallSpec[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("name:")) {
+      result.name = trimmed.slice(5).trim().replace(/^["']|["']$/g, "");
+    } else if (trimmed.startsWith("description:")) {
+      result.description = trimmed.slice(12).trim().replace(/^["']|["']$/g, "");
+    } else if (trimmed === "install:" || trimmed.startsWith("install:")) {
+      inInstall = true;
+    } else if (inInstall && trimmed.startsWith("- kind:")) {
+      // New install entry
+      if (currentInstall?.kind) {
+        installs.push(currentInstall as SkillInstallSpec);
+      }
+      const kind = trimmed.slice(7).trim().replace(/^["']|["']$/g, "") as InstallKind;
+      currentInstall = { kind };
+    } else if (inInstall && currentInstall && trimmed.startsWith("bins:")) {
+      // bins can be inline or multi-line
+      const inline = trimmed.slice(5).trim();
+      if (inline.startsWith("[")) {
+        // Inline array
+        const match = inline.match(/\[(.*?)\]/);
+        if (match) {
+          currentInstall.bins = match[1].split(",").map((s) => s.trim().replace(/^["']|["']$/g, ""));
+        }
+      }
+    } else if (inInstall && currentInstall && trimmed.startsWith("- ") && !trimmed.startsWith("- kind:")) {
+      // Might be bins array item
+      const val = trimmed.slice(2).trim().replace(/^["']|["']$/g, "");
+      if (!currentInstall.bins) currentInstall.bins = [];
+      currentInstall.bins.push(val);
+    } else if (inInstall && currentInstall) {
+      // Other fields
+      const colonIdx = trimmed.indexOf(":");
+      if (colonIdx > 0) {
+        const key = trimmed.slice(0, colonIdx).trim();
+        const val = trimmed.slice(colonIdx + 1).trim().replace(/^["']|["']$/g, "");
+        if (key === "package") currentInstall.package = val;
+        if (key === "crate") currentInstall.crate = val;
+        if (key === "formula") currentInstall.formula = val;
+        if (key === "module") currentInstall.module = val;
+        if (key === "label") currentInstall.label = val;
+      }
+    }
+  }
+
+  if (currentInstall?.kind) {
+    installs.push(currentInstall as SkillInstallSpec);
+  }
+
+  if (installs.length > 0) {
+    result.install = installs;
+  }
+
+  return result;
+}
+
+/**
+ * Get all skill directories
+ */
+function getSkillDirs(): string[] {
+  const dirs: string[] = [];
+
+  // Project-local skills
+  const localSkillsDir = path.join(process.cwd(), ".claude", "skills");
+  if (existsSync(localSkillsDir)) {
+    try {
+      const entries = readdirSync(localSkillsDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          dirs.push(path.join(localSkillsDir, entry.name));
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  // User skills
+  const homeDir = process.env.HOME ?? "";
+  const userSkillsDir = path.join(homeDir, ".claude", "skills");
+  if (existsSync(userSkillsDir)) {
+    try {
+      const entries = readdirSync(userSkillsDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          dirs.push(path.join(userSkillsDir, entry.name));
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  // Agent-core config skills
+  const agentCoreConfigDir = path.join(homeDir, ".config", "agent-core", "skills");
+  if (existsSync(agentCoreConfigDir)) {
+    try {
+      const entries = readdirSync(agentCoreConfigDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          dirs.push(path.join(agentCoreConfigDir, entry.name));
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  return dirs;
+}
+
+/**
+ * Find all missing dependencies from skills
+ */
+function findMissingDependencies(): MissingDependency[] {
+  const missing: MissingDependency[] = [];
+  const skillDirs = getSkillDirs();
+
+  for (const skillDir of skillDirs) {
+    const skillMdPath = path.join(skillDir, "SKILL.md");
+    if (!existsSync(skillMdPath)) continue;
+
+    try {
+      const content = readFileSync(skillMdPath, "utf-8");
+      const frontmatter = parseSkillFrontmatter(content);
+      if (!frontmatter?.install) continue;
+
+      const skillName = frontmatter.name ?? path.basename(skillDir);
+
+      for (const spec of frontmatter.install) {
+        const bins = spec.bins ?? [];
+        for (const bin of bins) {
+          if (!hasBinary(bin)) {
+            // Check if we already have this binary in missing list
+            const existing = missing.find((m) => m.binary === bin);
+            if (existing) {
+              // Add this spec if not already present
+              if (!existing.installSpecs.some((s) => s.kind === spec.kind)) {
+                existing.installSpecs.push(spec);
+              }
+            } else {
+              missing.push({
+                skillName,
+                skillPath: skillDir,
+                binary: bin,
+                installSpecs: [spec],
+              });
+            }
+          }
+        }
+      }
+    } catch {
+      // ignore parsing errors
+    }
+  }
+
+  return missing;
+}
+
+/**
+ * Find the best install spec for the current platform
+ */
+function findBestInstallSpec(specs: SkillInstallSpec[], platform: Platform): SkillInstallSpec | undefined {
+  // Priority order based on platform
+  const kindPriority: Record<Platform, InstallKind[]> = {
+    arch: ["pacman", "yay", "cargo", "brew", "node", "go", "uv", "download"],
+    debian: ["apt", "cargo", "brew", "node", "go", "uv", "download"],
+    ubuntu: ["apt", "cargo", "brew", "node", "go", "uv", "download"],
+    fedora: ["dnf", "cargo", "brew", "node", "go", "uv", "download"],
+    rhel: ["dnf", "cargo", "brew", "node", "go", "uv", "download"],
+    macos: ["brew", "cargo", "node", "go", "uv", "download"],
+    unknown: ["cargo", "node", "go", "uv", "download"],
+  };
+
+  const priority = kindPriority[platform];
+
+  for (const kind of priority) {
+    const spec = specs.find((s) => s.kind === kind);
+    if (spec) {
+      // Check if the package manager is available
+      if (kind === "pacman" && !hasBinary("pacman")) continue;
+      if (kind === "yay" && !hasBinary("yay")) continue;
+      if (kind === "apt" && !hasBinary("apt")) continue;
+      if (kind === "dnf" && !hasBinary("dnf")) continue;
+      if (kind === "brew" && !hasBinary("brew")) continue;
+      if (kind === "cargo" && !hasBinary("cargo")) continue;
+      if (kind === "node" && !hasBinary("npm") && !hasBinary("pnpm") && !hasBinary("bun")) continue;
+      if (kind === "go" && !hasBinary("go")) continue;
+      if (kind === "uv" && !hasBinary("uv")) continue;
+      return spec;
+    }
+  }
+
+  return specs[0]; // Fallback to first spec
+}
+
+/**
+ * Get the install command for a spec
+ */
+function getInstallCommand(spec: SkillInstallSpec): string | undefined {
+  switch (spec.kind) {
+    case "pacman":
+      return spec.package ? `sudo pacman -S ${spec.package}` : undefined;
+    case "yay":
+      return spec.package ? `yay -S ${spec.package}` : undefined;
+    case "apt":
+      return spec.package ? `sudo apt install ${spec.package}` : undefined;
+    case "dnf":
+      return spec.package ? `sudo dnf install ${spec.package}` : undefined;
+    case "brew":
+      return spec.formula ? `brew install ${spec.formula}` : undefined;
+    case "cargo":
+      return spec.crate ? `cargo install ${spec.crate}` : undefined;
+    case "node":
+      return spec.module ? `npm install -g ${spec.module}` : undefined;
+    case "go":
+      return spec.module ? `go install ${spec.module}` : undefined;
+    case "uv":
+      return spec.module ? `uv tool install ${spec.module}` : undefined;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Execute an install command
+ */
+async function executeInstall(command: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    await execAsync(command, { timeout: 300000 }); // 5 min timeout
+    return { success: true };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return { success: false, error: msg };
+  }
+}
+
+/**
+ * Check and optionally install missing skill dependencies
+ */
+export async function checkSkillDependencies(options: CheckSkillDependenciesOptions): Promise<void> {
+  const { prompter, fix } = options;
+
+  const missing = findMissingDependencies();
+  if (missing.length === 0) return;
+
+  const platform = detectPlatform();
+
+  // Group by binary for cleaner output
+  const lines: string[] = [`Found ${missing.length} missing skill dependencies:`];
+  for (const dep of missing) {
+    const spec = findBestInstallSpec(dep.installSpecs, platform);
+    const cmd = spec ? getInstallCommand(spec) : undefined;
+    lines.push(`  - ${dep.binary} (required by: ${dep.skillName})${cmd ? ` [${cmd}]` : ""}`);
+  }
+
+  note(lines.join("\n"), "Skill Dependencies");
+
+  if (!fix) {
+    return;
+  }
+
+  // Ask to install each
+  for (const dep of missing) {
+    const spec = findBestInstallSpec(dep.installSpecs, platform);
+    if (!spec) continue;
+
+    const cmd = getInstallCommand(spec);
+    if (!cmd) continue;
+
+    const shouldInstall = await prompter.confirmRepair({
+      message: `Install ${dep.binary} using: ${cmd}?`,
+      initialValue: true,
+    });
+
+    if (shouldInstall) {
+      note(`Installing ${dep.binary}...`, "Skill Dependencies");
+      const result = await executeInstall(cmd);
+      if (result.success) {
+        note(`Installed ${dep.binary} successfully.`, "Skill Dependencies");
+      } else {
+        note(`Failed to install ${dep.binary}: ${result.error}`, "Skill Dependencies");
+      }
+    }
+  }
+}

--- a/packages/personas/zee/src/commands/doctor-security.test.ts
+++ b/packages/personas/zee/src/commands/doctor-security.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ZeeConfig } from "../config/config.js";
+
+const note = vi.hoisted(() => vi.fn());
+
+vi.mock("../terminal/note.js", () => ({
+  note,
+}));
+
+vi.mock("../channels/plugins/index.js", () => ({
+  listChannelPlugins: () => [],
+}));
+
+import { noteSecurityWarnings } from "./doctor-security.js";
+
+describe("noteSecurityWarnings gateway exposure", () => {
+  let prevToken: string | undefined;
+  let prevPassword: string | undefined;
+
+  beforeEach(() => {
+    note.mockClear();
+    prevToken = process.env.ZEE_GATEWAY_TOKEN;
+    prevPassword = process.env.ZEE_GATEWAY_PASSWORD;
+    delete process.env.ZEE_GATEWAY_TOKEN;
+    delete process.env.ZEE_GATEWAY_PASSWORD;
+  });
+
+  afterEach(() => {
+    if (prevToken === undefined) delete process.env.ZEE_GATEWAY_TOKEN;
+    else process.env.ZEE_GATEWAY_TOKEN = prevToken;
+    if (prevPassword === undefined) delete process.env.ZEE_GATEWAY_PASSWORD;
+    else process.env.ZEE_GATEWAY_PASSWORD = prevPassword;
+  });
+
+  const lastMessage = () => String(note.mock.calls.at(-1)?.[0] ?? "");
+
+  it("warns when exposed without auth", async () => {
+    const cfg = { gateway: { bind: "lan" } } as ZeeConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).toContain("CRITICAL");
+    expect(message).toContain("without authentication");
+  });
+
+  it("uses env token to avoid critical warning", async () => {
+    process.env.ZEE_GATEWAY_TOKEN = "token-123";
+    const cfg = { gateway: { bind: "lan" } } as ZeeConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).toContain("WARNING");
+    expect(message).not.toContain("CRITICAL");
+  });
+
+  it("treats whitespace token as missing", async () => {
+    const cfg = {
+      gateway: { bind: "lan", auth: { mode: "token", token: "   " } },
+    } as ZeeConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).toContain("CRITICAL");
+  });
+
+  it("skips warning for loopback bind", async () => {
+    const cfg = { gateway: { bind: "loopback" } } as ZeeConfig;
+    await noteSecurityWarnings(cfg);
+    const message = lastMessage();
+    expect(message).toContain("No channel security warnings detected");
+    expect(message).not.toContain("Gateway bound");
+  });
+});
+

--- a/packages/personas/zee/src/commands/doctor.ts
+++ b/packages/personas/zee/src/commands/doctor.ts
@@ -50,6 +50,7 @@ import { MEMORY_SYSTEM_PROMPT, shouldSuggestMemorySystem } from "./doctor-worksp
 import { noteWorkspaceStatus } from "./doctor-workspace-status.js";
 import { applyWizardMetadata, printWizardHeader, randomToken } from "./onboard-helpers.js";
 import { ensureSystemdUserLingerInteractive } from "./systemd-linger.js";
+import { checkSkillDependencies } from "./doctor-dependencies.js";
 
 const intro = (message: string) => clackIntro(stylePromptTitle(message) ?? message);
 const outro = (message: string) => clackOutro(stylePromptTitle(message) ?? message);
@@ -252,6 +253,13 @@ export async function doctorCommand(
   }
 
   noteWorkspaceStatus(cfg);
+
+  // Check for missing skill dependencies
+  await checkSkillDependencies({
+    cfg,
+    prompter,
+    fix: prompter.shouldRepair,
+  });
 
   const { healthOk } = await checkGatewayHealth({
     runtime,

--- a/packages/personas/zee/src/commands/models/list.status-command.ts
+++ b/packages/personas/zee/src/commands/models/list.status-command.ts
@@ -581,13 +581,13 @@ export async function modelsStatusCommand(
         const modelLabel = result.model ?? `${result.provider}/-`;
         const modeLabel = result.mode ? ` ${colorize(rich, theme.muted, `(${result.mode})`)}` : "";
         const profile = `${colorize(rich, theme.accent, result.label)}${modeLabel}`;
-        const detail = result.error?.trim();
-        const detailLabel = detail ? `\n${colorize(rich, theme.muted, `↳ ${detail}`)}` : "";
-        const statusLabel = `${status}${colorize(rich, theme.muted, ` · ${latency}`)}${detailLabel}`;
+        const detail = result.error ? colorize(rich, theme.muted, result.error) : "";
+        const statusLabel = `${status}${colorize(rich, theme.muted, ` · ${latency}`)}`;
         return {
           Model: colorize(rich, theme.heading, modelLabel),
           Profile: profile,
           Status: statusLabel,
+          Detail: detail,
         };
       });
       runtime.log(
@@ -597,6 +597,7 @@ export async function modelsStatusCommand(
             { key: "Model", header: "Model", minWidth: 18 },
             { key: "Profile", header: "Profile", minWidth: 24 },
             { key: "Status", header: "Status", minWidth: 12 },
+            { key: "Detail", header: "Detail", minWidth: 16, flex: true },
           ],
           rows,
         }).trimEnd(),

--- a/packages/personas/zee/src/config/schema.ts
+++ b/packages/personas/zee/src/config/schema.ts
@@ -353,6 +353,9 @@ const FIELD_LABELS: Record<string, string> = {
   "plugins.installs.*.installPath": "Plugin Install Path",
   "plugins.installs.*.version": "Plugin Install Version",
   "plugins.installs.*.installedAt": "Plugin Install Time",
+  "discovery.wideArea.enabled": "Wide Area Discovery Enabled",
+  "discovery.mdns.enabled": "mDNS Discovery Enabled",
+  "discovery.mdns.minimal": "mDNS Discovery Minimal Mode",
 };
 
 const FIELD_HELP: Record<string, string> = {
@@ -366,6 +369,11 @@ const FIELD_HELP: Record<string, string> = {
   "gateway.remote.sshTarget":
     "Remote gateway over SSH (tunnels the gateway port to localhost). Format: user@host or user@host:port.",
   "gateway.remote.sshIdentity": "Optional SSH identity file path (passed to ssh -i).",
+  "discovery.wideArea.enabled":
+    "Enable wide-area discovery via unicast DNS-SD zone updates (tailnet).",
+  "discovery.mdns.enabled": "Enable mDNS/Bonjour discovery broadcasts (default: true).",
+  "discovery.mdns.minimal":
+    "When true (default), omit cliPath/sshPort from mDNS TXT records for better operational security.",
   "agents.list[].identity.avatar":
     "Avatar image path (relative to the agent workspace only) or a remote URL/data URL.",
   "gateway.auth.token": "Recommended for all gateways; required for non-loopback binds.",

--- a/packages/personas/zee/src/config/types.gateway.ts
+++ b/packages/personas/zee/src/config/types.gateway.ts
@@ -17,8 +17,19 @@ export type WideAreaDiscoveryConfig = {
   enabled?: boolean;
 };
 
+export type MdnsDiscoveryConfig = {
+  /** Enable mDNS/Bonjour discovery broadcasts (default: true). */
+  enabled?: boolean;
+  /**
+   * When true (default), omit sensitive fields (like cliPath/sshPort) from TXT records.
+   * Set to false for full discovery details.
+   */
+  minimal?: boolean;
+};
+
 export type DiscoveryConfig = {
   wideArea?: WideAreaDiscoveryConfig;
+  mdns?: MdnsDiscoveryConfig;
 };
 
 export type CanvasHostConfig = {

--- a/packages/personas/zee/src/config/zod-schema.ts
+++ b/packages/personas/zee/src/config/zod-schema.ts
@@ -272,6 +272,13 @@ export const ZeeSchema = z
           })
           .strict()
           .optional(),
+        mdns: z
+          .object({
+            enabled: z.boolean().optional(),
+            minimal: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/packages/personas/zee/src/gateway/auth.test.ts
+++ b/packages/personas/zee/src/gateway/auth.test.ts
@@ -125,6 +125,7 @@ describe("gateway auth", () => {
     const res = await authorizeGatewayConnect({
       auth: { mode: "token", token: "secret", allowTailscale: true },
       connectAuth: null,
+      tailscaleWhois: async () => ({ login: "peter", name: "Peter" }),
       req: {
         socket: { remoteAddress: "127.0.0.1" },
         headers: {

--- a/packages/personas/zee/src/gateway/hooks.test.ts
+++ b/packages/personas/zee/src/gateway/hooks.test.ts
@@ -47,15 +47,15 @@ describe("gateway hooks helpers", () => {
       },
     } as unknown as IncomingMessage;
     const url = new URL("http://localhost/hooks/wake?token=query");
-    expect(extractHookToken(req, url)).toBe("top");
+    expect(extractHookToken(req, url)).toEqual({ token: "top", fromQuery: false });
 
     const req2 = {
       headers: { "x-zee-token": "header" },
     } as unknown as IncomingMessage;
-    expect(extractHookToken(req2, url)).toBe("header");
+    expect(extractHookToken(req2, url)).toEqual({ token: "header", fromQuery: false });
 
     const req3 = { headers: {} } as unknown as IncomingMessage;
-    expect(extractHookToken(req3, url)).toBe("query");
+    expect(extractHookToken(req3, url)).toEqual({ token: "query", fromQuery: true });
   });
 
   test("normalizeWakePayload trims + validates", () => {

--- a/packages/personas/zee/src/gateway/hooks.ts
+++ b/packages/personas/zee/src/gateway/hooks.ts
@@ -41,21 +41,26 @@ export function resolveHooksConfig(cfg: ZeeConfig): HooksConfigResolved | null {
   };
 }
 
-export function extractHookToken(req: IncomingMessage, url: URL): string | undefined {
+export type HookTokenResult = {
+  token: string | undefined;
+  fromQuery: boolean;
+};
+
+export function extractHookToken(req: IncomingMessage, url: URL): HookTokenResult {
   const auth =
     typeof req.headers.authorization === "string" ? req.headers.authorization.trim() : "";
   if (auth.toLowerCase().startsWith("bearer ")) {
     const token = auth.slice(7).trim();
-    if (token) return token;
+    if (token) return { token, fromQuery: false };
   }
   const headerToken =
     typeof req.headers["x-zee-token"] === "string"
       ? req.headers["x-zee-token"].trim()
       : "";
-  if (headerToken) return headerToken;
+  if (headerToken) return { token: headerToken, fromQuery: false };
   const queryToken = url.searchParams.get("token");
-  if (queryToken) return queryToken.trim();
-  return undefined;
+  if (queryToken) return { token: queryToken.trim(), fromQuery: true };
+  return { token: undefined, fromQuery: false };
 }
 
 export async function readJsonBody(

--- a/packages/personas/zee/src/gateway/server-discovery-runtime.ts
+++ b/packages/personas/zee/src/gateway/server-discovery-runtime.ts
@@ -14,36 +14,46 @@ export async function startGatewayDiscovery(params: {
   canvasPort?: number;
   wideAreaDiscoveryEnabled: boolean;
   tailscaleMode: "off" | "serve" | "funnel";
+  /** mDNS/Bonjour discovery mode (default: minimal). */
+  mdnsMode?: "off" | "minimal" | "full";
   logDiscovery: { info: (msg: string) => void; warn: (msg: string) => void };
 }) {
   let bonjourStop: (() => Promise<void>) | null = null;
+  const mdnsMode = params.mdnsMode ?? "minimal";
+  // mDNS can be disabled via config (mdnsMode: off) or env var.
   const bonjourEnabled =
+    mdnsMode !== "off" &&
     process.env.ZEE_DISABLE_BONJOUR !== "1" &&
     process.env.NODE_ENV !== "test" &&
     !process.env.VITEST;
+  const mdnsMinimal = mdnsMode !== "full";
   const tailscaleEnabled = params.tailscaleMode !== "off";
   const needsTailnetDns = bonjourEnabled || params.wideAreaDiscoveryEnabled;
   const tailnetDns = needsTailnetDns
     ? await resolveTailnetDnsHint({ enabled: tailscaleEnabled })
     : undefined;
-  const sshPortEnv = process.env.ZEE_SSH_PORT?.trim();
+  const sshPortEnv = mdnsMinimal ? undefined : process.env.ZEE_SSH_PORT?.trim();
   const sshPortParsed = sshPortEnv ? Number.parseInt(sshPortEnv, 10) : NaN;
   const sshPort = Number.isFinite(sshPortParsed) && sshPortParsed > 0 ? sshPortParsed : undefined;
+  const cliPath = mdnsMinimal ? undefined : resolveBonjourCliPath();
 
-  try {
-    const bonjour = await startGatewayBonjourAdvertiser({
-      instanceName: formatBonjourInstanceName(params.machineDisplayName),
-      gatewayPort: params.port,
-      gatewayTlsEnabled: params.gatewayTls?.enabled ?? false,
-      gatewayTlsFingerprintSha256: params.gatewayTls?.fingerprintSha256,
-      canvasPort: params.canvasPort,
-      sshPort,
-      tailnetDns,
-      cliPath: resolveBonjourCliPath(),
-    });
-    bonjourStop = bonjour.stop;
-  } catch (err) {
-    params.logDiscovery.warn(`bonjour advertising failed: ${String(err)}`);
+  if (bonjourEnabled) {
+    try {
+      const bonjour = await startGatewayBonjourAdvertiser({
+        instanceName: formatBonjourInstanceName(params.machineDisplayName),
+        gatewayPort: params.port,
+        gatewayTlsEnabled: params.gatewayTls?.enabled ?? false,
+        gatewayTlsFingerprintSha256: params.gatewayTls?.fingerprintSha256,
+        canvasPort: params.canvasPort,
+        sshPort,
+        tailnetDns,
+        cliPath,
+        minimal: mdnsMinimal,
+      });
+      bonjourStop = bonjour.stop;
+    } catch (err) {
+      params.logDiscovery.warn(`bonjour advertising failed: ${String(err)}`);
+    }
   }
 
   if (params.wideAreaDiscoveryEnabled) {

--- a/packages/personas/zee/src/gateway/server-http.ts
+++ b/packages/personas/zee/src/gateway/server-http.ts
@@ -75,12 +75,19 @@ export function createHooksRequestHandler(
       return false;
     }
 
-    const token = extractHookToken(req, url);
+    const { token, fromQuery } = extractHookToken(req, url);
     if (!token || token !== hooksConfig.token) {
       res.statusCode = 401;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Unauthorized");
       return true;
+    }
+    if (fromQuery) {
+      logHooks.warn(
+        "Hook token provided via query parameter is deprecated for security reasons. " +
+          "Tokens in URLs appear in logs, browser history, and referrer headers. " +
+          "Use Authorization: Bearer <token> or X-Zee-Token header instead.",
+      );
     }
 
     if (req.method !== "POST") {

--- a/packages/personas/zee/src/gateway/server.impl.ts
+++ b/packages/personas/zee/src/gateway/server.impl.ts
@@ -344,6 +344,12 @@ export async function startGatewayServer(
     channelManager;
 
   const machineDisplayName = await getMachineDisplayName();
+  const mdnsMode =
+    cfgAtStart.discovery?.mdns?.enabled === false
+      ? "off"
+      : cfgAtStart.discovery?.mdns?.minimal === false
+        ? "full"
+        : "minimal";
   const discovery = await startGatewayDiscovery({
     machineDisplayName,
     port,
@@ -352,6 +358,7 @@ export async function startGatewayServer(
       : undefined,
     wideAreaDiscoveryEnabled: cfgAtStart.discovery?.wideArea?.enabled === true,
     tailscaleMode,
+    mdnsMode,
     logDiscovery,
   });
   bonjourStop = discovery.bonjourStop;

--- a/packages/personas/zee/src/gateway/server/ws-connection/message-handler.ts
+++ b/packages/personas/zee/src/gateway/server/ws-connection/message-handler.ts
@@ -26,7 +26,7 @@ import type { ResolvedGatewayAuth } from "../../auth.js";
 import { authorizeGatewayConnect } from "../../auth.js";
 import { loadConfig } from "../../../config/config.js";
 import { buildDeviceAuthPayload } from "../../device-auth.js";
-import { isLocalGatewayAddress, resolveGatewayClientIp } from "../../net.js";
+import { isLocalGatewayAddress, isTrustedProxyAddress, resolveGatewayClientIp } from "../../net.js";
 import { resolveNodeCommandAllowlist } from "../../node-command-policy.js";
 import {
   type ConnectParams,
@@ -177,7 +177,24 @@ export function attachGatewayWsMessageHandler(params: {
   const configSnapshot = loadConfig();
   const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
   const clientIp = resolveGatewayClientIp({ remoteAddr, forwardedFor, realIp, trustedProxies });
-  const isLocalClient = isLocalGatewayAddress(clientIp);
+
+  // If proxy headers are present but the remote address isn't trusted, don't treat
+  // the connection as local. This prevents auth bypass when running behind a reverse
+  // proxy without proper configuration - the proxy's loopback connection would otherwise
+  // cause all external requests to be treated as trusted local clients.
+  const hasProxyHeaders = Boolean(forwardedFor || realIp);
+  const remoteIsTrustedProxy = isTrustedProxyAddress(remoteAddr, trustedProxies);
+  const hasUntrustedProxyHeaders = hasProxyHeaders && !remoteIsTrustedProxy;
+  const isLocalClient = !hasUntrustedProxyHeaders && isLocalGatewayAddress(clientIp);
+  const reportedClientIp = hasUntrustedProxyHeaders ? undefined : clientIp;
+
+  if (hasUntrustedProxyHeaders) {
+    logWsControl.warn(
+      "Proxy headers detected from untrusted address. " +
+        "Connection will not be treated as local. " +
+        "Configure gateway.trustedProxies to restore local client detection behind your proxy.",
+    );
+  }
 
   const isWebchatConnect = (p: ConnectParams | null | undefined) => isWebchatClient(p?.client);
 
@@ -322,6 +339,31 @@ export function attachGatewayWsMessageHandler(params: {
         const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
         const allowInsecureControlUi =
           isControlUi && configSnapshot.gateway?.controlUi?.allowInsecureAuth === true;
+        if (hasUntrustedProxyHeaders && resolvedAuth.mode === "none") {
+          setHandshakeState("failed");
+          setCloseCause("proxy-auth-required", {
+            client: connectParams.client.id,
+            clientDisplayName: connectParams.client.displayName,
+            mode: connectParams.client.mode,
+            version: connectParams.client.version,
+          });
+          send({
+            type: "res",
+            id: frame.id,
+            ok: false,
+            error: errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              "gateway auth required behind reverse proxy",
+              {
+                details: {
+                  hint: "set gateway.auth or configure gateway.trustedProxies",
+                },
+              },
+            ),
+          });
+          close(1008, "gateway auth required");
+          return;
+        }
 
         if (!device) {
           const canSkipDevice = allowInsecureControlUi ? hasSharedAuth : hasTokenAuth;
@@ -581,7 +623,7 @@ export function attachGatewayWsMessageHandler(params: {
               clientMode: connectParams.client.mode,
               role,
               scopes,
-              remoteIp: clientIp,
+              remoteIp: reportedClientIp,
               silent: isLocalClient,
             });
             const context = buildRequestContext();
@@ -665,7 +707,7 @@ export function attachGatewayWsMessageHandler(params: {
               clientMode: connectParams.client.mode,
               role,
               scopes,
-              remoteIp: clientIp,
+              remoteIp: reportedClientIp,
             });
           }
         }
@@ -773,7 +815,7 @@ export function attachGatewayWsMessageHandler(params: {
         setHandshakeState("connected");
         if (role === "node") {
           const context = buildRequestContext();
-          const nodeSession = context.nodeRegistry.register(nextClient, { remoteIp: clientIp });
+          const nodeSession = context.nodeRegistry.register(nextClient, { remoteIp: reportedClientIp });
           const instanceIdRaw = connectParams.client.instanceId;
           const instanceId = typeof instanceIdRaw === "string" ? instanceIdRaw.trim() : "";
           const nodeIdsForPairing = new Set<string>([nodeSession.nodeId]);

--- a/packages/personas/zee/src/infra/tailscale.ts
+++ b/packages/personas/zee/src/infra/tailscale.ts
@@ -381,3 +381,85 @@ export async function disableTailscaleFunnel(exec: typeof runExec = runExec) {
     timeoutMs: 15_000,
   });
 }
+
+export type TailscaleWhoisIdentity = {
+  login: string;
+  name?: string;
+};
+
+type TailscaleWhoisCacheEntry = {
+  value: TailscaleWhoisIdentity | null;
+  expiresAt: number;
+};
+
+const whoisCache = new Map<string, TailscaleWhoisCacheEntry>();
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function parseWhoisIdentity(payload: Record<string, unknown>): TailscaleWhoisIdentity | null {
+  const userProfile =
+    readRecord(payload.UserProfile) ?? readRecord(payload.userProfile) ?? readRecord(payload.User);
+  const login =
+    getString(userProfile?.LoginName) ??
+    getString(userProfile?.Login) ??
+    getString(userProfile?.login) ??
+    getString(payload.LoginName) ??
+    getString(payload.login);
+  if (!login) return null;
+  const name =
+    getString(userProfile?.DisplayName) ??
+    getString(userProfile?.Name) ??
+    getString(userProfile?.displayName) ??
+    getString(payload.DisplayName) ??
+    getString(payload.name);
+  return { login, name };
+}
+
+function readCachedWhois(ip: string, now: number): TailscaleWhoisIdentity | null | undefined {
+  const cached = whoisCache.get(ip);
+  if (!cached) return undefined;
+  if (cached.expiresAt <= now) {
+    whoisCache.delete(ip);
+    return undefined;
+  }
+  return cached.value;
+}
+
+function writeCachedWhois(ip: string, value: TailscaleWhoisIdentity | null, ttlMs: number) {
+  whoisCache.set(ip, { value, expiresAt: Date.now() + ttlMs });
+}
+
+export async function readTailscaleWhoisIdentity(
+  ip: string,
+  exec: typeof runExec = runExec,
+  opts?: { timeoutMs?: number; cacheTtlMs?: number; errorTtlMs?: number },
+): Promise<TailscaleWhoisIdentity | null> {
+  const normalized = ip.trim();
+  if (!normalized) return null;
+  const now = Date.now();
+  const cached = readCachedWhois(normalized, now);
+  if (cached !== undefined) return cached;
+
+  const cacheTtlMs = opts?.cacheTtlMs ?? 60_000;
+  const errorTtlMs = opts?.errorTtlMs ?? 5_000;
+  try {
+    const tailscaleBin = await getTailscaleBinary();
+    const { stdout } = await exec(tailscaleBin, ["whois", "--json", normalized], {
+      timeoutMs: opts?.timeoutMs ?? 5_000,
+      maxBuffer: 200_000,
+    });
+    const parsed = stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
+    const identity = parseWhoisIdentity(parsed);
+    writeCachedWhois(normalized, identity, cacheTtlMs);
+    return identity;
+  } catch {
+    writeCachedWhois(normalized, null, errorTtlMs);
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes #109.

Ports upstream gateway exposure/auth hardening into Zee (scoped to gateway/transport/security):
- Default gateway auth now requires a token unless Tailscale serve identity is in use.
- Reverse-proxy safety: do not treat connections as local when proxy headers arrive from an untrusted address.
- Tailscale serve auth now verifies `tailscale-user-*` headers against `tailscale whois`.
- Hooks: query-param token auth remains supported but logs a deprecation warning (use Bearer / X-Zee-Token).
- Discovery: add `discovery.mdns.{enabled,minimal}` with default minimal TXT records (omit cliPath/sshPort).
- Doctor/security: warn when gateway bind is network-accessible without a shared secret.
- Models status: auth probe table now has a dedicated Detail column.

Tests
- cd packages/personas/zee && pnpm build
