### PR TITLE
Upstream security: LINE webhook signature timing-attack fix

### DIFF
--- a/packages/personas/zee/src/line/signature.test.ts
+++ b/packages/personas/zee/src/line/signature.test.ts
@@ -1,0 +1,27 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { validateLineSignature } from "./signature.js";
+
+const sign = (body: string, secret: string) => crypto.createHmac("SHA256", secret).update(body).digest("base64");
+
+describe("validateLineSignature", () => {
+  it("accepts valid signatures", () => {
+    const secret = "secret";
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+
+    expect(validateLineSignature(rawBody, sign(rawBody, secret), secret)).toBe(true);
+  });
+
+  it("rejects signatures computed with the wrong secret", () => {
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+
+    expect(validateLineSignature(rawBody, sign(rawBody, "wrong-secret"), "secret")).toBe(false);
+  });
+
+  it("rejects signatures with a different length", () => {
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+
+    expect(validateLineSignature(rawBody, "short", "secret")).toBe(false);
+  });
+});
+

--- a/packages/personas/zee/src/line/signature.ts
+++ b/packages/personas/zee/src/line/signature.ts
@@ -1,0 +1,15 @@
+import crypto from "node:crypto";
+
+export function validateLineSignature(body: string, signature: string, channelSecret: string): boolean {
+  const hash = crypto.createHmac("SHA256", channelSecret).update(body).digest("base64");
+  const hashBuffer = Buffer.from(hash);
+  const signatureBuffer = Buffer.from(signature);
+
+  // Use constant-time comparison to prevent timing attacks.
+  if (hashBuffer.length !== signatureBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(hashBuffer, signatureBuffer);
+}
+

--- a/packages/personas/zee/src/line/webhook.ts
+++ b/packages/personas/zee/src/line/webhook.ts
@@ -1,18 +1,13 @@
 import type { Request, Response, NextFunction } from "express";
-import crypto from "node:crypto";
 import type { WebhookRequestBody } from "@line/bot-sdk";
 import { logVerbose, danger } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { validateLineSignature } from "./signature.js";
 
 export interface LineWebhookOptions {
   channelSecret: string;
   onEvents: (body: WebhookRequestBody) => Promise<void>;
   runtime?: RuntimeEnv;
-}
-
-function validateSignature(body: string, signature: string, channelSecret: string): boolean {
-  const hash = crypto.createHmac("SHA256", channelSecret).update(body).digest("base64");
-  return hash === signature;
 }
 
 function readRawBody(req: Request): string | null {
@@ -52,7 +47,7 @@ export function createLineWebhookMiddleware(options: LineWebhookOptions) {
         return;
       }
 
-      if (!validateSignature(rawBody, signature, channelSecret)) {
+      if (!validateLineSignature(rawBody, signature, channelSecret)) {
         logVerbose("line: webhook signature validation failed");
         res.status(401).json({ error: "Invalid signature" });
         return;


### PR DESCRIPTION
Fixes #111.

What changed
- Use constant-time comparison (`crypto.timingSafeEqual`) for LINE webhook signature validation.
- Factor validation into `packages/personas/zee/src/line/signature.ts` and add focused unit tests.
- Expand LINE webhook middleware tests to cover invalid signatures and wrong secrets.

Tests
- `pnpm -C packages/personas/zee vitest run src/line/webhook.test.ts src/line/signature.test.ts`
- `pnpm -C packages/personas/zee build`