### PR TITLE
perf(memory): keyword/hybrid search + benchmarks

### DIFF
--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -42,3 +42,15 @@ agent-core
 agent-core --no-daemon
 agent-core daemon --hostname 127.0.0.1 --port 3210
 ```
+
+## Benchmark
+
+```bash
+cd packages/agent-core
+bun run bench --durationSeconds 10 --seedCount 500 --concurrency 5
+```
+
+- Writes JSON reports to `output/bench/<timestamp>.json`
+- Memory benches require Qdrant at `QDRANT_URL` (default: `http://localhost:6333`)
+- Inference bench uses your configured provider/model and measures streaming latency/throughput (FlashAttention is server-side; validate via throughput metrics)
+- Bench disables config dependency installation (`AGENT_CORE_DISABLE_CONFIG_DEPENDENCY_INSTALL=1`) to avoid mutating your config dirs

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -26,6 +26,7 @@
     "build": "bun run script/build.ts && ln -sf $(pwd)/dist/@agent-core/core-linux-x64/bin/agent-core ~/.bun/bin/agent-core",
     "dev": "bun run --conditions=browser ./src/index.ts",
     "memory:health": "bun run script/memory-health-check.ts",
+    "bench": "bun run script/bench/run.ts",
     "clean": "rm -rf node_modules dist"
   },
   "bin": {

--- a/packages/agent-core/script/bench/_util.ts
+++ b/packages/agent-core/script/bench/_util.ts
@@ -1,0 +1,113 @@
+export function msNow(): number {
+  return performance.now();
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  const clamped = Math.max(0, Math.min(1, p));
+  const idx = Math.round(clamped * (sortedAsc.length - 1));
+  return sortedAsc[idx] ?? sortedAsc[sortedAsc.length - 1] ?? 0;
+}
+
+export function summarizeLatenciesMs(latenciesMs: number[]): {
+  count: number;
+  mean: number;
+  min: number;
+  max: number;
+  p50: number;
+  p90: number;
+  p99: number;
+} {
+  if (latenciesMs.length === 0) {
+    return { count: 0, mean: 0, min: 0, max: 0, p50: 0, p90: 0, p99: 0 };
+  }
+
+  const sorted = [...latenciesMs].sort((a, b) => a - b);
+  const min = sorted[0] ?? 0;
+  const max = sorted[sorted.length - 1] ?? 0;
+  const sum = latenciesMs.reduce((s, v) => s + v, 0);
+  const mean = sum / latenciesMs.length;
+
+  return {
+    count: latenciesMs.length,
+    mean,
+    min,
+    max,
+    p50: percentile(sorted, 0.5),
+    p90: percentile(sorted, 0.9),
+    p99: percentile(sorted, 0.99),
+  };
+}
+
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const workers = Math.max(1, Math.floor(concurrency));
+  const results: R[] = new Array(items.length);
+  let next = 0;
+
+  await Promise.all(
+    Array.from({ length: workers }, async () => {
+      while (true) {
+        const idx = next++;
+        if (idx >= items.length) return;
+        results[idx] = await fn(items[idx] as T, idx);
+      }
+    }),
+  );
+
+  return results;
+}
+
+export async function runLoad(options: {
+  durationMs: number;
+  concurrency: number;
+  fn: (iteration: number) => Promise<void>;
+}): Promise<{
+  durationMs: number;
+  ops: number;
+  errors: number;
+  latenciesMs: number[];
+}> {
+  const startedAt = msNow();
+  const deadline = startedAt + Math.max(0, options.durationMs);
+  const concurrency = Math.max(1, Math.floor(options.concurrency));
+
+  const latenciesMs: number[] = [];
+  let ops = 0;
+  let errors = 0;
+
+  await Promise.all(
+    Array.from({ length: concurrency }, async (_, worker) => {
+      let iter = 0;
+      while (msNow() < deadline) {
+        const n = worker * 1_000_000_000 + iter++;
+        const t0 = msNow();
+        try {
+          await options.fn(n);
+        } catch {
+          errors++;
+        } finally {
+          const t1 = msNow();
+          latenciesMs.push(t1 - t0);
+          ops++;
+        }
+      }
+    }),
+  );
+
+  const finishedAt = msNow();
+  return {
+    durationMs: finishedAt - startedAt,
+    ops,
+    errors,
+    latenciesMs,
+  };
+}
+

