### PR TITLE
Upstream security: DNS pinning, SSH target hardening, trusted proxy IPs

### DIFF
--- a/packages/personas/zee/src/infra/net/ssrf.pinning.test.ts
+++ b/packages/personas/zee/src/infra/net/ssrf.pinning.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createPinnedLookup, resolvePinnedHostname } from "./ssrf.js";
+
+describe("ssrf pinning", () => {
+  it("pins resolved addresses for the target hostname", async () => {
+    const lookup = vi.fn(async () => [
+      { address: "93.184.216.34", family: 4 },
+      { address: "93.184.216.35", family: 4 },
+    ]);
+
+    const pinned = await resolvePinnedHostname("Example.com.", lookup);
+    expect(pinned.hostname).toBe("example.com");
+    expect(pinned.addresses).toEqual(["93.184.216.34", "93.184.216.35"]);
+
+    const first = await new Promise<{ address: string; family?: number }>((resolve, reject) => {
+      pinned.lookup("example.com", (err, address, family) => {
+        if (err) reject(err);
+        else resolve({ address: address as string, family });
+      });
+    });
+    expect(first.address).toBe("93.184.216.34");
+    expect(first.family).toBe(4);
+
+    const all = await new Promise<unknown>((resolve, reject) => {
+      pinned.lookup("example.com", { all: true }, (err, addresses) => {
+        if (err) reject(err);
+        else resolve(addresses);
+      });
+    });
+    expect(Array.isArray(all)).toBe(true);
+    expect((all as Array<{ address: string }>).map((entry) => entry.address)).toEqual(
+      pinned.addresses,
+    );
+  });
+
+  it("rejects private DNS results", async () => {
+    const lookup = vi.fn(async () => [{ address: "10.0.0.8", family: 4 }]);
+    await expect(resolvePinnedHostname("example.com", lookup)).rejects.toThrow(/private|internal/i);
+  });
+
+  it("falls back for non-matching hostnames", async () => {
+    const fallback = vi.fn((host: string, options?: unknown, callback?: unknown) => {
+      const cb = typeof options === "function" ? options : (callback as () => void);
+      (cb as (err: null, address: string, family: number) => void)(null, "1.2.3.4", 4);
+    });
+    const lookup = createPinnedLookup({
+      hostname: "example.com",
+      addresses: ["93.184.216.34"],
+      fallback,
+    });
+
+    const result = await new Promise<{ address: string }>((resolve, reject) => {
+      lookup("other.test", (err, address) => {
+        if (err) reject(err);
+        else resolve({ address: address as string });
+      });
+    });
+
+    expect(fallback).toHaveBeenCalledTimes(1);
+    expect(result.address).toBe("1.2.3.4");
+  });
+});
+

--- a/packages/personas/zee/src/infra/net/ssrf.ts
+++ b/packages/personas/zee/src/infra/net/ssrf.ts
@@ -1,4 +1,12 @@
 import { lookup as dnsLookup } from "node:dns/promises";
