### PR TITLE
Upstream Control UI auth/status improvements

### DIFF
--- a/packages/personas/zee/docs/gateway/configuration.md
+++ b/packages/personas/zee/docs/gateway/configuration.md
@@ -2783,6 +2783,8 @@ Control UI base path:
 - `gateway.controlUi.allowInsecureAuth` allows token-only auth for the Control UI and skips
   device identity + pairing (even on HTTPS). Default: `false`. Prefer HTTPS
   (Tailscale Serve) or `127.0.0.1`.
+- `gateway.controlUi.dangerouslyDisableDeviceAuth` disables device identity checks for the
+  Control UI (DANGEROUS). Default: `false`. Only use for short-lived break-glass scenarios.
 
 Related docs:
 - [Control UI](/web/control-ui)

--- a/packages/personas/zee/docs/web/control-ui.md
+++ b/packages/personas/zee/docs/web/control-ui.md
@@ -111,6 +111,21 @@ Zee **blocks** Control UI connections without device identity.
 This disables device identity + pairing for the Control UI (even on HTTPS). Use
 only if you trust the network.
 
+**Break-glass (disable Control UI device checks):**
+
+```json5
+{
+  gateway: {
+    controlUi: { dangerouslyDisableDeviceAuth: true },
+    bind: "loopback",
+    auth: { mode: "token", token: "replace-me" }
+  }
+}
+```
+
+This disables Control UI device identity checks entirely (DANGEROUS). Keep it
+loopback-only and remove it as soon as possible.
+
 See [Tailscale](/gateway/tailscale) for HTTPS setup guidance.
 
 ## Building the UI

--- a/packages/personas/zee/src/config/schema.ts
+++ b/packages/personas/zee/src/config/schema.ts
@@ -199,6 +199,7 @@ const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
   "gateway.controlUi.basePath": "Control UI Base Path",
   "gateway.controlUi.allowInsecureAuth": "Allow Insecure Control UI Auth",
+  "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
   "gateway.http.endpoints.chatCompletions.enabled": "OpenAI Chat Completions Endpoint",
   "gateway.reload.mode": "Config Reload Mode",
   "gateway.reload.debounceMs": "Config Reload Debounce (ms)",
@@ -382,6 +383,8 @@ const FIELD_HELP: Record<string, string> = {
     "Optional URL prefix where the Control UI is served (e.g. /zee).",
   "gateway.controlUi.allowInsecureAuth":
     "Allow Control UI auth over insecure HTTP (token-only; not recommended).",
+  "gateway.controlUi.dangerouslyDisableDeviceAuth":
+    "DANGEROUS: Disable device identity checks for the Control UI (default: false).",
   "gateway.http.endpoints.chatCompletions.enabled":
     "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
   "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',

--- a/packages/personas/zee/src/config/types.gateway.ts
+++ b/packages/personas/zee/src/config/types.gateway.ts
@@ -64,6 +64,8 @@ export type GatewayControlUiConfig = {
   basePath?: string;
   /** Allow token-only auth over insecure HTTP (default: false). */
   allowInsecureAuth?: boolean;
+  /** DANGEROUS: Disable device identity checks for the Control UI (default: false). */
+  dangerouslyDisableDeviceAuth?: boolean;
 };
 
 export type GatewayAuthMode = "token" | "password";

--- a/packages/personas/zee/src/config/zod-schema.ts
+++ b/packages/personas/zee/src/config/zod-schema.ts
@@ -320,6 +320,7 @@ export const ZeeSchema = z
             enabled: z.boolean().optional(),
             basePath: z.string().optional(),
             allowInsecureAuth: z.boolean().optional(),
+            dangerouslyDisableDeviceAuth: z.boolean().optional(),
           })
           .strict()
           .optional(),

