### PR TITLE
shield: Fix path traversal via symlinks for non-existent files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-05 - Path Traversal via Symlink for Non-Existent Files
+**Vulnerability:** `realpath` throws an error for non-existent files, leading to fallback logic that might rely on unsafe lexical path analysis (like `contains`). If a non-existent file path traverses an existing symlink pointing outside the sandbox, the lexical check returns true (safe), but writing to the file effectively writes outside the sandbox.
+**Learning:** `Filesystem.containsResolved` must not simply fallback to lexical checks when `realpath` fails. It must recursively resolve the path by walking up the directory tree until an existing ancestor is found, resolving that ancestor, and then checking containment.
+**Prevention:** Always implement recursive path resolution for non-existent files when verifying path containment in a sandbox.

--- a/packages/agent-core/src/util/filesystem.ts
+++ b/packages/agent-core/src/util/filesystem.ts
@@ -1,6 +1,6 @@
 import { realpathSync } from "fs"
 import { realpath } from "fs/promises"
-import { dirname, join, relative } from "path"
+import { basename, dirname, join, relative } from "path"
 
 export namespace Filesystem {
   export const sanitizePath = (value: string) => value.replace(/\0/g, "")
@@ -25,15 +25,36 @@ export namespace Filesystem {
   export async function containsResolved(parent: string, child: string): Promise<boolean> {
     parent = sanitizePath(parent)
     child = sanitizePath(child)
+
+    // Resolve parent to its real location
+    const resolvedParent = await realpath(parent).catch(() => parent)
+
+    let resolvedChild: string
     try {
-      // Resolve both paths to their real locations (following symlinks)
-      const resolvedParent = await realpath(parent).catch(() => parent)
-      const resolvedChild = await realpath(child).catch(() => child)
-      return !relative(resolvedParent, resolvedChild).startsWith("..")
+      resolvedChild = await realpath(child)
     } catch {
-      // If realpath fails (file doesn't exist yet), fall back to lexical check
-      return contains(parent, child)
+      // Child doesn't exist, find the first existing ancestor
+      let current = dirname(child)
+      let suffix = relative(current, child)
+
+      while (current !== dirname(current)) {
+        try {
+          const resolvedCurrent = await realpath(current)
+          resolvedChild = join(resolvedCurrent, suffix)
+          break
+        } catch {
+          suffix = join(basename(current), suffix)
+          current = dirname(current)
+        }
+      }
+
+      // If we couldn't find any existing ancestor (unlikely), fallback to original path
+      if (!resolvedChild!) {
+        resolvedChild = child
+      }
     }
+
+    return !relative(resolvedParent, resolvedChild).startsWith("..")
   }
 
   /**
@@ -42,13 +63,39 @@ export namespace Filesystem {
   export function containsResolvedSync(parent: string, child: string): boolean {
     parent = sanitizePath(parent)
     child = sanitizePath(child)
+
+    let resolvedParent: string
     try {
-      const resolvedParent = realpathSync(parent)
-      const resolvedChild = realpathSync(child)
-      return !relative(resolvedParent, resolvedChild).startsWith("..")
+      resolvedParent = realpathSync(parent)
     } catch {
-      return contains(parent, child)
+      resolvedParent = parent
     }
+
+    let resolvedChild: string
+    try {
+      resolvedChild = realpathSync(child)
+    } catch {
+      // Child doesn't exist, find the first existing ancestor
+      let current = dirname(child)
+      let suffix = relative(current, child)
+
+      while (current !== dirname(current)) {
+        try {
+          const resolvedCurrent = realpathSync(current)
+          resolvedChild = join(resolvedCurrent, suffix)
+          break
+        } catch {
+          suffix = join(basename(current), suffix)
+          current = dirname(current)
+        }
+      }
+
+      if (!resolvedChild!) {
+        resolvedChild = child
+      }
+    }
+
+    return !relative(resolvedParent, resolvedChild).startsWith("..")
   }
   /**
    * On Windows, normalize a path to its canonical casing using the filesystem.

--- a/packages/agent-core/test/fixture/fixture.ts
+++ b/packages/agent-core/test/fixture/fixture.ts
@@ -26,6 +26,14 @@ const shouldIgnoreNullBytePathError = (error: unknown) => {
   return code === "ENOENT" && (hasNullByte(pathValue) || hasNullByte(message))
 }
 
+async function run(cmd: string[], cwd: string) {
+  const proc = Bun.spawn(cmd, { cwd, stderr: "inherit", stdout: "inherit" })
+  const code = await proc.exited
+  if (code !== 0) {
+    throw new Error(`Command failed with exit code ${code}: ${cmd.join(" ")}`)
+  }
+}
+
 async function createTmpdir<T>(options: TmpDirOptions<T> | undefined) {
   const baseDir = process.env["AGENT_CORE_TEST_HOME"] ?? os.tmpdir()
   const rootDir = path.join(baseDir, "tmp")
@@ -33,8 +41,20 @@ async function createTmpdir<T>(options: TmpDirOptions<T> | undefined) {
   const dirpath = sanitizePath(path.join(rootDir, "opencode-test-" + randomUUID()))
   await fs.mkdir(dirpath, { recursive: true })
   if (options?.git) {
-    await $`git init`.cwd(dirpath).quiet()
-    await $`git commit --allow-empty -m "root commit ${dirpath}"`.cwd(dirpath).quiet()
+    // Configure git user to prevent CI failures
+    const env = { ...process.env, GIT_AUTHOR_NAME: "Test", GIT_AUTHOR_EMAIL: "test@example.com", GIT_COMMITTER_NAME: "Test", GIT_COMMITTER_EMAIL: "test@example.com" }
+
+    // Using Bun.spawn instead of Bun Shell to avoid ShellPromise errors in CI
+    const spawnGit = async (args: string[]) => {
+       const proc = Bun.spawn(["git", ...args], { cwd: dirpath, env, stdout: "ignore", stderr: "ignore" })
+       const code = await proc.exited
+       if (code !== 0) throw new Error(`git ${args.join(" ")} failed in ${dirpath}`)
+    }
+
+    await spawnGit(["init"])
+    await spawnGit(["config", "user.email", "test@example.com"])
+    await spawnGit(["config", "user.name", "Test User"])
+    await spawnGit(["commit", "--allow-empty", "-m", `root commit ${dirpath}`])
   }
   if (options?.config) {
     await Bun.write(

--- a/packages/agent-core/test/util/filesystem.test.ts
+++ b/packages/agent-core/test/util/filesystem.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import os from "node:os"
 import path from "node:path"
-import { mkdtemp, mkdir, rm } from "node:fs/promises"
+import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises"
 import { Filesystem } from "../../src/util/filesystem"
 
 describe("util.filesystem", () => {
@@ -61,6 +61,49 @@ describe("util.filesystem", () => {
 
     const found = await Filesystem.findFirstUp("missing.txt", dir, tmp)
     expect(found).toBeUndefined()
+
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  test("containsResolved() rejects non-existent files in symlinked directories pointing outside", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "opencode-filesystem-"))
+    const safeDir = path.join(tmp, "safe")
+    await mkdir(safeDir, { recursive: true })
+
+    const outsideTarget = os.tmpdir()
+    const symlinkPath = path.join(safeDir, "link")
+
+    // Create symlink: safeDir/link -> os.tmpdir()
+    await symlink(outsideTarget, symlinkPath)
+
+    // Check path: safeDir/link/non_existent_file
+    // Should resolve to os.tmpdir()/non_existent_file
+    // Which is OUTSIDE safeDir.
+    const maliciousPath = path.join(symlinkPath, "non_existent_file")
+
+    const isContained = await Filesystem.containsResolved(safeDir, maliciousPath)
+    expect(isContained).toBe(false)
+
+    // Sync version
+    const isContainedSync = Filesystem.containsResolvedSync(safeDir, maliciousPath)
+    expect(isContainedSync).toBe(false)
+
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  test("containsResolved() accepts non-existent files in regular directories", async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "opencode-filesystem-"))
+    const safeDir = path.join(tmp, "safe")
+    await mkdir(safeDir, { recursive: true })
+
+    const safePath = path.join(safeDir, "non_existent_file")
+
+    const isContained = await Filesystem.containsResolved(safeDir, safePath)
+    expect(isContained).toBe(true)
+
+    // Sync version
+    const isContainedSync = Filesystem.containsResolvedSync(safeDir, safePath)
+    expect(isContainedSync).toBe(true)
 
     await rm(tmp, { recursive: true, force: true })
   })


### PR DESCRIPTION
Implemented a fix for path traversal vulnerability in `Filesystem.containsResolved`. 

The previous implementation had a TOCTOU-like issue where if a file did not exist, `realpath` would throw, and the code would fallback to a simple `contains` check (lexical path comparison). This allowed an attacker (or compromised tool) to create a symlink to a sensitive directory (e.g. `/tmp` or `/etc`) inside the project, and then write to a non-existent file inside that symlinked directory. The lexical check would see `project/symlink/file` as inside `project`, but the write would land in `/tmp/file`.

The fix changes the fallback logic:
1. When `realpath(child)` fails (file doesn't exist), we don't just fallback.
2. We walk up the directory tree of `child` until we find an ancestor that *does* exist.
3. We resolve that ancestor to its physical path.
4. We append the non-existent suffix.
5. We check containment on this fully resolved path.

This ensures that even for non-existent files, we respect the physical location of their parent directories.

Verified with new regression tests in `packages/agent-core/test/util/filesystem.test.ts`.

---
*PR created automatically by Jules for task [2426304240442106241](https://jules.google.com/task/2426304240442106241) started by @dolagoartur*