--- a/packages/agent-core/script/bench/inference_openai_compat.bench.ts
+++ b/packages/agent-core/script/bench/inference_openai_compat.bench.ts
@@ -1,0 +1,170 @@
+import type { BenchCase } from "./types";
+import { Provider } from "../../src/provider/provider";
+import { ProviderTransform } from "../../src/provider/transform";
+import { Config } from "../../src/config/config";
+import { Instance } from "../../src/project/instance";
+import { streamText, type LanguageModel } from "ai";
+
+type ProviderList = Awaited<ReturnType<typeof Provider.list>>;
+
+function pickModel(config: any, providers: ProviderList): { providerID: string; modelID: string } | null {
+  const defaultAgent = (config?.default_agent as string | undefined) ?? "zee";
+  const agentConfig = (config?.agent as Record<string, { model?: string } | undefined>)?.[defaultAgent];
+  const agentModel = agentConfig?.model;
+
+  if (typeof agentModel === "string" && agentModel.includes("/")) {
+    const [providerID, modelID] = agentModel.split("/", 2) as [string, string];
+    if (providers[providerID]?.models?.[modelID]) return { providerID, modelID };
+  }
+
+  // Fallback: first configured provider with auth + first non-deprecated non-embedding model.
+  const isEmbeddingModel = (id: string) => id.includes("embedding") || id.includes("embed");
+
+  for (const [providerID, info] of Object.entries(providers)) {
+    if (!info.source) continue;
+    const eligible = Object.entries(info.models).filter(([id, m]) => m.status !== "deprecated" && !isEmbeddingModel(id));
+    if (eligible.length === 0) continue;
+    const [modelID] = eligible.sort(([, a], [, b]) => (a.cost.input || 0) - (b.cost.input || 0))[0] as [string, any];
+    return { providerID, modelID };
+  }
+
+  return null;
+}
+
+async function measureStreaming(model: LanguageModel, options: any): Promise<{
+  ttftMs: number | null;
+  totalMs: number;
+  completionTokens?: number;
+  totalTokens?: number;
+}> {
+  const startedAt = performance.now();
+  const result = await streamText({
+    model,
+    prompt: "Reply with a short paragraph about agent-core benchmarking. No markdown.",
+    temperature: 0,
+    maxRetries: 0,
+    maxOutputTokens: 256,
+    abortSignal: AbortSignal.timeout(60_000),
+    providerOptions: options.providerOptions,
+    headers: options.headers,
+  });
+
+  let ttftMs: number | null = null;
+  const stream = (result as any).textStream as AsyncIterable<string> | undefined;
+
+  if (stream && typeof (stream as any)[Symbol.asyncIterator] === "function") {
+    for await (const delta of stream) {
+      if (ttftMs === null) ttftMs = performance.now() - startedAt;
+      // Consume stream fully for stable timing. No-op with delta.
+      void delta;
+    }
+  }
+
+  const totalMs = performance.now() - startedAt;
+
+  let completionTokens: number | undefined;
+  let totalTokens: number | undefined;
+  try {
+    const usage = await (result as any).usage;
+    if (usage && typeof usage === "object") {
+      completionTokens = typeof usage.completionTokens === "number" ? usage.completionTokens : undefined;
+      totalTokens = typeof usage.totalTokens === "number" ? usage.totalTokens : undefined;
+    }
+  } catch {
+    // ignore
+  }
+
+  return { ttftMs, totalMs, completionTokens, totalTokens };
+}
+
+export const bench: BenchCase = {
+  id: "inference_openai_compat",
+  name: "Inference (OpenAI-compatible streaming)",
+  group: "inference",
+  async run(_ctx, opts) {
+    let result:
+      | { status: "ok"; metrics: Record<string, unknown> }
+      | { status: "skipped"; reason: string }
+      | { status: "error"; error: string } = { status: "skipped", reason: "Not executed" };
+
+    await Instance.provide({
+      directory: process.cwd(),
+      fn: async () => {
+        const config = await Config.get().catch(() => undefined);
+        const providers = await Provider.list();
+        const picked = pickModel(config, providers);
+        if (!picked) {
+          result = { status: "skipped", reason: "No configured provider/model found" };
+          return;
+        }
+
+        const info = providers[picked.providerID];
+        if (!info?.source) {
+          result = {
+            status: "skipped",
+            reason: `Provider ${picked.providerID} has no auth configured`,
+          };
+          return;
+        }
+
+        const model = info.models[picked.modelID];
+        if (!model) {
+          result = {
+            status: "skipped",
+            reason: `Model not found: ${picked.providerID}/${picked.modelID}`,
+          };
+          return;
+        }
+
+        const language = await Provider.getLanguage(model);
+        const transformed = ProviderTransform.options({
+          model,
+          sessionID: "bench",
+          providerOptions: info.options,
+        });
+
+        const runs = Math.max(1, Math.min(3, Math.floor(opts.concurrency)));
+        const measurements = [];
+        for (let i = 0; i < runs; i++) {
+          measurements.push(
+            await measureStreaming(language, {
+              providerOptions: ProviderTransform.providerOptions(model, transformed),
+              headers: model.headers,
+            }),
+          );
+        }
+
+        const ttfts = measurements.map((m) => m.ttftMs).filter((v): v is number => typeof v === "number");
+        const totals = measurements.map((m) => m.totalMs);
+        const completionTokens = measurements.map((m) => m.completionTokens).filter((v): v is number => typeof v === "number");
+
+        const mean = (xs: number[]) => (xs.length ? xs.reduce((s, v) => s + v, 0) / xs.length : 0);
+        const meanTtft = mean(ttfts);
+        const meanTotal = mean(totals);
+        const meanCompletion = mean(completionTokens);
+        const tokensPerSec = meanTotal > 0 && meanCompletion > 0 ? (meanCompletion / (meanTotal / 1000)) : undefined;
+
+        result = {
+          status: "ok",
+          metrics: {
+            model: `${picked.providerID}/${picked.modelID}`,
+            runs,
+            ttftMs: ttfts.length ? { mean: meanTtft, samples: ttfts } : { mean: null, samples: [] },
+            totalMs: { mean: meanTotal, samples: totals },
+            completionTokens: completionTokens.length ? { mean: meanCompletion, samples: completionTokens } : undefined,
+            tokensPerSec,
+          },
+        };
+      },
+    });
+
+    if (result.status === "ok") {
+      return { id: this.id, name: this.name, group: this.group, status: "ok", metrics: result.metrics };
+    }
+    if (result.status === "error") {
+      return { id: this.id, name: this.name, group: this.group, status: "error", error: result.error };
+    }
+    return { id: this.id, name: this.name, group: this.group, status: "skipped", reason: result.reason };
+  },
+};
+

--- a/packages/agent-core/script/bench/inference_openai_compat.bench.ts
+++ b/packages/agent-core/script/bench/inference_openai_compat.bench.ts
@@ -1,4 +1,4 @@
-import type { BenchCase } from "./types";
+import type { BenchCase, BenchResult } from "./types";
 import { Provider } from "../../src/provider/provider";
 import { ProviderTransform } from "../../src/provider/transform";
 import { Config } from "../../src/config/config";