--- a/packages/personas/zee/src/gateway/auth.ts
+++ b/packages/personas/zee/src/gateway/auth.ts
@@ -192,7 +192,7 @@ export function resolveGatewayAuth(params: {
   const token = authConfig.token ?? env.ZEE_GATEWAY_TOKEN ?? undefined;
   const password = authConfig.password ?? env.ZEE_GATEWAY_PASSWORD ?? undefined;
   const mode: ResolvedGatewayAuth["mode"] =
-    authConfig.mode ?? (password ? "password" : "token");
+    authConfig.mode ?? (password ? "password" : token ? "token" : "none");
   const allowTailscale =
     authConfig.allowTailscale ?? (params.tailscaleMode === "serve" && mode !== "password");
   return {

--- a/packages/personas/zee/src/gateway/server.auth.e2e.test.ts
+++ b/packages/personas/zee/src/gateway/server.auth.e2e.test.ts
@@ -351,6 +351,53 @@ describe("gateway server auth/connect", () => {
     }
   });
 
+  test("allows control ui with stale device identity when device auth is disabled", async () => {
+    testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
+    const prevToken = process.env.ZEE_GATEWAY_TOKEN;
+    process.env.ZEE_GATEWAY_TOKEN = "secret";
+    const port = await getFreePort();
+    const server = await startGatewayServer(port);
+    const ws = await openWs(port);
+    const { loadOrCreateDeviceIdentity, publicKeyRawBase64UrlFromPem, signDevicePayload } =
+      await import("../infra/device-identity.js");
+    const identity = loadOrCreateDeviceIdentity();
+    const signedAtMs = Date.now() - 60 * 60 * 1000;
+    const payload = buildDeviceAuthPayload({
+      deviceId: identity.deviceId,
+      clientId: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+      clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+      role: "operator",
+      scopes: [],
+      signedAtMs,
+      token: "secret",
+    });
+    const device = {
+      id: identity.deviceId,
+      publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+      signature: signDevicePayload(identity.privateKeyPem, payload),
+      signedAt: signedAtMs,
+    };
+    const res = await connectReq(ws, {
+      token: "secret",
+      device,
+      client: {
+        id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+        version: "1.0.0",
+        platform: "web",
+        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
+    ws.close();
+    await server.close();
+    if (prevToken === undefined) {
+      delete process.env.ZEE_GATEWAY_TOKEN;
+    } else {
+      process.env.ZEE_GATEWAY_TOKEN = prevToken;
+    }
+  });
+
   test("accepts device token auth for paired device", async () => {
     const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
     const { approveDevicePairing, getPairedDevice, listDevicePairing } =

--- a/packages/personas/zee/src/security/audit.test.ts
+++ b/packages/personas/zee/src/security/audit.test.ts
@@ -229,7 +229,7 @@ describe("security audit", () => {
     }
   });
 
-  it("warns when control UI allows insecure auth", async () => {
+  it("flags control UI insecure auth as critical", async () => {
     const cfg: ZeeConfig = {
       gateway: {
         controlUi: { allowInsecureAuth: true },
@@ -246,7 +246,30 @@ describe("security audit", () => {
       expect.arrayContaining([
         expect.objectContaining({
           checkId: "gateway.control_ui.insecure_auth",
-          severity: "warn",
+          severity: "critical",
+        }),
+      ]),
+    );
+  });
+
+  it("flags control UI device auth disabled as critical", async () => {
+    const cfg: ZeeConfig = {
+      gateway: {
+        controlUi: { dangerouslyDisableDeviceAuth: true },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "gateway.control_ui.device_auth_disabled",
+          severity: "critical",
         }),
       ]),
     );

--- a/packages/personas/zee/src/security/audit.ts
+++ b/packages/personas/zee/src/security/audit.ts
@@ -251,11 +251,22 @@ function collectGatewayConfigFindings(cfg: ZeeConfig): SecurityAuditFinding[] {
   if (cfg.gateway?.controlUi?.allowInsecureAuth === true) {
     findings.push({
       checkId: "gateway.control_ui.insecure_auth",
-      severity: "warn",
+      severity: "critical",
       title: "Control UI allows insecure HTTP auth",
       detail:
         "gateway.controlUi.allowInsecureAuth=true allows token-only auth over HTTP and skips device identity.",
       remediation: "Disable it or switch to HTTPS (Tailscale Serve) or localhost.",
+    });
+  }
+
+  if (cfg.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true) {
+    findings.push({
+      checkId: "gateway.control_ui.device_auth_disabled",
+      severity: "critical",
+      title: "DANGEROUS: Control UI device auth disabled",
+      detail:
+        "gateway.controlUi.dangerouslyDisableDeviceAuth=true disables device identity checks for the Control UI.",
+      remediation: "Disable it unless you are in a short-lived break-glass scenario.",
     });
   }
 


### PR DESCRIPTION
Fixes #124.

What changed
- Add `gateway.controlUi.dangerouslyDisableDeviceAuth` (DANGEROUS) to explicitly bypass Control UI device identity checks.
- In the WS connect handshake, ignore device identity when the bypass is enabled, and avoid attributing presence/device IDs to a bypassed device.
- Resolve gateway auth mode to `none` when no token/password is configured (keeps loopback/dev setups working while still blocking proxy/untrusted header scenarios).
- Security audit: treat `gateway.controlUi.allowInsecureAuth` as critical and flag `dangerouslyDisableDeviceAuth` as critical.
- Docs: gateway configuration + Control UI pages updated.

Tests
- `pnpm -C packages/personas/zee vitest run src/security/audit.test.ts src/gateway/server.auth.e2e.test.ts`
- `pnpm -C packages/personas/zee build`