### PR TITLE
🎨 Palette: Improve QuestionPrompt accessibility

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -3,6 +3,7 @@ import {
   createEffect,
   createMemo,
   createSignal,
+  createUniqueId,
   For,
   Match,
   Show,
@@ -1351,6 +1352,7 @@ function QuestionPrompt(props: { request: QuestionRequest }) {
   const options = createMemo(() => question()?.options ?? [])
   const input = createMemo(() => store.custom[store.tab] ?? "")
   const multi = createMemo(() => question()?.multiple === true)
+  const questionId = createUniqueId()
   const customPicked = createMemo(() => {
     const value = input()
     if (!value) return false
@@ -1469,16 +1471,26 @@ function QuestionPrompt(props: { request: QuestionRequest }) {
 
       <Show when={!confirm()}>
         <div data-slot="question-content">
-          <div data-slot="question-text">
+          <div data-slot="question-text" id={questionId}>
             {question()?.question}
             {multi() ? " " + i18n.t("ui.question.multiHint") : ""}
           </div>
-          <div data-slot="question-options">
+          <div
+            data-slot="question-options"
+            role={multi() ? "group" : "radiogroup"}
+            aria-labelledby={questionId}
+          >
             <For each={options()}>
               {(opt, i) => {
                 const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false
                 return (
-                  <button data-slot="question-option" data-picked={picked()} onClick={() => selectOption(i())}>
+                  <button
+                    data-slot="question-option"
+                    data-picked={picked()}
+                    onClick={() => selectOption(i())}
+                    role={multi() ? "checkbox" : "radio"}
+                    aria-checked={picked()}
+                  >
                     <span data-slot="option-label">{opt.label}</span>
                     <Show when={opt.description}>
                       <span data-slot="option-description">{opt.description}</span>
@@ -1494,6 +1506,8 @@ function QuestionPrompt(props: { request: QuestionRequest }) {
               data-slot="question-option"
               data-picked={customPicked()}
               onClick={() => selectOption(options().length)}
+              role={multi() ? "checkbox" : "radio"}
+              aria-checked={customPicked()}
             >
               <span data-slot="option-label">{i18n.t("ui.messagePart.option.typeOwnAnswer")}</span>
               <Show when={!store.editing && input()}>


### PR DESCRIPTION
💡 **What**: Added ARIA roles and attributes to the `QuestionPrompt` component in `packages/ui`.
🎯 **Why**: The custom selection buttons were inaccessible to screen readers as they lacked semantic roles.
♿ **Accessibility**:
- Added `role="radiogroup"` or `role="group"` to the options container.
- Added `aria-labelledby` linking to the question text.
- Added `role="radio"` or `role="checkbox"` to option buttons.
- Added `aria-checked` state to option buttons.

---
*PR created automatically by Jules for task [13204796063853317595](https://jules.google.com/task/13204796063853317595) started by @dolagoartur*