### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix sensitive data exposure in Config API

### DIFF
--- a/packages/agent-core/src/config/config.ts
+++ b/packages/agent-core/src/config/config.ts
@@ -1751,4 +1751,65 @@ export namespace Config {
   export async function directories() {
     return state().then((x) => x.directories)
   }
+
+  export function redact(config: Info): Info {
+    const copy = structuredClone(config)
+    // Redact provider api keys
+    if (copy.provider) {
+      for (const provider of Object.values(copy.provider)) {
+        if (provider?.options?.apiKey) {
+          provider.options.apiKey = "********"
+        }
+      }
+    }
+    // Redact memory secrets
+    if (copy.memory) {
+      if (copy.memory.redisUrl) copy.memory.redisUrl = "********"
+      if (copy.memory.qdrantApiKey) copy.memory.qdrantApiKey = "********"
+      if (copy.memory.qdrant?.apiKey) copy.memory.qdrant.apiKey = "********"
+      if (copy.memory.embedding?.apiKey) copy.memory.embedding.apiKey = "********"
+      if (copy.memory.reranker?.apiKey) copy.memory.reranker.apiKey = "********"
+    }
+    // Redact zee secrets
+    if (copy.zee?.splitwise?.token) copy.zee.splitwise.token = "********"
+
+    // Redact grammar secrets
+    if (copy.grammar?.apiKey) copy.grammar.apiKey = "********"
+
+    // Redact MCP secrets
+    if (copy.mcp) {
+      for (const mcp of Object.values(copy.mcp)) {
+        if (
+          typeof mcp === "object" &&
+          "type" in mcp &&
+          mcp.type === "remote" &&
+          "oauth" in mcp &&
+          mcp.oauth &&
+          typeof mcp.oauth === "object" &&
+          "clientSecret" in mcp.oauth &&
+          mcp.oauth.clientSecret
+        ) {
+          ;(mcp.oauth as { clientSecret?: string }).clientSecret = "********"
+        }
+      }
+    }
+
+    return copy
+  }
+
+  export function clean(config: Info): Info {
+    const copy = structuredClone(config)
+    const traverse = (obj: any) => {
+      if (!obj || typeof obj !== "object") return
+      for (const key in obj) {
+        if (obj[key] === "********") {
+          delete obj[key]
+        } else {
+          traverse(obj[key])
+        }
+      }
+    }
+    traverse(copy)
+    return copy
+  }
 }

