### PR TITLE
Zee security: harden gateway file serving and sanitize error responses

### DIFF
--- a/packages/personas/zee/src/gateway/server-http.ts
+++ b/packages/personas/zee/src/gateway/server-http.ts
@@ -289,10 +289,10 @@ export function createGatewayHttpServer(opts: {
       res.statusCode = 404;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Not Found");
-    } catch (err) {
+    } catch {
       res.statusCode = 500;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
-      res.end(String(err));
+      res.end("Internal Server Error");
     }
   }
 


### PR DESCRIPTION
Fixes #108.

Ports upstream hardenings to Zee's transport layer:
- Media and canvas file serving uses safe open within a root dir (symlink/path escape protection, regular-file checks).
- Media server aligns max served bytes with storage limits and returns deterministic 400/404/410/413 responses.
- Gateway HTTP server no longer returns raw error strings to clients.

Tests
- cd packages/personas/zee && pnpm vitest run src/media/server.test.ts src/canvas-host/server.test.ts src/security/fs-safe.test.ts
- cd packages/personas/zee && pnpm build
