### PR TITLE
Provider: preserve source when custom loaders merge options

### DIFF
--- a/packages/agent-core/src/provider/provider.ts
+++ b/packages/agent-core/src/provider/provider.ts
@@ -516,10 +516,11 @@ export namespace Provider {
       // Load for the main provider if auth exists
       if (auth) {
         const options = await plugin.auth.loader(() => Auth.get(providerID) as any, database[plugin.auth.provider])
-        mergeProvider(plugin.auth.provider, {
-          source: "custom",
-          options: options,
-        })
+        const opts = options ?? {}
+        const patch: Partial<Info> = providers[providerID]
+          ? { options: opts }
+          : { source: "custom", options: opts }
+        mergeProvider(providerID, patch)
 
         // If this is google plugin (antigravity), set up the provider properly
         // The plugin's fetch interceptor handles Claude/Gemini models via Google Cloud Code API
@@ -740,10 +741,11 @@ export namespace Provider {
       const result = await fn(data)
       if (result && (result.autoload || providers[providerID])) {
         if (result.getModel) modelLoaders[providerID] = result.getModel
-        mergeProvider(providerID, {
-          source: "custom",
-          options: result.options,
-        })
+        const opts = result.options ?? {}
+        const patch: Partial<Info> = providers[providerID]
+          ? { options: opts }
+          : { source: "custom", options: opts }
+        mergeProvider(providerID, patch)
       }
     }
 

--- a/packages/agent-core/test/provider/provider.test.ts
+++ b/packages/agent-core/test/provider/provider.test.ts
@@ -49,6 +49,7 @@ test("provider loaded from env variable", async () => {
       // Source is preserved as "env" because user-set credentials (env vars) take precedence
       // over plugin detection. Custom loaders still merge their options, but don't override source.
       expect(providers["anthropic"].source).toBe("env")
+      expect(providers["anthropic"].options.headers["anthropic-beta"]).toBeDefined()
     },
   })
 })


### PR DESCRIPTION
Fixes #92.

Custom provider loaders (and plugin auth loaders) should merge provider options without overwriting the original provider connection source (env/api/config).

Tests
- bun run --cwd packages/agent-core typecheck
- bun test --cwd packages/agent-core test/provider/provider.test.ts
