### PR TITLE
Trigger inventory restoration on order cancellation

### DIFF
--- a/packages/tiara/examples/05-swarm-apps/rest-api-advanced/src/models/order.model.js
+++ b/packages/tiara/examples/05-swarm-apps/rest-api-advanced/src/models/order.model.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const Product = require('./product.model');
 
 const orderItemSchema = new mongoose.Schema({
   product: {
@@ -366,7 +367,14 @@ orderSchema.methods.cancel = async function(reason, userId) {
   
   await this.updateStatus('cancelled', reason, userId);
   
-  // TODO: Trigger inventory restoration
+  // Trigger inventory restoration
+  for (const item of this.items) {
+    const product = await Product.findById(item.product);
+    if (product) {
+      await product.updateInventory(item.quantity, 'increment');
+    }
+  }
+
   // TODO: Trigger payment refund if applicable
   
   return this;

--- a/packages/tiara/examples/05-swarm-apps/rest-api-advanced/tests/integration/order_cancellation.test.js
+++ b/packages/tiara/examples/05-swarm-apps/rest-api-advanced/tests/integration/order_cancellation.test.js
@@ -1,0 +1,80 @@
+const mongoose = require('mongoose');
+const Order = require('../../src/models/order.model');
+const Product = require('../../src/models/product.model');
+const User = require('../../src/models/User');
+
+describe('Order Model Cancellation', () => {
+  let user;
+  let product;
+  let order;
+
+  beforeEach(async () => {
+    // Create User
+    user = await User.create({
+      email: 'test@example.com',
+      password: 'Password123!',
+      name: 'Test User',
+      role: 'user',
+      isEmailVerified: true,
+    });
+
+    // Create Product
+    product = await Product.create({
+      name: 'Test Product',
+      description: 'A test product',
+      price: 100,
+      category: 'Test',
+      inventory: {
+        quantity: 10,
+        trackInventory: true
+      },
+      images: [{ url: 'http://example.com/image.jpg' }]
+    });
+
+    // Create Order
+    order = await Order.create({
+      user: user._id,
+      orderNumber: 'ORD-TEST-1',
+      items: [{
+        product: product._id,
+        name: 'Test Product',
+        price: 100,
+        quantity: 2,
+        subtotal: 200
+      }],
+      totalAmount: 200,
+      subtotal: 200,
+      shippingAddress: {
+        fullName: 'Test User',
+        street: '123 Test St',
+        city: 'Test City',
+        state: 'TS',
+        zipCode: '12345',
+        country: 'Test Country',
+        phone: '1234567890',
+        email: 'test@example.com'
+      },
+      payment: {
+        method: 'credit_card',
+        amount: 200
+      },
+      status: 'pending'
+    });
+  });
+
+  it('should restore inventory when order is cancelled', async () => {
+    // Initial check
+    let p = await Product.findById(product._id);
+    expect(p.inventory.quantity).toBe(10);
+
+    // Cancel order
+    await order.cancel('Customer changed mind', user._id);
+
+    // Verify status
+    expect(order.status).toBe('cancelled');
+
+    // Verify inventory restored
+    p = await Product.findById(product._id);
+    expect(p.inventory.quantity).toBe(12); // 10 + 2
+  });
+});


### PR DESCRIPTION
Implemented logic in `packages/tiara/examples/05-swarm-apps/rest-api-advanced/src/models/order.model.js` to trigger inventory restoration when an order is cancelled.
- Iterates over `this.items` in `cancel` method.
- Updates product inventory using `product.updateInventory(item.quantity, 'increment')`.
- Added a new integration test `packages/tiara/examples/05-swarm-apps/rest-api-advanced/tests/integration/order_cancellation.test.js` to verify the functionality.

---
*PR created automatically by Jules for task [1962460305882621879](https://jules.google.com/task/1962460305882621879) started by @dolagoartur*