@@ -82,38 +82,30 @@ export const bench: BenchCase = {
   name: "Inference (OpenAI-compatible streaming)",
   group: "inference",
   async run(_ctx, opts) {
-    let result:
-      | { status: "ok"; metrics: Record<string, unknown> }
-      | { status: "skipped"; reason: string }
-      | { status: "error"; error: string } = { status: "skipped", reason: "Not executed" };
+    const id = this.id;
+    const name = this.name;
+    const group = this.group;
 
-    await Instance.provide({
+    // Instance.provide() currently types `fn` as synchronous, but it awaits the result at runtime.
+    // Double-await to keep TypeScript happy without changing Instance.provide()'s public signature.
+    return await (await Instance.provide({
       directory: process.cwd(),
-      fn: async () => {
+      fn: async (): Promise<BenchResult> => {
         const config = await Config.get().catch(() => undefined);
         const providers = await Provider.list();
         const picked = pickModel(config, providers);
         if (!picked) {
-          result = { status: "skipped", reason: "No configured provider/model found" };
-          return;
+          return { id, name, group, status: "skipped", reason: "No configured provider/model found" };
         }
 
         const info = providers[picked.providerID];
         if (!info?.source) {
-          result = {
-            status: "skipped",
-            reason: `Provider ${picked.providerID} has no auth configured`,
-          };
-          return;
+          return { id, name, group, status: "skipped", reason: `Provider ${picked.providerID} has no auth configured` };
         }
 
         const model = info.models[picked.modelID];
         if (!model) {
-          result = {
-            status: "skipped",
-            reason: `Model not found: ${picked.providerID}/${picked.modelID}`,
-          };
-          return;
+          return { id, name, group, status: "skipped", reason: `Model not found: ${picked.providerID}/${picked.modelID}` };
         }
 
         const language = await Provider.getLanguage(model);
@@ -144,7 +136,10 @@ export const bench: BenchCase = {
         const meanCompletion = mean(completionTokens);
         const tokensPerSec = meanTotal > 0 && meanCompletion > 0 ? (meanCompletion / (meanTotal / 1000)) : undefined;
 
-        result = {
+        return {
+          id,
+          name,
+          group,
           status: "ok",
           metrics: {
             model: `${picked.providerID}/${picked.modelID}`,
@@ -156,15 +151,6 @@ export const bench: BenchCase = {
           },
         };
       },
-    });
-
-    if (result.status === "ok") {
-      return { id: this.id, name: this.name, group: this.group, status: "ok", metrics: result.metrics };
-    }
-    if (result.status === "error") {
-      return { id: this.id, name: this.name, group: this.group, status: "error", error: result.error };
-    }
-    return { id: this.id, name: this.name, group: this.group, status: "skipped", reason: result.reason };
+    }));
   },
 };
-

--- a/packages/agent-core/script/bench/memory.ts
+++ b/packages/agent-core/script/bench/memory.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Memory, resetMemory } from "../../../../src/memory/unified";
+import { mapWithConcurrency } from "./_util";
+
+export interface MemoryBenchContext {
+  memory: Memory;
+  namespace: string;
+  qdrantUrl: string;
+  qdrantApiKey?: string;
+  collection: string;
+  ftsDir: string;
+  queries: {
+    keyword: string[];
+    semantic: string[];
+    hybrid: string[];
+  };
+  cleanup: () => Promise<void>;
+}
+
+async function checkQdrant(url: string, apiKey?: string): Promise<boolean> {
+  try {
+    const headers: Record<string, string> = {};
+    if (apiKey) headers["api-key"] = apiKey;
+    const res = await fetch(`${url.replace(/\/$/, "")}/collections`, {
+      headers,
+      signal: AbortSignal.timeout(1500),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function patchFetchWaitTrue(qdrantUrl: string): () => void {
+  const base = qdrantUrl.replace(/\/$/, "");
+  const originalFetch = globalThis.fetch;
+
+  const patchedFetch: typeof fetch = (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (url.startsWith(base) && (method === "PUT" || method === "POST" || method === "DELETE")) {
+      const isPointWrite =
+        url.includes("/points") &&
+        !url.includes("/points/scroll") &&
+        !url.includes("/points/search") &&
+        !url.includes("/points/count");
+
+      if (isPointWrite) {
+        const sep = url.includes("?") ? "&" : "?";
+        return originalFetch(`${url}${sep}wait=true`, init);
+      }
+    }
+
+    return originalFetch(input, init);
+  };
+
+  globalThis.fetch = patchedFetch;
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+export async function createMemoryBenchContext(options: {
+  seedCount: number;
+  concurrency: number;
+  qdrantUrl?: string;
+  qdrantApiKey?: string;
+  namespace?: string;
+}): Promise<{ ctx: MemoryBenchContext | null; skipReason?: string }> {
+  const qdrantUrl = options.qdrantUrl ?? process.env.QDRANT_URL ?? "http://localhost:6333";
+  const qdrantApiKey = options.qdrantApiKey ?? process.env.QDRANT_API_KEY ?? undefined;
+  const ok = await checkQdrant(qdrantUrl, qdrantApiKey);
+  if (!ok) {
+    return {
+      ctx: null,
+      skipReason: `Qdrant not reachable at ${qdrantUrl} (set QDRANT_URL to override)`,
+    };
+  }
+
+  const namespace = options.namespace ?? "bench";
+  const ftsDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-core-bench-fts-"));
+  const collection = `bench_mem_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  const restoreFetch = patchFetchWaitTrue(qdrantUrl);
+
+  resetMemory();
+  const memory = new Memory({
+    qdrant: { url: qdrantUrl, apiKey: qdrantApiKey, collection },
+    embedding: { provider: "openai", dimensions: 384, apiKey: "" },
+    namespace,
+    fts: { dbDir: ftsDir, dbName: "fts.sqlite" },
+    markdown: { enabled: false },
+  });
+
+  try {
+    await memory.init();
+    if (!memory.isAvailable()) {
+      restoreFetch();
+      return {
+        ctx: null,
+        skipReason: "Memory unavailable after init (Qdrant reachable but init failed)",
+      };
+    }
+
+    const seedCount = Math.max(0, Math.floor(options.seedCount));
+    const ids = Array.from({ length: seedCount }, (_, i) => i);
+
+    await mapWithConcurrency(ids, Math.max(1, options.concurrency), async (i) => {
+      const tag = i % 3 === 0 ? "alpha" : i % 3 === 1 ? "beta" : "gamma";
+      const topic = `topic_${i % 10}`;
+      const subtopic = `sub_${i % 4}`;
+      const bucket = `bucket_${i % 25}`;
+
+      await memory.save({
+        category: "note",
+        content: `agent-core bench entry_${i} ${topic} ${subtopic} ${bucket} tag ${tag} issue 206 memory search perf`,
+        summary: `bench entry_${i}`,
+        namespace,
+        domain: "bench",
+        topic,
+        subtopic,
+        metadata: { tags: [tag, bucket] },
+      });
+    });
+
+    const queryCount = Math.min(25, seedCount);
+    const queryIds = new Set<number>();
+    while (queryIds.size < queryCount && seedCount > 0) {
+      queryIds.add(Math.floor(Math.random() * seedCount));
+    }
+
+    const keyword = Array.from(queryIds).map((i) => `entry_${i}`);
+    const semantic = [
+      "agent-core bench memory search performance",
+      "issue 206 perf search",
+      "topic_1 sub_1",
+      "tag alpha",
+      "bucket_7",
+    ];
+    const hybrid = [
+      "agent-core issue 206 memory search",
+      "topic_2 sub_2 tag beta",
+      "bucket_3 tag gamma",
+    ];
+
+    const cleanup = async () => {
+      restoreFetch();
+
+      try {
+        const headers: Record<string, string> = {};
+        if (qdrantApiKey) headers["api-key"] = qdrantApiKey;
+        await fetch(`${qdrantUrl.replace(/\/$/, "")}/collections/${collection}`, {
+          method: "DELETE",
+          headers,
+          signal: AbortSignal.timeout(5000),
+        });
+      } catch {
+        // ignore
+      }
+
+      try {
+        fs.rmSync(ftsDir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+
+      resetMemory();
+    };
+
+    return {
+      ctx: {
+        memory,
+        namespace,
+        qdrantUrl,
+        qdrantApiKey,
+        collection,
+        ftsDir,
+        queries: { keyword, semantic, hybrid },
+        cleanup,
+      },
+    };
+  } catch (e) {
+    restoreFetch();
+    try {
+      fs.rmSync(ftsDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+    return {
+      ctx: null,
+      skipReason: `Memory bench init failed: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}

--- a/packages/agent-core/script/bench/memory.ts
+++ b/packages/agent-core/script/bench/memory.ts
@@ -37,7 +37,7 @@ function patchFetchWaitTrue(qdrantUrl: string): () => void {
   const base = qdrantUrl.replace(/\/$/, "");
   const originalFetch = globalThis.fetch;
 
-  const patchedFetch: typeof fetch = (input, init) => {
+  const patchedFetch = ((input, init) => {
     const url =
       typeof input === "string"
         ? input
@@ -60,7 +60,10 @@ function patchFetchWaitTrue(qdrantUrl: string): () => void {
     }
 
     return originalFetch(input, init);
-  };
+  }) as typeof fetch;
+
+  // Preserve Bun-specific fetch helpers (e.g. fetch.preconnect) for type + runtime compatibility.
+  (patchedFetch as any).preconnect = (originalFetch as any).preconnect;
 
   globalThis.fetch = patchedFetch;
   return () => {

--- a/packages/agent-core/script/bench/memory_hybrid.bench.ts
+++ b/packages/agent-core/script/bench/memory_hybrid.bench.ts
@@ -1,0 +1,76 @@
+import type { BenchCase } from "./types";
+import { runLoad, summarizeLatenciesMs } from "./_util";
+
+export const bench: BenchCase = {
+  id: "memory_hybrid",
+  name: "Memory search (hybrid)",
+  group: "memory",
+  async run(ctx, opts) {
+    const mem = ctx.memory;
+    if (!mem) {
+      return {
+        id: this.id,
+        name: this.name,
+        group: this.group,
+        status: "skipped",
+        reason: "Memory context unavailable",
+      };
+    }
+
+    const queries = mem.queries.hybrid;
+    if (queries.length === 0) {
+      return {
+        id: this.id,
+        name: this.name,
+        group: this.group,
+        status: "skipped",
+        reason: "No hybrid queries generated",
+      };
+    }
+
+    // Warmup
+    for (let i = 0; i < Math.min(10, queries.length); i++) {
+      await mem.memory.search({
+        query: queries[i] as string,
+        mode: "hybrid",
+        limit: 10,
+        includeSnippets: false,
+        includeVectors: false,
+      });
+    }
+
+    let empty = 0;
+    const load = await runLoad({
+      durationMs: opts.durationSeconds * 1000,
+      concurrency: opts.concurrency,
+      fn: async (n) => {
+        const q = queries[n % queries.length] as string;
+        const res = await mem.memory.search({
+          query: q,
+          mode: "hybrid",
+          limit: 10,
+          includeSnippets: false,
+          includeVectors: false,
+        });
+        if (res.length === 0) empty++;
+      },
+    });
+
+    const latency = summarizeLatenciesMs(load.latenciesMs);
+    return {
+      id: this.id,
+      name: this.name,
+      group: this.group,
+      status: "ok",
+      metrics: {
+        durationMs: load.durationMs,
+        ops: load.ops,
+        opsPerSec: load.durationMs > 0 ? load.ops / (load.durationMs / 1000) : 0,
+        errors: load.errors,
+        emptyResults: empty,
+        latencyMs: latency,
+      },
+    };
+  },
+};
+

--- a/packages/agent-core/script/bench/memory_keyword.bench.ts
+++ b/packages/agent-core/script/bench/memory_keyword.bench.ts
@@ -1,0 +1,76 @@
+import type { BenchCase } from "./types";
+import { runLoad, summarizeLatenciesMs } from "./_util";
+
+export const bench: BenchCase = {
+  id: "memory_keyword",
+  name: "Memory search (keyword)",
+  group: "memory",
+  async run(ctx, opts) {
+    const mem = ctx.memory;
+    if (!mem) {
+      return {
+        id: this.id,
+        name: this.name,
+        group: this.group,
+        status: "skipped",
+        reason: "Memory context unavailable",
+      };
+    }
+
+    const queries = mem.queries.keyword;
+    if (queries.length === 0) {
+      return {
+        id: this.id,
+        name: this.name,
+        group: this.group,
+        status: "skipped",
+        reason: "No keyword queries generated",
+      };
+    }
+
+    // Warmup
+    for (let i = 0; i < Math.min(10, queries.length); i++) {
+      await mem.memory.search({
+        query: queries[i] as string,
+        mode: "keyword",
+        limit: 10,
+        includeSnippets: false,
+        includeVectors: false,
+      });
+    }
+
+    let empty = 0;
+    const load = await runLoad({
+      durationMs: opts.durationSeconds * 1000,
+      concurrency: opts.concurrency,
+      fn: async (n) => {
+        const q = queries[n % queries.length] as string;
+        const res = await mem.memory.search({
+          query: q,
+          mode: "keyword",
+          limit: 10,
+          includeSnippets: false,
+          includeVectors: false,
+        });
+        if (res.length === 0) empty++;
+      },
+    });
+
+    const latency = summarizeLatenciesMs(load.latenciesMs);
+    return {
+      id: this.id,
+      name: this.name,
+      group: this.group,
+      status: "ok",
+      metrics: {
+        durationMs: load.durationMs,
+        ops: load.ops,
+        opsPerSec: load.durationMs > 0 ? load.ops / (load.durationMs / 1000) : 0,
+        errors: load.errors,
+        emptyResults: empty,
+        latencyMs: latency,
+      },
+    };
+  },
+};
+

--- a/packages/agent-core/script/bench/memory_vector.bench.ts
+++ b/packages/agent-core/script/bench/memory_vector.bench.ts
@@ -1,0 +1,74 @@
+import type { BenchCase } from "./types";
+import { runLoad, summarizeLatenciesMs } from "./_util";
+
+export const bench: BenchCase = {
+  id: "memory_semantic",
+  name: "Memory search (semantic)",
+  group: "memory",
+  async run(ctx, opts) {
+    const mem = ctx.memory;
+    if (!mem) {
+      return {
+        id: this.id,
+        name: this.name,
+        group: this.group,
+        status: "skipped",
+        reason: "Memory context unavailable",
+      };
+    }
+
+    const queries = mem.queries.semantic;
+    if (queries.length === 0) {
+      return {
+        id: this.id,
+        name: this.name,
+        group: this.group,
+        status: "skipped",
+        reason: "No semantic queries generated",
+      };
+    }
+
+    // Warmup
+    for (let i = 0; i < Math.min(10, queries.length); i++) {
+      await mem.memory.search({
+        query: queries[i] as string,
+        mode: "semantic",
+        limit: 10,
+        includeVectors: false,
+      });
+    }
+
+    let empty = 0;
+    const load = await runLoad({
+      durationMs: opts.durationSeconds * 1000,
+      concurrency: opts.concurrency,
+      fn: async (n) => {
+        const q = queries[n % queries.length] as string;
+        const res = await mem.memory.search({
+          query: q,
+          mode: "semantic",
+          limit: 10,
+          includeVectors: false,
+        });
+        if (res.length === 0) empty++;
+      },
+    });
+
+    const latency = summarizeLatenciesMs(load.latenciesMs);
+    return {
+      id: this.id,
+      name: this.name,
+      group: this.group,
+      status: "ok",
+      metrics: {
+        durationMs: load.durationMs,
+        ops: load.ops,
+        opsPerSec: load.durationMs > 0 ? load.ops / (load.durationMs / 1000) : 0,
+        errors: load.errors,
+        emptyResults: empty,
+        latencyMs: latency,
+      },
+    };
+  },
+};
+

--- a/packages/agent-core/script/bench/run.ts
+++ b/packages/agent-core/script/bench/run.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env bun
+import fs from "node:fs";
+import path from "node:path";
+import { createMemoryBenchContext } from "./memory";
+import type { BenchCase, BenchContext, BenchResult, BenchRunOptions } from "./types";
+import { bench as memoryKeyword } from "./memory_keyword.bench";
+import { bench as memorySemantic } from "./memory_vector.bench";
+import { bench as memoryHybrid } from "./memory_hybrid.bench";
+import { bench as inferenceOpenAICompat } from "./inference_openai_compat.bench";
+
+function parseArgs(argv: string[]): Record<string, string | boolean> {
+  const out: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i] as string;
+    if (!a.startsWith("--")) continue;
+
+    const eq = a.indexOf("=");
+    if (eq !== -1) {
+      const k = a.slice(2, eq);
+      const v = a.slice(eq + 1);
+      out[k] = v;
+      continue;
+    }
+
+    const k = a.slice(2);
+    const next = argv[i + 1];
+    if (next && !String(next).startsWith("--")) {
+      out[k] = String(next);
+      i++;
+    } else {
+      out[k] = true;
+    }
+  }
+  return out;
+}
+
+function toInt(v: unknown, fallback: number): number {
+  const n = typeof v === "string" ? Number.parseInt(v, 10) : typeof v === "number" ? v : NaN;
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function git(repoRoot: string, args: string[]): string | null {
+  const proc = Bun.spawnSync(["git", ...args], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0) return null;
+  return new TextDecoder().decode(proc.stdout).trim();
+}
+
+async function runBench(bench: BenchCase, ctx: BenchContext, opts: BenchRunOptions): Promise<BenchResult> {
+  try {
+    return await bench.run(ctx, opts);
+  } catch (e) {
+    return {
+      id: bench.id,
+      name: bench.name,
+      group: bench.group,
+      status: "error",
+      error: e instanceof Error ? e.stack ?? e.message : String(e),
+    };
+  }
+}
+
+async function main() {
+  // Benchmarks should not modify ~/.config/agent-core (or other config dirs) by installing plugins/deps.
+  // If you intentionally want that behavior, set AGENT_CORE_DISABLE_CONFIG_DEPENDENCY_INSTALL=0.
+  process.env.AGENT_CORE_DISABLE_CONFIG_DEPENDENCY_INSTALL ??= "1";
+
+  const args = parseArgs(process.argv.slice(2));
+
+  const opts: BenchRunOptions = {
+    durationSeconds: Math.max(1, toInt(args.durationSeconds, 10)),
+    seedCount: Math.max(0, toInt(args.seedCount, 500)),
+    concurrency: Math.max(1, toInt(args.concurrency, 5)),
+  };
+
+  const repoRoot = path.resolve(import.meta.dir, "../../../../");
+  const commit = git(repoRoot, ["rev-parse", "HEAD"]);
+  const branch = git(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const status = git(repoRoot, ["status", "--porcelain"]);
+  const dirty = status ? status.length > 0 : null;
+
+  const outputDir = path.resolve(process.cwd(), "output", "bench");
+  fs.mkdirSync(outputDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const outputFile = path.join(outputDir, `${ts}.json`);
+
+  const results: BenchResult[] = [];
+  let memoryCtx: Awaited<ReturnType<typeof createMemoryBenchContext>>["ctx"] | null = null;
+
+  try {
+    const created = await createMemoryBenchContext({
+      seedCount: opts.seedCount,
+      concurrency: opts.concurrency,
+    });
+    memoryCtx = created.ctx;
+
+    const benchCtx: BenchContext = { memory: memoryCtx };
+    const memoryBenches: BenchCase[] = [memoryKeyword, memorySemantic, memoryHybrid];
+
+    if (!memoryCtx && created.skipReason) {
+      for (const b of memoryBenches) {
+        results.push({
+          id: b.id,
+          name: b.name,
+          group: b.group,
+          status: "skipped",
+          reason: created.skipReason,
+        });
+      }
+    } else {
+      for (const b of memoryBenches) {
+        results.push(await runBench(b, benchCtx, opts));
+      }
+    }
+
+    if (memoryCtx) {
+      await memoryCtx.cleanup();
+      benchCtx.memory = null;
+      memoryCtx = null;
+    }
+
+    results.push(await runBench(inferenceOpenAICompat, { memory: null }, opts));
+  } finally {
+    if (memoryCtx) {
+      await memoryCtx.cleanup();
+    }
+  }
+
+  const report = {
+    tool: "agent-core benchmark",
+    generatedAt: new Date().toISOString(),
+    git: { commit, branch, dirty },
+    options: opts,
+    environment: {
+      platform: process.platform,
+      arch: process.arch,
+      bun: process.versions.bun,
+      node: process.versions.node,
+    },
+    results,
+  };
+
+  fs.writeFileSync(outputFile, JSON.stringify(report, null, 2));
+  // Explicit exit: Provider/Config can leave handles open.
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/agent-core/script/bench/types.ts
+++ b/packages/agent-core/script/bench/types.ts
@@ -1,0 +1,42 @@
+import type { MemoryBenchContext } from "./memory";
+
+export interface BenchRunOptions {
+  durationSeconds: number;
+  concurrency: number;
+  seedCount: number;
+}
+
+export interface BenchContext {
+  memory?: MemoryBenchContext | null;
+}
+
+export type BenchResult =
+  | {
+      id: string;
+      name: string;
+      group: string;
+      status: "ok";
+      metrics: Record<string, unknown>;
+    }
+  | {
+      id: string;
+      name: string;
+      group: string;
+      status: "skipped";
+      reason: string;
+    }
+  | {
+      id: string;
+      name: string;
+      group: string;
+      status: "error";
+      error: string;
+    };
+
+export interface BenchCase {
+  id: string;
+  name: string;
+  group: string;
+  run: (ctx: BenchContext, opts: BenchRunOptions) => Promise<BenchResult>;
+}
+

--- a/packages/agent-core/src/config/config.ts
+++ b/packages/agent-core/src/config/config.ts
@@ -249,6 +249,18 @@ export namespace Config {
   }
 
   export async function installDependencies(dir: string) {
+    // Benchmarks and certain automation should never mutate user config directories.
+    // This env var is intentionally read at call time (not via Flag) to avoid stale values
+    // when the process sets it after module import.
+    const disableInstall = (() => {
+      const v = process.env.AGENT_CORE_DISABLE_CONFIG_DEPENDENCY_INSTALL?.toLowerCase()
+      return v === "true" || v === "1"
+    })()
+    if (disableInstall) {
+      log.debug("dependency install disabled", { dir })
+      return
+    }
+
     const writable = await isWritable(dir)
     if (!writable) {
       log.debug("config dir is not writable, skipping dependency install", { dir })

--- a/packages/agent-core/src/server/route/memory.ts
+++ b/packages/agent-core/src/server/route/memory.ts
@@ -91,8 +91,11 @@ const MemoryInputSchema = z.object({
 
 const MemorySearchParamsSchema = z.object({
   query: z.string().min(1),
+  mode: z.enum(["auto", "semantic", "keyword", "hybrid"]).optional(),
   limit: z.number().min(1).max(100).optional().default(10),
-  threshold: z.number().min(0).max(1).optional().default(0.5),
+  threshold: z.number().min(0).max(1).optional(),
+  includeVectors: z.boolean().optional().default(false),
+  includeSnippets: z.boolean().optional().default(false),
   category: z.union([MemoryCategorySchema, z.array(MemoryCategorySchema)]).optional(),
   namespace: z.string().nullable().optional(),
   tags: z.array(z.string()).optional(),
@@ -108,12 +111,19 @@ const MemorySearchResultSchema = z.object({
   entry: MemoryEntrySchema,
   score: z.number(),
   highlights: z.array(z.string()).optional(),
+  snippet: z.string().optional(),
 })
 
 const MemoryStatsSchema = z.object({
   total: z.number(),
   byType: z.record(z.string(), z.number()),
   byCategory: z.record(z.string(), z.number()),
+  fts: z
+    .object({
+      totalEntries: z.number(),
+      dbSizeBytes: z.number(),
+    })
+    .optional(),
 })
 
 // =============================================================================

--- a/packages/agent-core/test/config/install-deps.test.ts
+++ b/packages/agent-core/test/config/install-deps.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Config } from "../../src/config/config"
+import { tmpdir } from "../fixture/fixture"
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.stat(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+test("Config.installDependencies is a no-op when AGENT_CORE_DISABLE_CONFIG_DEPENDENCY_INSTALL=1", async () => {
+  const original = process.env.AGENT_CORE_DISABLE_CONFIG_DEPENDENCY_INSTALL
+  process.env.AGENT_CORE_DISABLE_CONFIG_DEPENDENCY_INSTALL = "1"
+  try {
+    await using tmp = await tmpdir()
+    const dir = path.join(tmp.path, "config-dir")
+    await fs.mkdir(dir, { recursive: true })
+
+    await Config.installDependencies(dir)
+
+    expect(await exists(path.join(dir, "node_modules"))).toBe(false)
+    expect(await exists(path.join(dir, "package.json"))).toBe(false)
+    expect(await exists(path.join(dir, ".gitignore"))).toBe(false)
+    expect(await exists(path.join(dir, "bun.lock"))).toBe(false)
+  } finally {
+    if (typeof original === "string") {
+      process.env.AGENT_CORE_DISABLE_CONFIG_DEPENDENCY_INSTALL = original
+    } else {
+      delete process.env.AGENT_CORE_DISABLE_CONFIG_DEPENDENCY_INSTALL
+    }
+  }
+})
+

--- a/src/memory/qdrant.ts
+++ b/src/memory/qdrant.ts
@@ -442,7 +442,8 @@ export class QdrantVectorStorage implements VectorStorage {
   }
 
   async get(
-    ids: string[]
+    ids: string[],
+    options?: { withVector?: boolean }
   ): Promise<
     Array<{
       id: string;
@@ -459,7 +460,7 @@ export class QdrantVectorStorage implements VectorStorage {
         {
           ids,
           with_payload: true,
-          with_vector: true,
+          with_vector: options?.withVector ?? false,
         }
       );
 
@@ -593,9 +594,26 @@ export class QdrantVectorStorage implements VectorStorage {
         }
         // Range filter
         else {
-          const range = obj as { lt?: number; gt?: number; lte?: number; gte?: number };
-          if (range.lt !== undefined || range.gt !== undefined ||
-              range.lte !== undefined || range.gte !== undefined) {
+          const range: { lt?: number; gt?: number; lte?: number; gte?: number } = {};
+
+          const setRange = (from: string, to: "lt" | "gt" | "lte" | "gte") => {
+            const v = obj[from];
+            if (typeof v === "number" && Number.isFinite(v)) {
+              range[to] = v;
+            }
+          };
+
+          // Accept both Mongo-style `$lt` and plain `lt`.
+          setRange("lt", "lt");
+          setRange("$lt", "lt");
+          setRange("gt", "gt");
+          setRange("$gt", "gt");
+          setRange("lte", "lte");
+          setRange("$lte", "lte");
+          setRange("gte", "gte");
+          setRange("$gte", "gte");
+
+          if (range.lt !== undefined || range.gt !== undefined || range.lte !== undefined || range.gte !== undefined) {
             must.push({ key, range });
           }
         }

--- a/src/memory/sqlite-fts.ts
+++ b/src/memory/sqlite-fts.ts
@@ -66,6 +66,8 @@ export interface FtsSearchResult {
   namespace?: string
   domain?: string
   topic?: string
+  subtopic?: string
+  createdAt?: number
   /** BM25 rank converted to a 0-1 score */
   score: number
   /** Raw BM25 rank from SQLite (lower is better) */
@@ -215,6 +217,7 @@ export class SqliteFtsStore {
     if (!ftsQuery) return []
 
     const limit = options.limit ?? 20
+    const includeSnippets = options.includeSnippets ?? false
     const conditions: string[] = []
     const params: (string | number)[] = [ftsQuery]
 
@@ -234,14 +237,30 @@ export class SqliteFtsStore {
       conditions.push("topic = ?")
       params.push(options.topic)
     }
+    if (options.subtopic) {
+      conditions.push("subtopic = ?")
+      params.push(options.subtopic)
+    }
+    if (options.timeRange?.start !== undefined) {
+      conditions.push("created_at >= ?")
+      params.push(options.timeRange.start)
+    }
+    if (options.timeRange?.end !== undefined) {
+      conditions.push("created_at <= ?")
+      params.push(options.timeRange.end)
+    }
 
     const where = conditions.length > 0 ? `AND ${conditions.join(" AND ")}` : ""
 
     params.push(limit)
 
+    const snippetExpr = includeSnippets
+      ? "snippet(memory_fts, 1, '<b>', '</b>', '...', 32) as snippet"
+      : "NULL as snippet"
+
     const rows = this.db.query<FtsRow, (string | number)[]>(
-      `SELECT id, content, summary, category, namespace, domain, topic,
-              rank, snippet(memory_fts, 1, '<b>', '</b>', '...', 32) as snippet
+      `SELECT id, content, summary, category, namespace, domain, topic, subtopic, created_at,
+              rank, ${snippetExpr}
        FROM memory_fts
        WHERE memory_fts MATCH ? ${where}
        ORDER BY rank
@@ -256,9 +275,11 @@ export class SqliteFtsStore {
       namespace: row.namespace || undefined,
       domain: row.domain || undefined,
       topic: row.topic || undefined,
+      subtopic: row.subtopic || undefined,
+      createdAt: typeof row.created_at === "number" ? row.created_at : undefined,
       score: bm25RankToScore(row.rank),
       rank: row.rank,
-      snippet: row.snippet || undefined,
+      snippet: includeSnippets ? (row.snippet || undefined) : undefined,
     }))
   }
 
@@ -334,6 +355,9 @@ export interface FtsSearchOptions {
   category?: string
   domain?: string
   topic?: string
+  subtopic?: string
+  timeRange?: { start?: number; end?: number }
+  includeSnippets?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -348,8 +372,10 @@ type FtsRow = {
   namespace: string
   domain: string
   topic: string
+  subtopic: string
+  created_at: number
   rank: number
-  snippet: string
+  snippet: string | null
 }
 
 /**

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -194,10 +194,15 @@ export interface MemoryInput {
 // Search Types
 // =============================================================================
 
+/** Search mode selection. */
+export type MemorySearchMode = "auto" | "semantic" | "keyword" | "hybrid";
+
 /** Search parameters for memory retrieval */
 export interface MemorySearchParams {
   /** Search query text */
   query: string;
+  /** Search mode selection. Default: "auto". */
+  mode?: MemorySearchMode;
   /** Maximum results to return */
   limit?: number;
   /** Minimum similarity threshold (0-1) */
@@ -217,6 +222,8 @@ export interface MemorySearchParams {
   includeMetadata?: boolean;
   /** Include embedding vectors in results */
   includeVectors?: boolean;
+  /** Include snippets (keyword and hybrid search only). Default: false. */
+  includeSnippets?: boolean;
 
   // Context Tree filters
   domain?: string;
@@ -251,6 +258,8 @@ export interface MemorySearchResult {
   score: number;
   /** Highlighted matches */
   highlights?: string[];
+  /** Keyword snippet with match highlights (if available). */
+  snippet?: string;
 }
 
 // =============================================================================

--- a/src/memory/unified.ts
+++ b/src/memory/unified.ts
@@ -16,6 +16,7 @@ import { createEmbeddingProvider, createEmbeddingProviderAsync, type EmbeddingCo
 import type {
   MemoryEntry,
   MemoryInput,
+  MemorySearchMode,
   MemorySearchParams,
   MemorySearchResult,
   MemoryCategory,
@@ -498,6 +499,7 @@ export class Memory {
             log.info("SQLite FTS initialized for hybrid search");
           } catch (ftsErr) {
             this.ftsInitFailed = true;
+            this.ftsStore = undefined;
             log.warn("SQLite FTS initialization failed, hybrid search unavailable", {
               error: ftsErr instanceof Error ? ftsErr.message : String(ftsErr),
             });
@@ -650,6 +652,17 @@ export class Memory {
           parentVersion = prevVersion;
           // Mark old version as superseded
           await this.storage.update(prev.id, { superseded: true });
+          // Keep FTS "current-only": remove superseded entry from keyword index.
+          if (this.ftsStore) {
+            try {
+              this.ftsStore.delete(prev.id);
+            } catch (ftsErr) {
+              log.debug("FTS delete failed for superseded version (non-fatal)", {
+                id: prev.id,
+                error: ftsErr instanceof Error ? ftsErr.message : String(ftsErr),
+              });
+            }
+          }
           // Decrement tree index counts for the old point (it's now superseded)
           // Not needed: tree counts track total non-superseded entries, and we're
           // adding a new one to replace the old, so net change is zero.
@@ -767,7 +780,7 @@ export class Memory {
     return entry;
   }
 
-  /** Search memories semantically */
+  /** Search memories using semantic, keyword, or hybrid retrieval. */
   async search(params: MemorySearchParams): Promise<MemorySearchResult[]> {
     await this.init();
 
@@ -777,12 +790,60 @@ export class Memory {
       return [];
     }
 
-    const queryVector = await this.embedding.embed(params.query);
+    const mode = this.resolveSearchMode(params);
 
-    // Build filter
-    const filter: Record<string, unknown> = {
-      type: "memory",
-    };
+    if (mode === "keyword") {
+      return this.keywordSearch(params);
+    }
+
+    if (mode === "hybrid") {
+      return this.hybridSearchMode(params);
+    }
+
+    // Default: semantic
+    return this.semanticSearch(params);
+  }
+
+  private resolveSearchMode(params: MemorySearchParams): MemorySearchMode {
+    const requested = params.mode ?? "auto";
+
+    if (requested !== "auto") {
+      if ((requested === "keyword" || requested === "hybrid") && !this.ftsStore) {
+        log.debug("FTS unavailable; falling back to semantic search", { requested });
+        return "semantic";
+      }
+      return requested;
+    }
+
+    // Auto mode: use keyword fast-path for identifier-like queries, otherwise hybrid if FTS is available.
+    if (this.ftsStore && this.isLikelyKeywordQuery(params.query)) {
+      return "keyword";
+    }
+
+    if (this.ftsStore) return "hybrid";
+    return "semantic";
+  }
+
+  private isLikelyKeywordQuery(query: string): boolean {
+    const q = query.trim();
+    if (!q) return false;
+
+    // Explicit keyword operators / quoting.
+    if (q.includes("*") || q.includes(":") || q.includes("\"")) return true;
+
+    const tokens = q.split(/\s+/g).filter(Boolean);
+    if (tokens.length > 2) return false;
+
+    const isShort = q.length <= 32;
+    if (!isShort) return false;
+
+    // Single token or identifier-like patterns.
+    if (tokens.length === 1) return true;
+    return /[_\d]/.test(q);
+  }
+
+  private buildSemanticFilter(params: MemorySearchParams): Record<string, unknown> {
+    const filter: Record<string, unknown> = { type: "memory" };
 
     // Namespace filtering: pass namespace: null to search all namespaces
     if (params.namespace === null) {
@@ -801,6 +862,13 @@ export class Memory {
 
     if (params.tags?.length) {
       filter["metadata.tags"] = { $in: params.tags };
+    }
+
+    if (params.timeRange?.start !== undefined || params.timeRange?.end !== undefined) {
+      const createdAtRange: Record<string, number> = {};
+      if (params.timeRange?.start !== undefined) createdAtRange.$gte = params.timeRange.start;
+      if (params.timeRange?.end !== undefined) createdAtRange.$lte = params.timeRange.end;
+      filter.createdAt = createdAtRange;
     }
 
     // Context Tree filters
@@ -851,16 +919,248 @@ export class Memory {
       filter.confidence = confidenceFilter;
     }
 
+    return filter;
+  }
+
+  private matchesSearchParams(entry: MemoryEntry, params: MemorySearchParams): boolean {
+    if (params.namespace !== null) {
+      const ns = params.namespace ?? this.namespace;
+      if (entry.namespace !== ns) return false;
+    }
+
+    if (params.category) {
+      if (Array.isArray(params.category)) {
+        if (!params.category.includes(entry.category)) return false;
+      } else if (entry.category !== params.category) {
+        return false;
+      }
+    }
+
+    if (params.tags?.length) {
+      const tags = entry.metadata?.tags;
+      if (!Array.isArray(tags)) return false;
+      const hasAny = params.tags.some((t) => tags.includes(t));
+      if (!hasAny) return false;
+    }
+
+    if (params.timeRange?.start !== undefined && entry.createdAt < params.timeRange.start) return false;
+    if (params.timeRange?.end !== undefined && entry.createdAt > params.timeRange.end) return false;
+
+    if (params.domain && entry.domain !== params.domain) return false;
+    if (params.topic && entry.topic !== params.topic) return false;
+    if (params.subtopic && entry.subtopic !== params.subtopic) return false;
+
+    if (params.memoryId && entry.memoryId !== params.memoryId) return false;
+
+    // Default: current-only. Treat missing superseded as current for back-compat.
+    if (params.superseded !== undefined) {
+      if (entry.superseded !== params.superseded) return false;
+    } else {
+      if (entry.superseded === true) return false;
+    }
+
+    if (params.kind) {
+      const kind = entry.kind;
+      if (Array.isArray(params.kind)) {
+        if (!kind || !params.kind.includes(kind)) return false;
+      } else if (kind !== params.kind) {
+        return false;
+      }
+    }
+
+    if (params.priority) {
+      const priority = entry.priority;
+      if (Array.isArray(params.priority)) {
+        if (!priority || !params.priority.includes(priority)) return false;
+      } else if (priority !== params.priority) {
+        return false;
+      }
+    }
+
+    if (params.bookmarked !== undefined && entry.bookmarked !== params.bookmarked) return false;
+    if (params.memoryType && entry.memoryType !== params.memoryType) return false;
+
+    if (params.minConfidence !== undefined) {
+      if (typeof entry.confidence !== "number") return false;
+      if (entry.confidence < params.minConfidence) return false;
+    }
+
+    if (params.maxConfidence !== undefined) {
+      if (typeof entry.confidence !== "number") return false;
+      if (entry.confidence > params.maxConfidence) return false;
+    }
+
+    return true;
+  }
+
+  private async semanticSearch(params: MemorySearchParams): Promise<MemorySearchResult[]> {
+    const queryVector = await this.embedding.embed(params.query);
+    const filter = this.buildSemanticFilter(params);
+
+    const limit = params.limit ?? 10;
+    const threshold = params.threshold ?? 0.5;
+
     const results = await this.storage.search(queryVector, {
-      limit: params.limit ?? 10,
-      threshold: params.threshold ?? 0.5,
+      limit,
+      threshold,
       filter,
     });
 
-    return results.map((r) => ({
-      entry: this.pointToEntry({ id: r.id, payload: r.payload }),
-      score: r.score,
-    }));
+    if (!params.includeVectors) {
+      return results.map((r) => ({
+        entry: this.pointToEntry({ id: r.id, payload: r.payload }),
+        score: r.score,
+      }));
+    }
+
+    const ids = results.map((r) => r.id);
+    const fetched = await this.storage.get(ids, { withVector: true });
+    const fetchedMap = new Map(
+      fetched.filter((p): p is NonNullable<typeof p> => !!p).map((p) => [p.id, p]),
+    );
+
+    return results.map((r) => {
+      const point = fetchedMap.get(r.id);
+      return {
+        entry: point ? this.pointToEntry(point) : this.pointToEntry({ id: r.id, payload: r.payload }),
+        score: r.score,
+      };
+    });
+  }
+
+  private async keywordSearch(params: MemorySearchParams): Promise<MemorySearchResult[]> {
+    if (!this.ftsStore) {
+      return this.semanticSearch(params);
+    }
+
+    const limit = params.limit ?? 10;
+    const threshold = params.threshold ?? 0.0;
+    const includeSnippets = params.includeSnippets ?? false;
+    const effectiveNamespace = params.namespace === null ? undefined : (params.namespace ?? this.namespace);
+
+    const keywordResults = this.ftsStore.search(params.query, {
+      limit: Math.min(limit * 5, 200),
+      namespace: effectiveNamespace,
+      category: typeof params.category === "string" ? params.category : undefined,
+      domain: params.domain,
+      topic: params.topic,
+      subtopic: params.subtopic,
+      timeRange: params.timeRange,
+      includeSnippets,
+    }).filter((r) => r.score >= threshold);
+
+    if (keywordResults.length === 0) return [];
+
+    const idMeta = new Map<string, { score: number; snippet?: string }>();
+    for (const r of keywordResults) {
+      idMeta.set(r.id, { score: r.score, snippet: r.snippet });
+    }
+
+    const orderedIds = keywordResults.map((r) => r.id);
+    const withVector = params.includeVectors ?? false;
+
+    const out: MemorySearchResult[] = [];
+    const maxPerCall = 50;
+    const maxTotal = 200;
+    let cursor = 0;
+    let hydrated = 0;
+
+    while (out.length < limit && cursor < orderedIds.length && hydrated < maxTotal) {
+      const batch = orderedIds.slice(cursor, cursor + maxPerCall);
+      cursor += maxPerCall;
+      hydrated += batch.length;
+
+      const points = await this.storage.get(batch, { withVector });
+      for (const point of points) {
+        if (!point || point.payload.type !== "memory") continue;
+        const entry = this.pointToEntry(point);
+        if (!this.matchesSearchParams(entry, params)) continue;
+
+        const meta = idMeta.get(entry.id);
+        if (!meta) continue;
+
+        out.push({
+          entry,
+          score: meta.score,
+          snippet: includeSnippets ? meta.snippet : undefined,
+        });
+        if (out.length >= limit) break;
+      }
+    }
+
+    return out;
+  }
+
+  private async hybridSearchMode(params: MemorySearchParams): Promise<MemorySearchResult[]> {
+    if (!this.ftsStore) {
+      return this.semanticSearch(params);
+    }
+
+    const limit = params.limit ?? 10;
+    const includeSnippets = params.includeSnippets ?? false;
+    const effectiveNamespace = params.namespace === null ? undefined : (params.namespace ?? this.namespace);
+
+    // Vector search (recall) + keyword search (BM25) merged via weights.
+    const [vectorResults, keywordResults] = await Promise.all([
+      this.semanticSearch({
+        ...params,
+        limit: limit * 2,
+        threshold: params.threshold ?? 0.5,
+      }),
+      Promise.resolve(
+        this.ftsStore.search(params.query, {
+          limit: Math.min(limit * 4, 200),
+          namespace: effectiveNamespace,
+          category: typeof params.category === "string" ? params.category : undefined,
+          domain: params.domain,
+          topic: params.topic,
+          subtopic: params.subtopic,
+          timeRange: params.timeRange,
+          includeSnippets,
+        }),
+      ),
+    ]);
+
+    const merged = mergeHybridResults(
+      vectorResults,
+      keywordResults.map((kr) => ({ id: kr.id, score: kr.score, snippet: kr.snippet })),
+      {
+        limit,
+        threshold: params.threshold ?? 0.3,
+      },
+    );
+
+    const missingIds = merged.filter((m) => !m.entry).map((m) => m.id);
+    const withVector = params.includeVectors ?? false;
+    const hydrated = missingIds.length
+      ? await this.storage.get(missingIds.slice(0, 200), { withVector })
+      : [];
+    const hydratedMap = new Map(
+      hydrated.filter((p): p is NonNullable<typeof p> => !!p).map((p) => [p.id, p]),
+    );
+
+    const out: MemorySearchResult[] = [];
+    for (const item of merged) {
+      let entry = item.entry ?? null;
+
+      if (!entry) {
+        const point = hydratedMap.get(item.id);
+        if (!point || point.payload.type !== "memory") continue;
+        entry = this.pointToEntry(point);
+      }
+
+      if (!this.matchesSearchParams(entry, params)) continue;
+
+      out.push({
+        entry,
+        score: item.score,
+        snippet: includeSnippets ? item.snippet : undefined,
+      });
+
+      if (out.length >= limit) break;
+    }
+
+    return out;
   }
 
   /** Get a memory by ID */
@@ -907,6 +1207,16 @@ export class Memory {
   async delete(id: string): Promise<void> {
     await this.init();
     await this.storage.delete([id]);
+    if (this.ftsStore) {
+      try {
+        this.ftsStore.delete(id);
+      } catch (ftsErr) {
+        log.debug("FTS delete failed (non-fatal)", {
+          id,
+          error: ftsErr instanceof Error ? ftsErr.message : String(ftsErr),
+        });
+      }
+    }
   }
 
   /** Delete memories matching filter */
@@ -1084,7 +1394,7 @@ export class Memory {
     }
 
     // Run vector search (always)
-    const vectorResults = await this.search(params);
+    const vectorResults = await this.semanticSearch(params);
 
     // If FTS is not available, return vector results in hybrid format
     if (!this.ftsStore) {
@@ -1099,10 +1409,13 @@ export class Memory {
     // Run keyword search in parallel
     const keywordResults = this.ftsStore.search(params.query, {
       limit: (params.limit ?? 10) * 2, // fetch more for better merge
-      namespace: typeof params.namespace === "string" ? params.namespace : undefined,
+      namespace: params.namespace === null ? undefined : (params.namespace ?? this.namespace),
       category: typeof params.category === "string" ? params.category : undefined,
       domain: params.domain,
       topic: params.topic,
+      subtopic: params.subtopic,
+      timeRange: params.timeRange,
+      includeSnippets: params.includeSnippets ?? false,
     });
 
     // Merge using configurable weights
@@ -1237,8 +1550,38 @@ export class Memory {
 
       if (isCurrent) {
         await this.storage.update(entry.id, { superseded: false });
+        if (this.ftsStore) {
+          try {
+            this.ftsStore.index({
+              id: entry.id,
+              content: entry.content,
+              summary: entry.summary,
+              category: entry.category,
+              namespace: entry.namespace,
+              domain: entry.domain,
+              topic: entry.topic,
+              subtopic: entry.subtopic,
+              createdAt: entry.createdAt,
+            });
+          } catch (ftsErr) {
+            log.debug("FTS re-index failed for rolled-back current version (non-fatal)", {
+              id: entry.id,
+              error: ftsErr instanceof Error ? ftsErr.message : String(ftsErr),
+            });
+          }
+        }
       } else if (shouldBeSuperseded) {
         await this.storage.update(entry.id, { superseded: true });
+        if (this.ftsStore) {
+          try {
+            this.ftsStore.delete(entry.id);
+          } catch (ftsErr) {
+            log.debug("FTS delete failed for rolled-back superseded version (non-fatal)", {
+              id: entry.id,
+              error: ftsErr instanceof Error ? ftsErr.message : String(ftsErr),
+            });
+          }
+        }
       }
     }
 
@@ -2083,6 +2426,7 @@ export class Memory {
     total: number;
     byType: Record<EntryType, number>;
     byCategory: Record<string, number>;
+    fts?: { totalEntries: number; dbSizeBytes: number };
   }> {
     await this.init();
 
@@ -2103,10 +2447,22 @@ export class Memory {
       byCategory[cat] = await this.storage.count({ type: "memory", category: cat });
     }
 
+    let fts: { totalEntries: number; dbSizeBytes: number } | undefined;
+    if (this.ftsStore) {
+      try {
+        fts = this.ftsStore.stats();
+      } catch (ftsErr) {
+        log.debug("FTS stats failed (non-fatal)", {
+          error: ftsErr instanceof Error ? ftsErr.message : String(ftsErr),
+        });
+      }
+    }
+
     return {
       total,
       byType: byType as Record<EntryType, number>,
       byCategory,
+      ...(fts ? { fts } : {}),
     };
   }
 


### PR DESCRIPTION
## What
- Adds Memory.search modes: auto / semantic / keyword / hybrid (keyword uses SQLite FTS fast-path; hybrid merges keyword + semantic).
- Fixes Qdrant filter range operator normalization and adds `withVector` option for `get()` (default false).
- Improves FTS filtering (subtopic + timeRange) and optional snippets; keeps FTS index in sync on save/delete/rollback.
- Extends `/memory/search` to accept `mode`, `includeVectors`, `includeSnippets` and returns optional `snippet`; `/memory/stats` returns optional `fts`.
- Adds benchmark runner (`bun run bench`) with memory benches + OpenAI-compatible streaming inference bench.
  - Bench disables config dependency installs via `AGENT_CORE_DISABLE_CONFIG_DEPENDENCY_INSTALL=1` to avoid mutating config dirs.

## How To Test
- `cd packages/agent-core && bun test`
- `cd packages/agent-core && bun run build && ./script/verify-binary.sh`
- `cd packages/agent-core && bun run bench --durationSeconds 10 --seedCount 500 --concurrency 5` (requires Qdrant at `QDRANT_URL`)

Refs #206
