### PR TITLE
🎨 Palette: Add accessibility labels to chat controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,7 @@
 ## 2025-10-27 - Auto-expanding Textareas and Lit Refs
 **Learning:** Chat inputs that don't auto-expand are a common UX pain point. Implementing this in Lit requires imperative DOM manipulation. Using the `ref` directive allows executing logic on every render/update, which is crucial for handling external state resets (like clearing the draft after sending). Binding `style` attributes conditionally can be flaky if the attribute is removed by Lit, so direct DOM manipulation via `ref` is more robust for persistent visual state.
 **Action:** Use `ref` for auto-resize logic in Lit components to ensure the UI stays in sync with state, especially for "reset" scenarios.
+
+## 2025-02-14 - Manual Icon Buttons in Lit
+**Learning:** In the Lit-based UI (`zee` persona), icon-only buttons are often implemented as standard `<button>` elements with classes (e.g., `btn btn--icon`) rather than a dedicated component. These manual implementations frequently lack `aria-label`, relying only on `title` which is insufficient for all screen readers.
+**Action:** When working with `btn--icon` classes, explicitly verify that `aria-label` is present and descriptive.

--- a/packages/personas/zee/ui/src/ui/app-render.helpers.ts
+++ b/packages/personas/zee/ui/src/ui/app-render.helpers.ts
@@ -90,6 +90,7 @@ export function renderChatControls(state: AppViewState) {
           void loadChatHistory(state);
         }}
         title="Refresh chat history"
+        aria-label="Refresh chat history"
       >
         ${refreshIcon}
       </button>
@@ -108,6 +109,7 @@ export function renderChatControls(state: AppViewState) {
         title=${disableThinkingToggle
           ? "Disabled during onboarding"
           : "Toggle assistant thinking/working output"}
+        aria-label="Toggle assistant thinking"
       >
         ${icons.brain}
       </button>
@@ -125,6 +127,7 @@ export function renderChatControls(state: AppViewState) {
         title=${disableFocusToggle
           ? "Disabled during onboarding"
           : "Toggle focus mode (hide sidebar + page header)"}
+        aria-label="Toggle focus mode"
       >
         ${focusIcon}
       </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to three icon-only buttons in the chat interface:
- Refresh chat history
- Toggle assistant thinking
- Toggle focus mode

🎯 **Why:** These buttons previously relied only on `title` attributes (tooltips) or visual icons. Adding explicit `aria-label` ensures that screen reader users can identify the purpose of these controls, improving accessibility compliance (WCAG 2.1 SC 4.1.2).

♿ **Accessibility:** Screen readers will now announce "Refresh chat history", "Toggle assistant thinking", and "Toggle focus mode" instead of "button" or the icon file name.

📸 **Before/After:** No visual changes, but inspection of the DOM reveals the new attributes.

---
*PR created automatically by Jules for task [3071221943242390186](https://jules.google.com/task/3071221943242390186) started by @dolagoartur*