### PR TITLE
Telegram UX: quote replies, silent sends, edit action

### DIFF
--- a/packages/personas/zee/src/agents/tools/message-tool.ts
+++ b/packages/personas/zee/src/agents/tools/message-tool.ts
@@ -59,6 +59,10 @@ function buildSendSchema(options: { includeButtons: boolean; includeCards: boole
     replyTo: Type.Optional(Type.String()),
     threadId: Type.Optional(Type.String()),
     asVoice: Type.Optional(Type.Boolean()),
+    silent: Type.Optional(Type.Boolean()),
+    quoteText: Type.Optional(
+      Type.String({ description: "Quote text for Telegram reply_parameters" }),
+    ),
     bestEffort: Type.Optional(Type.Boolean()),
     gifPlayback: Type.Optional(Type.Boolean()),
     buttons: Type.Optional(

--- a/packages/personas/zee/src/agents/tools/telegram-actions.ts
+++ b/packages/personas/zee/src/agents/tools/telegram-actions.ts
@@ -3,6 +3,7 @@ import type { ZeeConfig } from "../../config/config.js";
 import { resolveTelegramReactionLevel } from "../../telegram/reaction-level.js";
 import {
   deleteMessageTelegram,
+  editMessageTelegram,
   reactMessageTelegram,
   sendMessageTelegram,
 } from "../../telegram/send.js";
@@ -162,6 +163,7 @@ export async function handleTelegramAction(
     const messageThreadId = readNumberParam(params, "messageThreadId", {
       integer: true,
     });
+    const quoteText = readStringParam(params, "quoteText");
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       throw new Error(
@@ -175,7 +177,9 @@ export async function handleTelegramAction(
       buttons,
       replyToMessageId: replyToMessageId ?? undefined,
       messageThreadId: messageThreadId ?? undefined,
+      quoteText: quoteText ?? undefined,
       asVoice: typeof params.asVoice === "boolean" ? params.asVoice : undefined,
+      silent: typeof params.silent === "boolean" ? params.silent : undefined,
     });
     return jsonResult({
       ok: true,
@@ -206,6 +210,51 @@ export async function handleTelegramAction(
       accountId: accountId ?? undefined,
     });
     return jsonResult({ ok: true, deleted: true });
+  }
+
+  if (action === "editMessage") {
+    if (!isActionEnabled("editMessage")) {
+      throw new Error("Telegram editMessage is disabled.");
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const messageId = readNumberParam(params, "messageId", {
+      required: true,
+      integer: true,
+    });
+    const content = readStringParam(params, "content", {
+      required: true,
+      allowEmpty: false,
+    });
+    const buttons = readTelegramButtons(params);
+    if (buttons) {
+      const inlineButtonsScope = resolveTelegramInlineButtonsScope({
+        cfg,
+        accountId: accountId ?? undefined,
+      });
+      if (inlineButtonsScope === "off") {
+        throw new Error(
+          'Telegram inline buttons are disabled. Set channels.telegram.capabilities.inlineButtons to "dm", "group", "all", or "allowlist".',
+        );
+      }
+    }
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    const result = await editMessageTelegram(chatId ?? "", messageId ?? 0, content, {
+      token,
+      accountId: accountId ?? undefined,
+      buttons,
+    });
+    return jsonResult({
+      ok: true,
+      messageId: result.messageId,
+      chatId: result.chatId,
+    });
   }
 
   throw new Error(`Unsupported Telegram action: ${action}`);

--- a/packages/personas/zee/src/channels/plugins/actions/telegram.ts
+++ b/packages/personas/zee/src/channels/plugins/actions/telegram.ts
@@ -1,5 +1,6 @@
 import {
   createActionGate,
+  readNumberParam,
   readStringOrNumberParam,
   readStringParam,
 } from "../../../agents/tools/common.js";
@@ -13,15 +14,15 @@ const providerId = "telegram";
 function readTelegramSendParams(params: Record<string, unknown>) {
   const to = readStringParam(params, "to", { required: true });
   const mediaUrl = readStringParam(params, "media", { trim: false });
-  const content =
-    readStringParam(params, "message", {
-      required: !mediaUrl,
-      allowEmpty: true,
-    }) ?? "";
+  const message = readStringParam(params, "message", { required: !mediaUrl, allowEmpty: true });
+  const caption = readStringParam(params, "caption", { allowEmpty: true });
+  const content = message || caption || "";
   const replyTo = readStringParam(params, "replyTo");
   const threadId = readStringParam(params, "threadId");
   const buttons = params.buttons;
   const asVoice = typeof params.asVoice === "boolean" ? params.asVoice : undefined;
+  const silent = typeof params.silent === "boolean" ? params.silent : undefined;
+  const quoteText = readStringParam(params, "quoteText");
   return {
     to,
     content,
@@ -30,6 +31,8 @@ function readTelegramSendParams(params: Record<string, unknown>) {
     messageThreadId: threadId ?? undefined,
     buttons,
     asVoice,
+    silent,
+    quoteText: quoteText ?? undefined,
   };
 }
 
@@ -43,6 +46,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     const actions = new Set<ChannelMessageActionName>(["send"]);
     if (gate("reactions")) actions.add("react");
     if (gate("deleteMessage")) actions.add("delete");
+    if (gate("editMessage")) actions.add("edit");
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -108,6 +112,30 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           action: "deleteMessage",
           chatId,
           messageId: Number(messageId),
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "edit") {
+      const chatId =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringOrNumberParam(params, "channelId") ??
+        readStringParam(params, "to", { required: true });
+      const messageId = readNumberParam(params, "messageId", {
+        required: true,
+        integer: true,
+      });
+      const message = readStringParam(params, "message", { required: true, allowEmpty: false });
+      const buttons = params.buttons;
+      return await handleTelegramAction(
+        {
+          action: "editMessage",
+          chatId,
+          messageId,
+          content: message,
+          buttons,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/packages/personas/zee/src/config/types.telegram.ts
+++ b/packages/personas/zee/src/config/types.telegram.ts
@@ -15,6 +15,7 @@ export type TelegramActionConfig = {
   reactions?: boolean;
   sendMessage?: boolean;
   deleteMessage?: boolean;
+  editMessage?: boolean;
 };
 
 export type TelegramInlineButtonsScope = "off" | "dm" | "group" | "all" | "allowlist";

--- a/packages/personas/zee/src/config/zod-schema.providers-core.ts
+++ b/packages/personas/zee/src/config/zod-schema.providers-core.ts
@@ -119,6 +119,7 @@ export const TelegramAccountSchemaBase = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
+        editMessage: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/packages/personas/zee/src/telegram/bot-message-context.ts
+++ b/packages/personas/zee/src/telegram/bot-message-context.ts
@@ -458,9 +458,13 @@ export const buildTelegramMessageContext = async ({
   const replyTarget = describeReplyTarget(msg);
   const forwardOrigin = normalizeForwardedContext(msg);
   const replySuffix = replyTarget
-    ? `\n\n[Replying to ${replyTarget.sender}${
-        replyTarget.id ? ` id:${replyTarget.id}` : ""
-      }]\n${replyTarget.body}\n[/Replying]`
+    ? replyTarget.kind === "quote"
+      ? `\n\n[Quoting ${replyTarget.sender}${replyTarget.id ? ` id:${replyTarget.id}` : ""}]\n"${
+          replyTarget.body
+        }"\n[/Quoting]`
+      : `\n\n[Replying to ${replyTarget.sender}${replyTarget.id ? ` id:${replyTarget.id}` : ""}]\n${
+          replyTarget.body
+        }\n[/Replying]`
     : "";
   const forwardPrefix = forwardOrigin
     ? `[Forwarded from ${forwardOrigin.from}${
@@ -543,6 +547,7 @@ export const buildTelegramMessageContext = async ({
     ReplyToId: replyTarget?.id,
     ReplyToBody: replyTarget?.body,
     ReplyToSender: replyTarget?.sender,
+    ReplyToIsQuote: replyTarget?.kind === "quote" ? true : undefined,
     ForwardedFrom: forwardOrigin?.from,
     ForwardedFromType: forwardOrigin?.fromType,
     ForwardedFromId: forwardOrigin?.fromId,

--- a/packages/personas/zee/src/telegram/bot-message-dispatch.ts
+++ b/packages/personas/zee/src/telegram/bot-message-dispatch.ts
@@ -204,6 +204,10 @@ export const dispatchTelegramMessage = async ({
           await flushDraft();
           draftStream?.stop();
         }
+        const replyQuoteText =
+          ctxPayload.ReplyToIsQuote && ctxPayload.ReplyToBody
+            ? ctxPayload.ReplyToBody.trim() || undefined
+            : undefined;
         await deliverReplies({
           replies: [payload],
           chatId: String(chatId),
@@ -217,6 +221,7 @@ export const dispatchTelegramMessage = async ({
           chunkMode,
           onVoiceRecording: sendRecordVoice,
           linkPreview: telegramCfg.linkPreview,
+          replyQuoteText,
         });
       },
       onError: (err, info) => {

--- a/packages/personas/zee/src/telegram/bot/delivery.test.ts
+++ b/packages/personas/zee/src/telegram/bot/delivery.test.ts
@@ -164,4 +164,35 @@ describe("deliverReplies", () => {
       }),
     );
   });
+
+  it("uses reply_parameters when quote text is provided", async () => {
+    const runtime = { error: vi.fn(), log: vi.fn() };
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 10,
+      chat: { id: "123" },
+    });
+    const bot = { api: { sendMessage } } as unknown as Bot;
+
+    await deliverReplies({
+      replies: [{ text: "Hello there", replyToId: "500" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "all",
+      textLimit: 4000,
+      replyQuoteText: "quoted text",
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.any(String),
+      expect.objectContaining({
+        reply_parameters: {
+          message_id: 500,
+          quote: "quoted text",
+        },
+      }),
+    );
+  });
 });

--- a/packages/personas/zee/src/telegram/bot/types.ts
+++ b/packages/personas/zee/src/telegram/bot/types.ts
@@ -1,6 +1,12 @@
 import type { Message } from "@grammyjs/types";
 
-export type TelegramMessage = Message;
+export type TelegramQuote = {
+  text?: string;
+};
+
+export type TelegramMessage = Message & {
+  quote?: TelegramQuote;
+};
 
 export type TelegramStreamMode = "off" | "partial" | "block";
 

--- a/packages/personas/zee/src/telegram/send.edit-message.test.ts
+++ b/packages/personas/zee/src/telegram/send.edit-message.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const botApi = {
+  editMessageText: vi.fn(),
+};
+
+vi.mock("./accounts.js", () => ({
+  resolveTelegramAccount: vi.fn(() => ({
+    accountId: "default",
+    config: {},
+    enabled: true,
+    token: "",
+    tokenSource: "none",
+  })),
+}));
+
+vi.mock("../infra/retry-policy.js", () => ({
+  createTelegramRetryRunner: vi.fn(() => async (fn: () => Promise<unknown>) => fn()),
+}));
+
+import { editMessageTelegram } from "./send.js";
+
+describe("editMessageTelegram", () => {
+  beforeEach(() => {
+    botApi.editMessageText.mockReset();
+  });
+
+  it("keeps existing buttons when buttons is undefined (no reply_markup)", async () => {
+    botApi.editMessageText.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "hi", {
+      token: "tok",
+      cfg: {},
+      api: botApi,
+    });
+
+    expect(botApi.editMessageText).toHaveBeenCalledTimes(1);
+    const call = botApi.editMessageText.mock.calls[0] ?? [];
+    const params = call[3] as Record<string, unknown>;
+    expect(params).toEqual(expect.objectContaining({ parse_mode: "HTML" }));
+    expect(params).not.toHaveProperty("reply_markup");
+  });
+
+  it("removes buttons when buttons is empty (reply_markup.inline_keyboard = [])", async () => {
+    botApi.editMessageText.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "hi", {
+      token: "tok",
+      cfg: {},
+      buttons: [],
+      api: botApi,
+    });
+
+    expect(botApi.editMessageText).toHaveBeenCalledTimes(1);
+    const params = (botApi.editMessageText.mock.calls[0] ?? [])[3] as Record<string, unknown>;
+    expect(params).toEqual(
+      expect.objectContaining({
+        parse_mode: "HTML",
+        reply_markup: { inline_keyboard: [] },
+      }),
+    );
+  });
+
+  it("falls back to plain text when Telegram HTML parse fails (and preserves reply_markup)", async () => {
+    botApi.editMessageText
+      .mockRejectedValueOnce(new Error("400: Bad Request: can't parse entities"))
+      .mockResolvedValueOnce({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "<bad> html", {
+      token: "tok",
+      cfg: {},
+      buttons: [],
+      api: botApi,
+    });
+
+    expect(botApi.editMessageText).toHaveBeenCalledTimes(2);
+
+    const firstParams = (botApi.editMessageText.mock.calls[0] ?? [])[3] as Record<string, unknown>;
+    expect(firstParams).toEqual(
+      expect.objectContaining({
+        parse_mode: "HTML",
+        reply_markup: { inline_keyboard: [] },
+      }),
+    );
+
+    const secondParams = (botApi.editMessageText.mock.calls[1] ?? [])[3] as Record<string, unknown>;
+    expect(secondParams).toEqual(
+      expect.objectContaining({
+        reply_markup: { inline_keyboard: [] },
+      }),
+    );
+  });
+});

--- a/packages/personas/zee/src/telegram/send.preserves-thread-params-plain-text-fallback.test.ts
+++ b/packages/personas/zee/src/telegram/send.preserves-thread-params-plain-text-fallback.test.ts
@@ -235,6 +235,54 @@ describe("buildInlineKeyboard", () => {
       message_thread_id: 99,
     });
   });
+
+  it("uses reply_parameters when quoteText is provided", async () => {
+    const chatId = "-1001234567890";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 61,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "quoted reply", {
+      token: "tok",
+      api,
+      replyToMessageId: 321,
+      quoteText: "Quoted section",
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "quoted reply", {
+      parse_mode: "HTML",
+      reply_parameters: {
+        message_id: 321,
+        quote: "Quoted section",
+      },
+    });
+  });
+
+  it("sets disable_notification when silent is true", async () => {
+    const chatId = "-1001234567890";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 62,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "quiet message", {
+      token: "tok",
+      api,
+      silent: true,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "quiet message", {
+      parse_mode: "HTML",
+      disable_notification: true,
+    });
+  });
 });
 
 describe("reactMessageTelegram", () => {

--- a/packages/personas/zee/src/telegram/send.ts
+++ b/packages/personas/zee/src/telegram/send.ts
@@ -40,8 +40,12 @@ type TelegramSendOpts = {
   plainText?: string;
   /** Send audio as voice message (voice bubble) instead of audio file. Defaults to false. */
   asVoice?: boolean;
+  /** Send message silently (no notification). Defaults to false. */
+  silent?: boolean;
   /** Message ID to reply to (for threading) */
   replyToMessageId?: number;
+  /** Quote text for Telegram reply_parameters. */
+  quoteText?: string;
   /** Forum topic thread ID (for forum supergroups) */
   messageThreadId?: number;
   /** Inline keyboard buttons (reply markup). */
@@ -192,9 +196,17 @@ export async function sendMessageTelegram(
   const messageThreadId =
     opts.messageThreadId != null ? opts.messageThreadId : target.messageThreadId;
   const threadIdParams = buildTelegramThreadParams(messageThreadId);
-  const threadParams: Record<string, number> = threadIdParams ? { ...threadIdParams } : {};
+  const threadParams: Record<string, unknown> = threadIdParams ? { ...threadIdParams } : {};
+  const quoteText = opts.quoteText?.trim();
   if (opts.replyToMessageId != null) {
-    threadParams.reply_to_message_id = Math.trunc(opts.replyToMessageId);
+    if (quoteText) {
+      threadParams.reply_parameters = {
+        message_id: Math.trunc(opts.replyToMessageId),
+        quote: quoteText,
+      };
+    } else {
+      threadParams.reply_to_message_id = Math.trunc(opts.replyToMessageId);
+    }
   }
   const hasThreadParams = Object.keys(threadParams).length > 0;
   const request = createTelegramRetryRunner({
@@ -240,6 +252,9 @@ export async function sendMessageTelegram(
     const baseParams = params ? { ...params } : {};
     if (linkPreviewOptions) {
       baseParams.link_preview_options = linkPreviewOptions;
+    }
+    if (opts.silent === true) {
+      baseParams.disable_notification = true;
     }
     const hasBaseParams = Object.keys(baseParams).length > 0;
     const sendParams = {
@@ -297,6 +312,7 @@ export async function sendMessageTelegram(
     const mediaParams = {
       caption: htmlCaption,
       ...(htmlCaption ? { parse_mode: "HTML" as const } : {}),
+      ...(opts.silent === true ? { disable_notification: true } : {}),
       ...baseMediaParams,
     };
     let result:
@@ -489,6 +505,99 @@ export async function deleteMessageTelegram(
   await requestWithDiag(() => api.deleteMessage(chatId, messageId), "deleteMessage");
   logVerbose(`[telegram] Deleted message ${messageId} from chat ${chatId}`);
   return { ok: true };
+}
+
+type TelegramEditOpts = {
+  token?: string;
+  accountId?: string;
+  verbose?: boolean;
+  api?: Bot["api"];
+  retry?: RetryConfig;
+  textMode?: "markdown" | "html";
+  /** Inline keyboard buttons (reply markup). Pass empty array to remove buttons. */
+  buttons?: Array<Array<{ text: string; callback_data: string }>>;
+  /** Optional config injection to avoid global loadConfig() (improves testability). */
+  cfg?: ReturnType<typeof loadConfig>;
+};
+
+export async function editMessageTelegram(
+  chatIdInput: string | number,
+  messageIdInput: string | number,
+  text: string,
+  opts: TelegramEditOpts = {},
+): Promise<{ ok: true; messageId: string; chatId: string }> {
+  const cfg = opts.cfg ?? loadConfig();
+  const account = resolveTelegramAccount({
+    cfg,
+    accountId: opts.accountId,
+  });
+  const token = resolveToken(opts.token, account);
+  const chatId = normalizeChatId(String(chatIdInput));
+  const messageId = normalizeMessageId(messageIdInput);
+  const client = resolveTelegramClientOptions(account);
+  const api = opts.api ?? new Bot(token, client ? { client } : undefined).api;
+  const request = createTelegramRetryRunner({
+    retry: opts.retry,
+    configRetry: account.config.retry,
+    verbose: opts.verbose,
+  });
+  const logHttpError = createTelegramHttpLogger(cfg);
+  const requestWithDiag = <T>(fn: () => Promise<T>, label?: string) =>
+    request(fn, label).catch((err) => {
+      logHttpError(label ?? "request", err);
+      throw err;
+    });
+
+  const textMode = opts.textMode ?? "markdown";
+  const tableMode = resolveMarkdownTableMode({
+    cfg,
+    channel: "telegram",
+    accountId: account.accountId,
+  });
+  const htmlText = renderTelegramHtmlText(text, { textMode, tableMode });
+
+  // Reply markup semantics:
+  // - buttons === undefined → don't send reply_markup (keep existing)
+  // - buttons is [] (or filters to empty) → send { inline_keyboard: [] } (remove)
+  // - otherwise → send built inline keyboard
+  const shouldTouchButtons = opts.buttons !== undefined;
+  const builtKeyboard = shouldTouchButtons ? buildInlineKeyboard(opts.buttons) : undefined;
+  const replyMarkup = shouldTouchButtons ? builtKeyboard ?? { inline_keyboard: [] } : undefined;
+
+  const editParams: Record<string, unknown> = {
+    parse_mode: "HTML",
+  };
+  if (replyMarkup !== undefined) {
+    editParams.reply_markup = replyMarkup;
+  }
+
+  await requestWithDiag(
+    () => api.editMessageText(chatId, messageId, htmlText, editParams),
+    "editMessage",
+  ).catch(async (err) => {
+    // Telegram rejects malformed HTML. Fall back to plain text.
+    const errText = formatErrorMessage(err);
+    if (PARSE_ERR_RE.test(errText)) {
+      if (opts.verbose) {
+        console.warn(`telegram HTML parse failed, retrying as plain text: ${errText}`);
+      }
+      const plainParams: Record<string, unknown> = {};
+      if (replyMarkup !== undefined) {
+        plainParams.reply_markup = replyMarkup;
+      }
+      return await requestWithDiag(
+        () =>
+          Object.keys(plainParams).length > 0
+            ? api.editMessageText(chatId, messageId, text, plainParams)
+            : api.editMessageText(chatId, messageId, text),
+        "editMessage-plain",
+      );
+    }
+    throw err;
+  });
+
+  logVerbose(`[telegram] Edited message ${messageId} in chat ${chatId}`);
+  return { ok: true, messageId: String(messageId), chatId };
 }
 
 function inferFilename(kind: ReturnType<typeof mediaKindFromMime>) {


### PR DESCRIPTION
## Summary\n- add quote reply support via reply_parameters and expose quoteText\n- add silent send and edit message action wiring across schema/adapters\n- switch newline chunking to paragraph-aware splits\n- add tests for chunking, reply parameters, and edit message behavior\n\n## Notes\n- Voice fallback and sticker actions intentionally omitted to avoid overlap with #114 and #113.\n\n## Testing\n- pnpm vitest run src/auto-reply/chunk.test.ts src/telegram/bot/delivery.test.ts src/telegram/send.preserves-thread-params-plain-text-fallback.test.ts src/telegram/send.edit-message.test.ts