+import { lookup as dnsLookupCb, type LookupAddress } from "node:dns";
+import { Agent, type Dispatcher } from "undici";
+
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address: string | LookupAddress[],
+  family?: number,
+) => void;
 
 export class SsrFBlockedError extends Error {
   constructor(message: string) {
@@ -101,10 +109,71 @@ export function isBlockedHostname(hostname: string): boolean {
   );
 }
 
-export async function assertPublicHostname(
+export function createPinnedLookup(params: {
+  hostname: string;
+  addresses: string[];
+  fallback?: typeof dnsLookupCb;
+}): typeof dnsLookupCb {
+  const normalizedHost = normalizeHostname(params.hostname);
+  const fallback = params.fallback ?? dnsLookupCb;
+  const fallbackLookup = fallback as unknown as (
+    hostname: string,
+    callback: LookupCallback,
+  ) => void;
+  const fallbackWithOptions = fallback as unknown as (
+    hostname: string,
+    options: unknown,
+    callback: LookupCallback,
+  ) => void;
+  const records = params.addresses.map((address) => ({
+    address,
+    family: address.includes(":") ? 6 : 4,
+  }));
+  let index = 0;
+
+  return ((host: string, options?: unknown, callback?: unknown) => {
+    const cb: LookupCallback =
+      typeof options === "function" ? (options as LookupCallback) : (callback as LookupCallback);
+    if (!cb) return;
+    const normalized = normalizeHostname(host);
+    if (!normalized || normalized !== normalizedHost) {
+      if (typeof options === "function" || options === undefined) {
+        return fallbackLookup(host, cb);
+      }
+      return fallbackWithOptions(host, options, cb);
+    }
+
+    const opts =
+      typeof options === "object" && options !== null
+        ? (options as { all?: boolean; family?: number })
+        : {};
+    const requestedFamily =
+      typeof options === "number" ? options : typeof opts.family === "number" ? opts.family : 0;
+    const candidates =
+      requestedFamily === 4 || requestedFamily === 6
+        ? records.filter((entry) => entry.family === requestedFamily)
+        : records;
+    const usable = candidates.length > 0 ? candidates : records;
+    if (opts.all) {
+      cb(null, usable as LookupAddress[]);
+      return;
+    }
+    const chosen = usable[index % usable.length];
+    index += 1;
+    cb(null, chosen.address, chosen.family);
+  }) as typeof dnsLookupCb;
+}
+
+export type PinnedHostname = {
+  hostname: string;
+  addresses: string[];
+  lookup: typeof dnsLookupCb;
+};
+
+export async function resolvePinnedHostname(
   hostname: string,
   lookupFn: LookupFn = dnsLookup,
-): Promise<void> {
+): Promise<PinnedHostname> {
   const normalized = normalizeHostname(hostname);
   if (!normalized) {
     throw new Error("Invalid hostname");
@@ -128,4 +197,47 @@ export async function assertPublicHostname(
       throw new SsrFBlockedError("Blocked: resolves to private/internal IP address");
     }
   }
+
+  const addresses = Array.from(new Set(results.map((entry) => entry.address)));
+  if (addresses.length === 0) {
+    throw new Error(`Unable to resolve hostname: ${hostname}`);
+  }
+
+  return {
+    hostname: normalized,
+    addresses,
+    lookup: createPinnedLookup({ hostname: normalized, addresses }),
+  };
 }
+
+export function createPinnedDispatcher(pinned: PinnedHostname): Dispatcher {
+  return new Agent({
+    connect: {
+      lookup: pinned.lookup,
+    },
+  });
+}
+
+export async function closeDispatcher(dispatcher?: Dispatcher | null): Promise<void> {
+  if (!dispatcher) return;
+  const candidate = dispatcher as { close?: () => Promise<void> | void; destroy?: () => void };
+  try {
+    if (typeof candidate.close === "function") {
+      await candidate.close();
+      return;
+    }
+    if (typeof candidate.destroy === "function") {
+      candidate.destroy();
+    }
+  } catch {
+    // ignore dispatcher cleanup errors
+  }
+}
+
+export async function assertPublicHostname(
+  hostname: string,
+  lookupFn: LookupFn = dnsLookup,
+): Promise<void> {
+  await resolvePinnedHostname(hostname, lookupFn);
+}
+

--- a/packages/personas/zee/src/infra/ssh-tunnel.test.ts
+++ b/packages/personas/zee/src/infra/ssh-tunnel.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSshTarget } from "./ssh-tunnel.js";
+
+describe("ssh tunnel target parsing", () => {
+  it("parses user@host:port", () => {
+    expect(parseSshTarget("user@example.com:2222")).toEqual({
+      user: "user",
+      host: "example.com",
+      port: 2222,
+    });
+  });
+
+  it("parses host with default port", () => {
+    expect(parseSshTarget("example.com")).toEqual({ user: undefined, host: "example.com", port: 22 });
+  });
+
+  it("rejects targets containing whitespace or flags", () => {
+    expect(parseSshTarget("ssh -i key user@example.com")).toBeNull();
+    expect(parseSshTarget("-oProxyCommand=echo pwned")).toBeNull();
+  });
+});
+

--- a/packages/personas/zee/src/infra/ssh-tunnel.ts
+++ b/packages/personas/zee/src/infra/ssh-tunnel.ts
@@ -25,6 +25,9 @@ function isErrno(err: unknown): err is NodeJS.ErrnoException {
 export function parseSshTarget(raw: string): SshParsedTarget | null {
   const trimmed = raw.trim().replace(/^ssh\s+/, "");
   if (!trimmed) return null;
+  // Hardening: targets must be a plain user@host[:port] string (no flags/whitespace).
+  if (/\s/.test(trimmed)) return null;
+  if (trimmed.startsWith("-")) return null;
 
   const [userPart, hostPart] = trimmed.includes("@")
     ? ((): [string | undefined, string] => {
@@ -134,7 +137,8 @@ export async function startSshPortForward(opts: {
   if (opts.identity?.trim()) {
     args.push("-i", opts.identity.trim());
   }
-  args.push(userHost);
+  // Ensure the host is treated as a positional argument even if it starts with "-".
+  args.push("--", userHost);
 
   const stderr: string[] = [];
   const child = spawn("/usr/bin/ssh", args, {

--- a/packages/personas/zee/src/media/input-files.ts
+++ b/packages/personas/zee/src/media/input-files.ts
@@ -1,5 +1,6 @@
 import { logWarn } from "../logger.js";
-import { assertPublicHostname } from "../infra/net/ssrf.js";
+import { closeDispatcher, createPinnedDispatcher, resolvePinnedHostname } from "../infra/net/ssrf.js";
+import type { Dispatcher } from "undici";
 
 type CanvasModule = typeof import("@napi-rs/canvas");
 type PdfJsModule = typeof import("pdfjs-dist/legacy/build/pdf.mjs");
@@ -154,50 +155,57 @@ export async function fetchWithGuard(params: {
       if (!["http:", "https:"].includes(parsedUrl.protocol)) {
         throw new Error(`Invalid URL protocol: ${parsedUrl.protocol}. Only HTTP/HTTPS allowed.`);
       }
-      await assertPublicHostname(parsedUrl.hostname);
+      const pinned = await resolvePinnedHostname(parsedUrl.hostname);
+      const dispatcher = createPinnedDispatcher(pinned);
 
-      const response = await fetch(parsedUrl, {
-        signal: controller.signal,
-        headers: { "User-Agent": "Zee-Gateway/1.0" },
-        redirect: "manual",
-      });
+      try {
+        const response = await fetch(parsedUrl, {
+          signal: controller.signal,
+          headers: { "User-Agent": "Zee-Gateway/1.0" },
+          redirect: "manual",
+          dispatcher,
+        } as RequestInit & { dispatcher: Dispatcher });
 
-      if (isRedirectStatus(response.status)) {
-        const location = response.headers.get("location");
-        if (!location) {
-          throw new Error(`Redirect missing location header (${response.status})`);
+        if (isRedirectStatus(response.status)) {
+          const location = response.headers.get("location");
+          if (!location) {
+            throw new Error(`Redirect missing location header (${response.status})`);
+          }
+          redirectCount += 1;
+          if (redirectCount > params.maxRedirects) {
+            throw new Error(`Too many redirects (limit: ${params.maxRedirects})`);
+          }
+          void response.body?.cancel();
+          currentUrl = new URL(location, parsedUrl).toString();
+          continue;
         }
-        redirectCount += 1;
-        if (redirectCount > params.maxRedirects) {
-          throw new Error(`Too many redirects (limit: ${params.maxRedirects})`);
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
         }
-        currentUrl = new URL(location, parsedUrl).toString();
-        continue;
-      }
 
-      if (!response.ok) {
-        throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
-      }
-
-      const contentLength = response.headers.get("content-length");
-      if (contentLength) {
-        const size = parseInt(contentLength, 10);
-        if (size > params.maxBytes) {
-          throw new Error(`Content too large: ${size} bytes (limit: ${params.maxBytes} bytes)`);
+        const contentLength = response.headers.get("content-length");
+        if (contentLength) {
+          const size = parseInt(contentLength, 10);
+          if (size > params.maxBytes) {
+            throw new Error(`Content too large: ${size} bytes (limit: ${params.maxBytes} bytes)`);
+          }
         }
-      }
 
-      const buffer = Buffer.from(await response.arrayBuffer());
-      if (buffer.byteLength > params.maxBytes) {
-        throw new Error(
-          `Content too large: ${buffer.byteLength} bytes (limit: ${params.maxBytes} bytes)`,
-        );
-      }
+        const buffer = Buffer.from(await response.arrayBuffer());
+        if (buffer.byteLength > params.maxBytes) {
+          throw new Error(
+            `Content too large: ${buffer.byteLength} bytes (limit: ${params.maxBytes} bytes)`,
+          );
+        }
 
-      const contentType = response.headers.get("content-type") || undefined;
-      const parsed = parseContentType(contentType);
-      const mimeType = parsed.mimeType ?? "application/octet-stream";
-      return { buffer, mimeType, contentType };
+        const contentType = response.headers.get("content-type") || undefined;
+        const parsed = parseContentType(contentType);
+        const mimeType = parsed.mimeType ?? "application/octet-stream";
+        return { buffer, mimeType, contentType };
+      } finally {
+        await closeDispatcher(dispatcher);
+      }
     }
   } finally {
     clearTimeout(timeoutId);

--- a/packages/personas/zee/src/media/store.redirect.test.ts
+++ b/packages/personas/zee/src/media/store.redirect.test.ts
@@ -18,6 +18,9 @@ vi.doMock("node:os", () => ({
 vi.doMock("node:https", () => ({
   request: (...args: unknown[]) => mockRequest(...args),
 }));
+vi.doMock("node:dns/promises", () => ({
+  lookup: async () => [{ address: "93.184.216.34", family: 4 }],
+}));
 
 const loadStore = async () => await import("./store.js");
 

--- a/packages/personas/zee/src/media/store.ts
+++ b/packages/personas/zee/src/media/store.ts
@@ -1,9 +1,11 @@
 import crypto from "node:crypto";
 import { createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
-import { request } from "node:https";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
+import { resolvePinnedHostname } from "../infra/net/ssrf.js";
 import { resolveConfigDir } from "../utils.js";
 import { detectMime, extensionForMime } from "./mime.js";
 
@@ -88,51 +90,69 @@ async function downloadToFile(
   maxRedirects = 5,
 ): Promise<{ headerMime?: string; sniffBuffer: Buffer; size: number }> {
   return await new Promise((resolve, reject) => {
-    const req = request(url, { headers }, (res) => {
-      // Follow redirects
-      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
-        const location = res.headers.location;
-        if (!location || maxRedirects <= 0) {
-          reject(new Error(`Redirect loop or missing Location header`));
-          return;
-        }
-        const redirectUrl = new URL(location, url).href;
-        resolve(downloadToFile(redirectUrl, dest, headers, maxRedirects - 1));
-        return;
-      }
-      if (!res.statusCode || res.statusCode >= 400) {
-        reject(new Error(`HTTP ${res.statusCode ?? "?"} downloading media`));
-        return;
-      }
-      let total = 0;
-      const sniffChunks: Buffer[] = [];
-      let sniffLen = 0;
-      const out = createWriteStream(dest);
-      res.on("data", (chunk) => {
-        total += chunk.length;
-        if (sniffLen < 16384) {
-          sniffChunks.push(chunk);
-          sniffLen += chunk.length;
-        }
-        if (total > MAX_BYTES) {
-          req.destroy(new Error("Media exceeds 5MB limit"));
-        }
-      });
-      pipeline(res, out)
-        .then(() => {
-          const sniffBuffer = Buffer.concat(sniffChunks, Math.min(sniffLen, 16384));
-          const rawHeader = res.headers["content-type"];
-          const headerMime = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
-          resolve({
-            headerMime,
-            sniffBuffer,
-            size: total,
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      reject(new Error("Invalid URL"));
+      return;
+    }
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      reject(new Error(`Invalid URL protocol: ${parsedUrl.protocol}. Only HTTP/HTTPS allowed.`));
+      return;
+    }
+
+    const requestImpl = parsedUrl.protocol === "https:" ? httpsRequest : httpRequest;
+
+    resolvePinnedHostname(parsedUrl.hostname)
+      .then((pinned) => {
+        const req = requestImpl(parsedUrl, { headers, lookup: pinned.lookup }, (res) => {
+          // Follow redirects
+          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+            const location = res.headers.location;
+            if (!location || maxRedirects <= 0) {
+              reject(new Error(`Redirect loop or missing Location header`));
+              return;
+            }
+            const redirectUrl = new URL(location, url).href;
+            resolve(downloadToFile(redirectUrl, dest, headers, maxRedirects - 1));
+            return;
+          }
+          if (!res.statusCode || res.statusCode >= 400) {
+            reject(new Error(`HTTP ${res.statusCode ?? "?"} downloading media`));
+            return;
+          }
+          let total = 0;
+          const sniffChunks: Buffer[] = [];
+          let sniffLen = 0;
+          const out = createWriteStream(dest);
+          res.on("data", (chunk) => {
+            total += chunk.length;
+            if (sniffLen < 16384) {
+              sniffChunks.push(chunk);
+              sniffLen += chunk.length;
+            }
+            if (total > MAX_BYTES) {
+              req.destroy(new Error("Media exceeds 5MB limit"));
+            }
           });
-        })
-        .catch(reject);
-    });
-    req.on("error", reject);
-    req.end();
+          pipeline(res, out)
+            .then(() => {
+              const sniffBuffer = Buffer.concat(sniffChunks, Math.min(sniffLen, 16384));
+              const rawHeader = res.headers["content-type"];
+              const headerMime = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+              resolve({
+                headerMime,
+                sniffBuffer,
+                size: total,
+              });
+            })
+            .catch(reject);
+        });
+        req.on("error", reject);
+        req.end();
+      })
+      .catch(reject);
   });
 }
 


### PR DESCRIPTION
Fixes #110.

Notes
- This PR ports Zee gateway/transport hardenings only (per issue scope).
- Trusted proxy IP handling and discovery hardening already landed on `dev` (commit 2866836869); this PR adds the remaining DNS pinning + SSH target hardening pieces.

What changed
- DNS pinning helpers in `packages/personas/zee/src/infra/net/ssrf.ts` (pinned lookup/dispatcher) and tests.
- Use pinned dispatcher/lookup for media URL fetch paths (`input-files.ts`, `store.ts`) to reduce DNS-rebinding risk.
- Harden SSH target parsing and ensure `ssh` is spawned with `--` before host to avoid option injection.

Tests
- `pnpm -C packages/personas/zee vitest run src/infra/net/ssrf.pinning.test.ts src/media/store.redirect.test.ts src/infra/ssh-tunnel.test.ts`
- `pnpm -C packages/personas/zee build`