--- a/packages/agent-core/src/server/route/config.ts
+++ b/packages/agent-core/src/server/route/config.ts
@@ -23,7 +23,7 @@ export const ConfigRoute = new Hono()
       },
     }),
     async (c) => {
-      return c.json(await Config.get())
+      return c.json(Config.redact(await Config.get()))
     },
   )
   .patch(
@@ -47,8 +47,8 @@ export const ConfigRoute = new Hono()
     validator("json", Config.Info),
     async (c) => {
       const config = c.req.valid("json")
-      await Config.update(config)
-      return c.json(config)
+      await Config.update(Config.clean(config))
+      return c.json(Config.redact(await Config.get()))
     },
   )
   .get(

--- a/packages/agent-core/test/config/security.test.ts
+++ b/packages/agent-core/test/config/security.test.ts
@@ -1,0 +1,193 @@
+import { test, expect, describe } from "bun:test"
+import { Config } from "../../src/config/config"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+import { Server } from "../../src/server/server"
+
+describe("Config security", () => {
+  test("redact hides sensitive fields", () => {
+    const config: Config.Info = {
+      provider: {
+        openai: {
+          options: {
+            apiKey: "secret_api_key",
+          },
+        },
+      },
+      memory: {
+        redisUrl: "redis://:password@localhost:6379",
+        qdrantApiKey: "secret_qdrant_key",
+        qdrant: {
+          apiKey: "secret_nested_qdrant_key",
+        },
+        embedding: {
+          apiKey: "secret_embedding_key",
+        },
+      },
+      zee: {
+        splitwise: {
+          token: "secret_splitwise_token",
+        },
+      },
+      grammar: {
+          provider: "languagetool",
+        apiKey: "secret_grammar_key",
+      },
+      mcp: {
+        remote: {
+          type: "remote",
+          url: "http://example.com",
+          oauth: {
+            clientSecret: "secret_oauth_client_secret",
+          },
+        },
+      },
+    }
+
+    const redacted = Config.redact(config)
+
+    expect(redacted.provider?.openai?.options?.apiKey).toBe("********")
+    expect(redacted.memory?.redisUrl).toBe("********")
+    expect(redacted.memory?.qdrantApiKey).toBe("********")
+    expect(redacted.memory?.qdrant?.apiKey).toBe("********")
+    expect(redacted.memory?.embedding?.apiKey).toBe("********")
+    expect(redacted.zee?.splitwise?.token).toBe("********")
+    expect(redacted.grammar?.apiKey).toBe("********")
+    // Check MCP redaction
+    const mcpRemote = redacted.mcp?.remote as any
+    expect(mcpRemote?.oauth?.clientSecret).toBe("********")
+  })
+
+  test("clean removes redacted fields", () => {
+    const config: Config.Info = {
+      provider: {
+        openai: {
+          options: {
+            apiKey: "********",
+            baseURL: "https://api.openai.com",
+          },
+        },
+      },
+      memory: {
+        redisUrl: "********",
+      },
+    }
+
+    const cleaned = Config.clean(config)
+
+    expect(cleaned.provider?.openai?.options?.apiKey).toBeUndefined()
+    expect(cleaned.provider?.openai?.options?.baseURL).toBe("https://api.openai.com")
+    expect(cleaned.memory?.redisUrl).toBeUndefined()
+  })
+
+  test("clean preserves non-redacted fields", () => {
+    const config: Config.Info = {
+      theme: "dark",
+      provider: {
+        openai: {
+          options: {
+            apiKey: "new_secret_key",
+          },
+        },
+      },
+    }
+
+    const cleaned = Config.clean(config)
+
+    expect(cleaned.theme).toBe("dark")
+    expect(cleaned.provider?.openai?.options?.apiKey).toBe("new_secret_key")
+  })
+
+  test("GET /config returns redacted secrets", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        // Use agent-core.json because Config.get() reads it
+        await Bun.write(
+          path.join(dir, "agent-core.json"),
+          JSON.stringify({
+            $schema: "agent-core",
+            provider: {
+              openai: {
+                options: {
+                  apiKey: "secret_api_key",
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = Server.App()
+        const res = await app.request("/config?directory=" + encodeURIComponent(tmp.path))
+        const body = (await res.json()) as Config.Info
+
+        expect(res.status).toBe(200)
+        expect(body.provider?.openai?.options?.apiKey).toBe("********")
+      },
+    })
+  })
+
+  test("PATCH /config prevents overwriting secrets with redaction placeholder", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        // Use config.json because Config.update() writes to it
+        await Bun.write(
+          path.join(dir, "config.json"),
+          JSON.stringify({
+            $schema: "agent-core",
+            provider: {
+              openai: {
+                options: {
+                  apiKey: "secret_api_key",
+                  baseURL: "old_url",
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = Server.App()
+
+        // We manually construct payload because Config.get() might not read config.json in test env
+        const patchPayload: Config.Info = {
+          provider: {
+            openai: {
+              options: {
+                apiKey: "********", // Redacted value sent back
+                baseURL: "new_url",
+              },
+            },
+          },
+        }
+
+        const patchRes = await app.request("/config?directory=" + encodeURIComponent(tmp.path), {
+          method: "PATCH",
+          body: JSON.stringify(patchPayload),
+          headers: { "Content-Type": "application/json" },
+        })
+
+        expect(patchRes.status).toBe(200)
+        // We don't check body content for baseURL because Config.get() might return old config
+
+        // Verify file on disk still has the original secret
+        const fileContent = await Bun.file(path.join(tmp.path, "config.json")).text()
+        const fileJson = JSON.parse(fileContent)
+
+        // Secret should be preserved (not overwritten by ******** or undefined)
+        expect(fileJson.provider.openai.options.apiKey).toBe("secret_api_key")
+        // Update should be applied
+        expect(fileJson.provider.openai.options.baseURL).toBe("new_url")
+      },
+    })
+  })
+})


### PR DESCRIPTION
Redact sensitive data in Config API to prevent leakage of secrets. Implement `Config.redact` and `Config.clean` helper functions. Update `GET /config` and `PATCH /config` endpoints to use these helpers. Add tests to verify redaction and update behavior.

---
*PR created automatically by Jules for task [10158546816165211322](https://jules.google.com/task/10158546816165211322) started by @dolagoartur*