### PR TITLE
Upstream browser control routing + evaluate safety gates

### DIFF
--- a/packages/personas/zee/docs/gateway/configuration.md
+++ b/packages/personas/zee/docs/gateway/configuration.md
@@ -2706,6 +2706,7 @@ scheme/host for profiles that only set `cdpPort`.
 
 Defaults:
 - enabled: `true`
+- evaluate enabled: `true` (set `browser.evaluateEnabled=false` to disable act:evaluate and wait --fn)
 - control URL: `http://127.0.0.1:18791` (CDP uses `18792`)
 - CDP URL: `http://127.0.0.1:18792` (control URL + 1, legacy single-profile)
 - profile color: `#FF4500` (lobster-orange)

--- a/packages/personas/zee/src/agents/sandbox/browser.ts
+++ b/packages/personas/zee/src/agents/sandbox/browser.ts
@@ -45,6 +45,7 @@ function buildSandboxBrowserResolvedConfig(params: {
   const cdpHost = "127.0.0.1";
   return {
     enabled: true,
+    evaluateEnabled: true,
     controlUrl,
     controlHost,
     controlPort: params.controlPort,

--- a/packages/personas/zee/src/browser/config.ts
+++ b/packages/personas/zee/src/browser/config.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_ZEE_BROWSER_COLOR,
   DEFAULT_ZEE_BROWSER_CONTROL_URL,
   DEFAULT_ZEE_BROWSER_ENABLED,
+  DEFAULT_ZEE_BROWSER_EVALUATE_ENABLED,
   DEFAULT_BROWSER_DEFAULT_PROFILE_NAME,
   DEFAULT_ZEE_BROWSER_PROFILE_NAME,
 } from "./constants.js";
@@ -14,6 +15,7 @@ import { CDP_PORT_RANGE_START, getUsedPorts } from "./profiles.js";
 
 export type ResolvedBrowserConfig = {
   enabled: boolean;
+  evaluateEnabled: boolean;
   controlUrl: string;
   controlHost: string;
   controlPort: number;
@@ -139,6 +141,7 @@ function ensureDefaultChromeExtensionProfile(
 }
 export function resolveBrowserConfig(cfg: BrowserConfig | undefined): ResolvedBrowserConfig {
   const enabled = cfg?.enabled ?? DEFAULT_ZEE_BROWSER_ENABLED;
+  const evaluateEnabled = cfg?.evaluateEnabled ?? DEFAULT_ZEE_BROWSER_EVALUATE_ENABLED;
   const envControlUrl = process.env.ZEE_BROWSER_CONTROL_URL?.trim();
   const controlToken = cfg?.controlToken?.trim() || undefined;
   const derivedControlPort = (() => {
@@ -211,6 +214,7 @@ export function resolveBrowserConfig(cfg: BrowserConfig | undefined): ResolvedBr
 
   return {
     enabled,
+    evaluateEnabled,
     controlUrl: controlInfo.normalized,
     controlHost: controlInfo.parsed.hostname,
     controlPort,

--- a/packages/personas/zee/src/browser/constants.ts
+++ b/packages/personas/zee/src/browser/constants.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_ZEE_BROWSER_ENABLED = true;
+export const DEFAULT_ZEE_BROWSER_EVALUATE_ENABLED = true;
 export const DEFAULT_ZEE_BROWSER_CONTROL_URL = "http://127.0.0.1:18791";
 export const DEFAULT_ZEE_BROWSER_COLOR = "#FF4500";
 export const DEFAULT_ZEE_BROWSER_PROFILE_NAME = "zee";

--- a/packages/personas/zee/src/browser/pw-session.get-page-for-targetid.url-fallback.test.ts
+++ b/packages/personas/zee/src/browser/pw-session.get-page-for-targetid.url-fallback.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("pw-session getPageForTargetId", () => {
+  it("falls back to /json/list URL matching when CDP session attachment is blocked", async () => {
+    vi.resetModules();
+
+    const pageOn = vi.fn();
+    const contextOn = vi.fn();
+    const browserOn = vi.fn();
+    const browserClose = vi.fn(async () => {});
+
+    const context = {
+      pages: () => [],
+      on: contextOn,
+      newCDPSession: vi.fn(async () => {
+        throw new Error("Not allowed");
+      }),
+    } as unknown as import("playwright-core").BrowserContext;
+
+    const pageA = {
+      on: pageOn,
+      context: () => context,
+      url: () => "https://example.com/a",
+    } as unknown as import("playwright-core").Page;
+
+    const pageB = {
+      on: pageOn,
+      context: () => context,
+      url: () => "https://example.com/b",
+    } as unknown as import("playwright-core").Page;
+
+    // Fill pages() after pages exist.
+    (context as unknown as { pages: () => unknown[] }).pages = () => [pageA, pageB];
+
+    const browser = {
+      contexts: () => [context],
+      on: browserOn,
+      close: browserClose,
+    } as unknown as import("playwright-core").Browser;
+
+    vi.doMock("playwright-core", () => ({
+      chromium: {
+        connectOverCDP: vi.fn(async () => browser),
+      },
+    }));
+
+    vi.doMock("./chrome.js", () => ({
+      getChromeWebSocketUrl: vi.fn(async () => null),
+    }));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (!String(url).includes("/json/list")) {
+          throw new Error(`unexpected fetch url: ${url}`);
+        }
+        return {
+          ok: true,
+          json: async () => [{ id: "TAB_B", url: "https://example.com/b" }],
+        } as unknown as Response;
+      }),
+    );
+
+    const mod = await import("./pw-session.js");
+    const resolved = await mod.getPageForTargetId({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "TAB_B",
+    });
+    expect(resolved).toBe(pageB);
+
+    await mod.closePlaywrightBrowserConnection();
+    expect(browserClose).toHaveBeenCalled();
+  });
+});
+

--- a/packages/personas/zee/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/packages/personas/zee/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -7,6 +7,7 @@ let testPort = 0;
 let cdpBaseUrl = "";
 let reachable = false;
 let cfgAttachOnly = false;
+let cfgEvaluateEnabled = true;
 let createTargetId: string | null = null;
 
 const cdpMocks = vi.hoisted(() => ({
@@ -88,6 +89,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
     loadConfig: () => ({
       browser: {
         enabled: true,
+        evaluateEnabled: cfgEvaluateEnabled,
         controlUrl: `http://127.0.0.1:${testPort}`,
         color: "#FF4500",
         attachOnly: cfgAttachOnly,
@@ -185,6 +187,7 @@ describe("browser control server", () => {
   beforeEach(async () => {
     reachable = false;
     cfgAttachOnly = false;
+    cfgEvaluateEnabled = true;
     createTargetId = null;
 
     cdpMocks.createTargetViaCdp.mockImplementation(async () => {
@@ -338,6 +341,30 @@ describe("browser control server", () => {
         fn: "() => 1",
         ref: undefined,
       });
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "blocks act:evaluate when browser.evaluateEnabled=false",
+    async () => {
+      cfgEvaluateEnabled = false;
+      const base = await startServerAndBase();
+
+      const waitRes = (await postJson(`${base}/act`, {
+        kind: "wait",
+        fn: "() => window.ready === true",
+      })) as { error?: string };
+      expect(waitRes.error).toContain("browser.evaluateEnabled=false");
+      expect(pwMocks.waitForViaPlaywright).not.toHaveBeenCalled();
+
+      const res = (await postJson(`${base}/act`, {
+        kind: "evaluate",
+        fn: "() => 1",
+      })) as { error?: string };
+
+      expect(res.error).toContain("browser.evaluateEnabled=false");
+      expect(pwMocks.evaluateViaPlaywright).not.toHaveBeenCalled();
     },
     slowTimeoutMs,
   );

--- a/packages/personas/zee/src/config/schema.ts
+++ b/packages/personas/zee/src/config/schema.ts
@@ -276,6 +276,7 @@ const FIELD_LABELS: Record<string, string> = {
   "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",
   "browser.controlUrl": "Browser Control URL",
+  "browser.evaluateEnabled": "Browser Evaluate Enabled",
   "browser.snapshotDefaults": "Browser Snapshot Defaults",
   "browser.snapshotDefaults.mode": "Browser Snapshot Mode",
   "browser.remoteCdpTimeoutMs": "Remote CDP Timeout (ms)",
@@ -396,6 +397,8 @@ const FIELD_HELP: Record<string, string> = {
   "nodeHost.browserProxy.enabled": "Expose the local browser control server via node proxy.",
   "nodeHost.browserProxy.allowProfiles":
     "Optional allowlist of browser profile names exposed via the node proxy.",
+  "browser.evaluateEnabled":
+    "Allow act:evaluate and wait --fn in the browser control API (default: true).",
   "diagnostics.flags":
     'Enable targeted diagnostics logs by flag (e.g. ["telegram.http"]). Supports wildcards like "telegram.*" or "*".',
   "diagnostics.cacheTrace.enabled":

--- a/packages/personas/zee/src/config/types.browser.ts
+++ b/packages/personas/zee/src/config/types.browser.ts
@@ -14,6 +14,13 @@ export type BrowserSnapshotDefaults = {
 };
 export type BrowserConfig = {
   enabled?: boolean;
+  /**
+   * When false, disable script evaluation helpers (act:evaluate and wait --fn).
+   * Useful for hardened gateway deployments where arbitrary page evaluation is not allowed.
+   *
+   * Default: true
+   */
+  evaluateEnabled?: boolean;
   /** Base URL of the zee browser control server. Default: http://127.0.0.1:18791 */
   controlUrl?: string;
   /**

--- a/packages/personas/zee/src/config/zod-schema.ts
+++ b/packages/personas/zee/src/config/zod-schema.ts
@@ -134,6 +134,7 @@ export const ZeeSchema = z
     browser: z
       .object({
         enabled: z.boolean().optional(),
+        evaluateEnabled: z.boolean().optional(),
         controlUrl: z.string().optional(),
         controlToken: z.string().optional(),
         cdpUrl: z.string().optional(),


### PR DESCRIPTION
Fixes #112.

What changed
- Add URL-based /json/list fallback when resolving Playwright pages by targetId (helps Chrome extension relay scenarios where CDP attach APIs are blocked).
- Add `browser.evaluateEnabled` config (default true) and gate `act:evaluate` + `wait --fn` when disabled.

Notes
- Node browser proxy routing is already present in Zee; this PR focuses on the missing transport hardening and safety gate pieces from the referenced upstream commits.

Tests
- `pnpm -C packages/personas/zee vitest run src/browser/pw-session.get-page-for-targetid.url-fallback.test.ts src/browser/server.agent-contract-form-layout-act-commands.test.ts`
- `pnpm -C packages/personas/zee build`