### PR TITLE
🎨 Palette: Add accessible labels to chat controls

### DIFF
--- a/packages/personas/zee/ui/src/ui/app-render.helpers.ts
+++ b/packages/personas/zee/ui/src/ui/app-render.helpers.ts
@@ -90,6 +90,7 @@ export function renderChatControls(state: AppViewState) {
           void loadChatHistory(state);
         }}
         title="Refresh chat history"
+        aria-label="Refresh chat history"
       >
         ${refreshIcon}
       </button>
@@ -108,6 +109,7 @@ export function renderChatControls(state: AppViewState) {
         title=${disableThinkingToggle
           ? "Disabled during onboarding"
           : "Toggle assistant thinking/working output"}
+        aria-label="Toggle thinking output"
       >
         ${icons.brain}
       </button>
@@ -125,6 +127,7 @@ export function renderChatControls(state: AppViewState) {
         title=${disableFocusToggle
           ? "Disabled during onboarding"
           : "Toggle focus mode (hide sidebar + page header)"}
+        aria-label="Toggle focus mode"
       >
         ${focusIcon}
       </button>


### PR DESCRIPTION
💡 What: Added `aria-label` to three icon-only buttons in the chat interface controls.
🎯 Why: Screen readers were unable to identify the purpose of these buttons, relying on inconsistent fallback behavior (like reading SVG paths or title).
♿ Accessibility: Explicitly set accessible names for "Refresh chat history", "Toggle thinking output", and "Toggle focus mode".

---
*PR created automatically by Jules for task [5610236449846006535](https://jules.google.com/task/5610236449846006535) started by @dolagoartur*