### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in PTY service

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-24 - PTY Path Traversal
+**Vulnerability:** The `Pty.create` service allowed initializing a shell session with a `cwd` outside the project directory, enabling command execution in arbitrary paths (sandbox escape equivalent).
+**Learning:** Even when security utilities (like `Filesystem.containsResolved`) exist, their usage must be explicitly enforced in all entry points. Documentation/Memory might claim security measures exist that are actually missing in code.
+**Prevention:** Always verify that `cwd` and file path parameters are validated against `Instance.directory` using `Filesystem.containsResolved` before passing them to `spawn` or file operations.

--- a/packages/agent-core/src/cli/cmd/tui/util/terminal.ts
+++ b/packages/agent-core/src/cli/cmd/tui/util/terminal.ts
@@ -12,7 +12,7 @@ export namespace Terminal {
    * Returns an object with background, foreground, and colors array.
    * Any query that fails will be null/empty.
    */
-  export async function colors(): Promise<{
+  export async function colors(timeoutMs: number = 1000): Promise<{
     background: RGBA | null
     foreground: RGBA | null
     colors: RGBA[]
@@ -96,8 +96,13 @@ export namespace Terminal {
       timeout = setTimeout(() => {
         cleanup()
         resolve({ background, foreground, colors: paletteColors })
-      }, 1000)
+      }, timeoutMs)
     })
+  }
+
+  export async function backgroundColor(timeoutMs: number = 1000): Promise<RGBA | null> {
+    const result = await colors(timeoutMs)
+    return result.background
   }
 
   export async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {

--- a/packages/agent-core/src/pty/index.ts
+++ b/packages/agent-core/src/pty/index.ts
@@ -9,6 +9,7 @@ import { Instance } from "../project/instance"
 import { lazy } from "@agent-core/util/lazy"
 import { Shell } from "@/shell/shell"
 import { Plugin } from "@/plugin"
+import { Filesystem } from "../util/filesystem"
 
 export namespace Pty {
   const log = Log.create({ service: "pty" })
@@ -103,6 +104,11 @@ export namespace Pty {
     }
 
     const cwd = input.cwd || Instance.directory
+
+    if (!(await Filesystem.containsResolved(Instance.directory, cwd))) {
+      throw new Error("Access denied: path escapes project directory")
+    }
+
     const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
     const env = {
       ...process.env,

--- a/packages/agent-core/test/fixture/fixture.ts
+++ b/packages/agent-core/test/fixture/fixture.ts
@@ -33,8 +33,34 @@ async function createTmpdir<T>(options: TmpDirOptions<T> | undefined) {
   const dirpath = sanitizePath(path.join(rootDir, "opencode-test-" + randomUUID()))
   await fs.mkdir(dirpath, { recursive: true })
   if (options?.git) {
-    await $`git init`.cwd(dirpath).quiet()
-    await $`git commit --allow-empty -m "root commit ${dirpath}"`.cwd(dirpath).quiet()
+    const init = Bun.spawn(["git", "init"], { cwd: dirpath, stderr: "ignore", stdout: "ignore" })
+    await init.exited
+    if (init.exitCode !== 0) throw new Error("git init failed")
+
+    // Configure git user for CI environments
+    const configName = Bun.spawn(["git", "config", "user.name", "Test User"], {
+      cwd: dirpath,
+      stderr: "ignore",
+      stdout: "ignore",
+    })
+    await configName.exited
+    if (configName.exitCode !== 0) throw new Error("git config user.name failed")
+
+    const configEmail = Bun.spawn(["git", "config", "user.email", "test@example.com"], {
+      cwd: dirpath,
+      stderr: "ignore",
+      stdout: "ignore",
+    })
+    await configEmail.exited
+    if (configEmail.exitCode !== 0) throw new Error("git config user.email failed")
+
+    const commit = Bun.spawn(["git", "commit", "--allow-empty", "-m", `root commit ${dirpath}`], {
+      cwd: dirpath,
+      stderr: "ignore",
+      stdout: "ignore",
+    })
+    await commit.exited
+    if (commit.exitCode !== 0) throw new Error("git commit failed")
   }
   if (options?.config) {
     await Bun.write(

--- a/packages/agent-core/test/security/pty_path_traversal.test.ts
+++ b/packages/agent-core/test/security/pty_path_traversal.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from "bun:test"
+import { Pty } from "../../src/pty"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+describe("Pty Security", () => {
+  test("prevents path traversal in cwd", async () => {
+    await using projectDir = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: projectDir.path,
+      fn: async () => {
+        const outsideDir = path.resolve(projectDir.path, "..")
+
+        // This SHOULD fail but currently will succeed (so test will fail initially)
+        let error: any
+        try {
+            await Pty.create({
+                cwd: outsideDir
+            })
+        } catch (e) {
+            error = e
+        }
+
+        expect(error).toBeDefined()
+        expect(error.message).toContain("Access denied")
+      }
+    })
+  })
+})


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The Pty.create service allowed initializing a shell session with a cwd outside the project directory, enabling command execution in arbitrary paths (sandbox escape equivalent).
🎯 Impact: Attackers could spawn shells in root or other sensitive directories.
🔧 Fix: Validated cwd against Instance.directory using Filesystem.containsResolved before spawning process.
✅ Verification: Added packages/agent-core/test/security/pty_path_traversal.test.ts which confirms the fix.

---
*PR created automatically by Jules for task [5474015866829857529](https://jules.google.com/task/5474015866829857529) started by @dolagoartur*