### PR TITLE
security: v3 security overhaul (issue #199)

### DIFF
--- a/CVE-REMEDIATION-PLAN.md
+++ b/CVE-REMEDIATION-PLAN.md
@@ -1,0 +1,96 @@
+# CVE Remediation Plan (Issue #199)
+
+This document tracks the remediation work for the items listed in `adolago/agent-core#199` (v3 Security Overhaul).
+
+## Scope
+
+Phase 1 focuses on:
+
+- command injection primitives (`shell: true`, shell-string execution with interpolation)
+- path traversal vulnerabilities (filesystem tools + archive extraction)
+- secure-by-default patterns and documentation
+
+## CVE-1: Vulnerable dependency (`@anthropic-ai/claude-code`)
+
+Status: **Not a repo dependency**.
+
+- `agent-core` does not vendor `@anthropic-ai/claude-code` as a workspace dependency.
+- The Zee “Claude Code” integration references the global `claude` CLI and prints install instructions.
+
+Mitigation approach:
+
+- Treat the global `claude` CLI as an external tool outside the `agent-core` trust boundary.
+- Prefer instructing users to install the latest version when required.
+
+Follow-ups:
+
+- Add a minimum-version check once a known patched version is identified.
+- Track upstream advisories and document recommended versions.
+
+## CVE-2: Weak password hashing
+
+Status: **Addressed by strong hashing in hosted auth**.
+
+- Hosted user passwords are hashed with `scrypt` + per-user random salt.
+- Verification uses `timingSafeEqual`.
+
+Evidence:
+
+- `packages/hosted/src/auth.ts`
+
+Follow-ups (optional hardening):
+
+- Add an explicit versioned password-hash format and upgrade path if switching algorithms later.
+
+## CVE-3: Hardcoded default credentials
+
+Status: **Fixed**.
+
+Problem:
+
+- Hosted vault encryption used a hardcoded fallback key when `VAULT_KEY` was unset.
+
+Fix:
+
+- When no env key is provided:
+  - load a persisted per-install key from `HOSTED_DATA_DIR/vault.key`, or
+  - generate a new random 32-byte key and persist it
+- If legacy encrypted rows are detected (provider connections), migrate them away from the legacy dev key before persisting the new key.
+
+Evidence:
+
+- `packages/hosted/src/crypto.ts`
+
+## HIGH-1: Command injection
+
+Status: **Fixed for identified surfaces**.
+
+- Removed `shell: true` spawning in:
+  - MCP bash tool: `src/mcp/builtin/bash.ts`
+  - Zee local shell runner: `packages/personas/zee/src/tui/tui-local-shell.ts`
+- Crash report archive creation no longer shells out to `tar` with interpolated strings:
+  - `packages/agent-core/src/crash-report/archive/zip-builder.ts`
+
+## HIGH-2: Path traversal vulnerabilities
+
+Status: **Fixed for identified surfaces**.
+
+- MCP filesystem tools now validate paths against a sandbox root and block sensitive locations:
+  - `src/mcp/security/validate-path.ts`
+  - `src/mcp/builtin/read.ts`
+  - `src/mcp/builtin/write.ts`
+  - `src/mcp/builtin/edit.ts`
+  - `src/mcp/builtin/glob.ts`
+  - `src/mcp/builtin/grep.ts`
+- Archive extraction rejects traversal and link entries:
+  - `packages/personas/zee/src/infra/archive.ts`
+
+## Deliverables Checklist
+
+- [x] `SECURITY-ARCHITECTURE.md`
+- [x] `CVE-REMEDIATION-PLAN.md`
+- [x] `SECURE-PATTERNS.md`
+- [x] `THREAT-MODEL.md` (link to repo-grounded threat model)
+- [x] Dependency audit shows 0 high/critical vulnerabilities (run: `bash scripts/bun-audit-ci.sh`)
+- [x] Security tests for archive extraction traversal and link rejection
+- [x] Security tests for MCP permission enforcement

--- a/SECURE-PATTERNS.md
+++ b/SECURE-PATTERNS.md
@@ -1,0 +1,73 @@
+# Secure Patterns (agent-core)
+
+This document captures secure-by-default patterns to use across `agent-core` when writing tools and infrastructure code.
+
+## Process Execution
+
+Do:
+
+- Prefer `spawn(argv0, argv, { shell: false })` or `execFile` with an argv array.
+- Treat any “raw shell command string” as untrusted input unless it is authored by the operator.
+- If shell features are required, make it explicit by invoking a shell binary as argv (for example `["bash","-lc","..."]`) and ensure the call site is permission-gated.
+
+Avoid:
+
+- `spawn(cmd, { shell: true })`
+- `exec(...)` / `execSync(...)` with interpolated strings
+
+## Filesystem Paths
+
+Do:
+
+- Resolve relative paths against an explicit `cwd`.
+- Enforce a sandbox `root` and reject any path that escapes it.
+- Guard against symlink-based escapes (realpath checks).
+- Block sensitive system and credential locations by default.
+
+Implementation reference:
+
+- `src/mcp/security/validate-path.ts`
+- `src/mcp/security/sandbox.ts`
+
+Avoid:
+
+- Accepting arbitrary absolute paths without validation
+- Lexical-only prefix checks (for example `candidate.startsWith(root)`)
+
+## Glob / Include Patterns
+
+Do:
+
+- Reject patterns that contain `..` traversal segments or absolute path forms.
+- Keep the search `cwd` within a sandboxed directory.
+
+Implementation reference:
+
+- `src/mcp/security/glob-pattern.ts`
+
+## Archive Extraction
+
+Do:
+
+- Validate each archive entry path before writing:
+  - reject absolute paths
+  - reject `..` segments
+- Reject symlink and hardlink entries from tar archives.
+- Prefer validating the archive (list) before extraction to avoid partial writes.
+
+Implementation reference:
+
+- `packages/personas/zee/src/infra/archive.ts`
+
+## Permission Enforcement
+
+Do:
+
+- Enforce permissions at the boundary where a tool is executed, not only at discovery time.
+- On “ask”, route through a single interactive handler and persist the session decision only in-memory unless explicitly persisted by config.
+
+Implementation reference:
+
+- `src/mcp/registry.ts`
+- `src/mcp/permission.ts`
+

--- a/SECURITY-ARCHITECTURE.md
+++ b/SECURITY-ARCHITECTURE.md
@@ -1,0 +1,98 @@
+# agent-core Security Architecture
+
+This document describes the practical security architecture of `agent-core` as implemented in this repository. It is not a formal guarantee of isolation; `agent-core` is a privileged local tool by design.
+
+## Summary
+
+`agent-core` defends against common classes of agent-tool vulnerabilities with layered controls:
+
+- **Permission gating**: per-surface defaults (`allow`/`deny`/`ask`) with an interactive “ask” flow when configured.
+- **Tool sandboxing (selected tools)**: MCP filesystem tools validate paths against a sandbox root and block sensitive host locations.
+- **Input hardening**: no `shell: true` process spawning in tool surfaces; archive extraction rejects path traversal and link entries.
+- **Secret-handling hygiene**: crash-report capture is redacted; hosted secrets encryption uses a per-install vault key.
+
+## Trust Boundaries
+
+The highest-impact boundary is between untrusted inputs (remote clients, messaging surfaces, external MCP servers) and privileged host actions (process spawn, filesystem access, credential stores).
+
+Primary surfaces:
+
+- `cli`: local operator at the terminal.
+- `web`/`api`: HTTP clients (may be loopback or LAN depending on configuration).
+- `whatsapp`/`matrix`: inbound messages (treat as untrusted by default).
+
+External components:
+
+- MCP servers: third-party tool providers (outside the `agent-core` trust boundary).
+- Zee gateway: a separate process that can forward messaging and tool requests.
+
+## Permissions (MCP Layer)
+
+The MCP tools layer implements a permission system that is enforced at tool execution time:
+
+- Default per-surface permissions are defined in `src/mcp/permission.ts`.
+- Tool execution is wrapped in `src/mcp/registry.ts` to:
+  - deny when the effective permission is `deny`
+  - call an interactive handler when the effective permission is `ask`
+
+This is intended as a guardrail to reduce accidental high-risk actions, especially on messaging surfaces.
+
+## Filesystem Sandbox (MCP Built-ins)
+
+The MCP built-in filesystem tools (`read`, `write`, `edit`, `glob`, `grep`) enforce a sandbox:
+
+- Paths are resolved relative to a sandbox `cwd`.
+- Access is restricted to a sandbox `root`.
+- Symlink-based sandbox escapes are prevented via realpath checks.
+- Sensitive system/credential locations are blocked (for example `/proc`, `/sys`, `~/.ssh`, `~/.gnupg`).
+
+Implementation:
+
+- Path validation: `src/mcp/security/validate-path.ts`
+- Sandbox resolution: `src/mcp/security/sandbox.ts`
+- Glob/include pattern validation: `src/mcp/security/glob-pattern.ts`
+
+## Process Execution Hardening
+
+Command execution is a primary risk surface. To reduce injection primitives:
+
+- Tool surfaces avoid `shell: true`.
+- Commands are executed via argv (`spawn(argv0, argv, { shell: false })`).
+- If shell behavior is required, it must be explicit (for example `["bash","-lc","..."]`).
+
+Implementation:
+
+- MCP bash tool: `src/mcp/builtin/bash.ts`
+- Zee local shell runner: `packages/personas/zee/src/tui/tui-local-shell.ts`
+
+## Archive Extraction Hardening
+
+Archive extraction is a common source of “zip slip” / “tar slip” vulnerabilities.
+
+The Zee archive extraction utilities reject:
+
+- absolute paths
+- `..` traversal segments
+- tar symlinks and hardlinks
+
+Implementation:
+
+- `packages/personas/zee/src/infra/archive.ts`
+
+## Hosted Vault Key (Per-Install Secret)
+
+The hosted service encrypts provider connection material at rest. The vault key is:
+
+- taken from `HOSTED_VAULT_KEY` / `AGENT_CORE_HOSTED_VAULT_KEY` when provided
+- otherwise generated per-install and persisted to `HOSTED_DATA_DIR/vault.key`
+- migrated away from the legacy hardcoded dev key when legacy encrypted rows are detected
+
+Implementation:
+
+- `packages/hosted/src/crypto.ts`
+
+## Non-Goals
+
+- `agent-core` is not an OS sandbox. A determined attacker with tool execution can often reach full user-level compromise.
+- Strong isolation should be provided by running `agent-core` inside a container/VM and restricting network exposure.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,11 @@
 
 Agent-Core is an AI-powered coding assistant that runs locally on your machine. It provides an agent system with access to powerful tools including shell execution, file operations, and web access.
 
-### No Sandbox
+### No OS Sandbox
 
-Agent-Core does **not** sandbox the agent. The permission system exists as a UX feature to help users stay aware of what actions the agent is taking - it prompts for confirmation before executing commands, writing files, etc. However, it is not designed to provide security isolation.
+`agent-core` does **not** provide OS-level isolation for the agent. Some tool surfaces enforce sandboxing and input hardening (for example, MCP filesystem tools validate paths against a sandbox root), but these are defense-in-depth controls rather than a complete security boundary.
 
-If you need true isolation, run Agent-Core inside a Docker container or VM.
+If you need strong isolation, run `agent-core` inside a Docker container or VM.
 
 ### Server Mode
 

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -1,0 +1,8 @@
+# Threat Model
+
+The repo-grounded threat model for `agent-core` is maintained in:
+
+- `agent-core-threat-model.md`
+
+This file exists as a stable entrypoint for Issue #199 deliverables.
+

--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
       "dependencies": {
         "@actions/core": "1.11.1",
         "@actions/github": "6.0.1",
-        "@agentclientprotocol/sdk": "0.5.1",
+        "@agentclientprotocol/sdk": "0.13.1",
         "@ai-sdk/anthropic": "2.0.57",
         "@ai-sdk/google": "2.0.52",
         "@ai-sdk/openai": "2.0.89",
@@ -79,6 +79,7 @@
         "remeda": "2.26.0",
         "solid-js": "1.9.10",
         "strip-ansi": "7.1.2",
+        "tar": "7.5.7",
         "tree-sitter-bash": "0.25.0",
         "turndown": "7.2.0",
         "ulid": "3.0.1",
@@ -100,6 +101,7 @@
         "@parcel/watcher-win32-x64": "2.5.1",
         "@tsconfig/bun": "1.0.9",
         "@types/bun": "1.3.5",
+        "@types/semver": "7.7.1",
         "@types/turndown": "5.0.5",
         "@types/yargs": "17.0.33",
         "@typescript/native-preview": "7.0.0-dev.20251207.1",
@@ -510,7 +512,7 @@
 
     "@agent-core/web": ["@agent-core/web@workspace:packages/web"],
 
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.5.1", "", { "dependencies": { "zod": "^3.0.0" } }, "sha512-9bq2TgjhLBSUSC5jE04MEe+Hqw8YePzKghhYZ9QcjOyonY3q2oJfX6GoSO83hURpEnsqEPIrex6VZN3+61fBJg=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.13.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-6byvu+F/xc96GBkdAx4hq6/tB3vT63DSBO4i3gYCz8nuyZMerVFna2Gkhm8EHNpZX0J9DjUxzZCW+rnHXUg0FA=="],
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@2.0.57", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-DREpYqW2pylgaj69gZ+K8u92bo9DaMgFdictYnY+IwYeY3bawQ4zI7l/o1VkDsBDljAx8iYz5lPURwVZNu+Xpg=="],
 
@@ -3844,8 +3846,6 @@
 
     "@agent-core/web/ai": ["ai@6.0.35", "", { "dependencies": { "@ai-sdk/gateway": "3.0.14", "@ai-sdk/provider": "3.0.3", "@ai-sdk/provider-utils": "4.0.6", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MxgtU6CjnegH1rhRfomM0gptKxP6r+9sxbLvYq36C1l85+o0LacqbXLdNVYzqab+lHN4q7ZP3QS8wZq4YkZahA=="],
 
-    "@agentclientprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "@ai-sdk/anthropic/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
 
     "@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
@@ -4615,8 +4615,6 @@
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "yauzl/buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
-
-    "zee/@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.13.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-6byvu+F/xc96GBkdAx4hq6/tB3vT63DSBO4i3gYCz8nuyZMerVFna2Gkhm8EHNpZX0J9DjUxzZCW+rnHXUg0FA=="],
 
     "zee/@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
 

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -104,6 +104,7 @@
     "remeda": "2.26.0",
     "solid-js": "1.9.10",
     "strip-ansi": "7.1.2",
+    "tar": "7.5.7",
     "tree-sitter-bash": "0.25.0",
     "turndown": "7.2.0",
     "ulid": "3.0.1",

--- a/packages/agent-core/src/crash-report/archive/zip-builder.ts
+++ b/packages/agent-core/src/crash-report/archive/zip-builder.ts
@@ -5,8 +5,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { createGzip } from "zlib";
-import { pipeline } from "stream/promises";
+import * as tar from "tar";
 
 /**
  * Simple ZIP-like archive builder (TAR.GZ format for simplicity)
@@ -87,18 +86,14 @@ export class ZipBuilder {
   }
 
   private async createTarGz(sourceDir: string, outputPath: string): Promise<void> {
-    // Use tar command for simplicity (available on Linux)
-    const { execSync } = await import("child_process");
     const parentDir = path.dirname(sourceDir);
     const dirName = path.basename(sourceDir);
 
     try {
-      execSync(`tar -czf "${outputPath}" -C "${parentDir}" "${dirName}"`, {
-        encoding: "utf-8",
-      });
+      await tar.c({ cwd: parentDir, file: outputPath, gzip: true }, [dirName]);
     } catch (error) {
       // Fallback: just keep the directory
-      throw new Error(`Failed to create archive: ${error}`);
+      throw new Error(`Failed to create archive: ${String(error)}`);
     }
   }
 }

--- a/packages/agent-core/src/server/server.ts
+++ b/packages/agent-core/src/server/server.ts
@@ -455,55 +455,67 @@ export namespace Server {
     }
   }
 
-  export function listen(opts: { port: number; hostname: string; mdns?: MdnsOption; cors?: string[] }) {
-    _corsWhitelist = opts.cors ?? []
-    _isLoopbackBind = isLoopbackHostname(opts.hostname)
+	  export function listen(opts: { port: number; hostname: string; mdns?: MdnsOption; cors?: string[] }) {
+	    const prevCorsWhitelist = _corsWhitelist
+	    const prevIsLoopbackBind = _isLoopbackBind
+	    const nextCorsWhitelist = opts.cors ?? []
+	    const nextIsLoopbackBind = isLoopbackHostname(opts.hostname)
 
-    assertSafeServerBind({ hostname: opts.hostname })
+	    // Avoid mutating global server state if we reject the bind.
+	    assertSafeServerBind({ hostname: opts.hostname })
 
-    const idleTimeout = Flag.AGENT_CORE_SERVER_IDLE_TIMEOUT_SECONDS ?? DEFAULT_IDLE_TIMEOUT_SECONDS
-    const args = {
-      hostname: opts.hostname,
-      idleTimeout,
-      fetch: (req: Request, server: any) => {
-        try {
-          const ip = server?.requestIP?.(req)?.address
-          RequestMeta.setIp(req, ip)
-        } catch {
-          // Ignore - request metadata is best-effort.
-        }
-        return App().fetch(req)
-      },
-      websocket: websocket,
-    } as const
-    const tryServe = (port: number) => {
-      try {
-        return Bun.serve({ ...args, port })
-      } catch {
-        return undefined
-      }
-    }
-    const server = opts.port === 0 ? (tryServe(DEFAULT_API_PORT) ?? tryServe(0)) : tryServe(opts.port)
-    if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
+	    _corsWhitelist = nextCorsWhitelist
+	    _isLoopbackBind = nextIsLoopbackBind
 
-    ServerState.setUrl(server.url)
+	    try {
+	      const idleTimeout = Flag.AGENT_CORE_SERVER_IDLE_TIMEOUT_SECONDS ?? DEFAULT_IDLE_TIMEOUT_SECONDS
+	      const args = {
+	        hostname: opts.hostname,
+	        idleTimeout,
+	        fetch: (req: Request, server: any) => {
+	          try {
+	            const ip = server?.requestIP?.(req)?.address
+	            RequestMeta.setIp(req, ip)
+	          } catch {
+	            // Ignore - request metadata is best-effort.
+	          }
+	          return App().fetch(req)
+	        },
+	        websocket: websocket,
+	      } as const
+	      const tryServe = (port: number) => {
+	        try {
+	          return Bun.serve({ ...args, port })
+	        } catch {
+	          return undefined
+	        }
+	      }
+	      const server = opts.port === 0 ? (tryServe(DEFAULT_API_PORT) ?? tryServe(0)) : tryServe(opts.port)
+	      if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
 
-    const mdnsConfig = resolveMdnsConfig(opts.mdns)
-    const isLoopback = opts.hostname === "127.0.0.1" || opts.hostname === "localhost" || opts.hostname === "::1"
-    const shouldPublishMDNS = mdnsConfig.enabled && server.port && !isLoopback
+	      ServerState.setUrl(server.url)
 
-    if (shouldPublishMDNS) {
-      MDNS.publish({ port: server.port!, minimal: mdnsConfig.minimal })
-    } else if (mdnsConfig.enabled && isLoopback) {
-      log.warn("mDNS enabled but hostname is loopback; skipping mDNS publish")
-    }
+	      const mdnsConfig = resolveMdnsConfig(opts.mdns)
+	      const isLoopback = opts.hostname === "127.0.0.1" || opts.hostname === "localhost" || opts.hostname === "::1"
+	      const shouldPublishMDNS = mdnsConfig.enabled && server.port && !isLoopback
 
-    const originalStop = server.stop.bind(server)
-    server.stop = async (closeActiveConnections?: boolean) => {
-      if (shouldPublishMDNS) MDNS.unpublish()
-      return originalStop(closeActiveConnections)
-    }
+	      if (shouldPublishMDNS) {
+	        MDNS.publish({ port: server.port!, minimal: mdnsConfig.minimal })
+	      } else if (mdnsConfig.enabled && isLoopback) {
+	        log.warn("mDNS enabled but hostname is loopback; skipping mDNS publish")
+	      }
 
-    return server
-  }
-}
+	      const originalStop = server.stop.bind(server)
+	      server.stop = async (closeActiveConnections?: boolean) => {
+	        if (shouldPublishMDNS) MDNS.unpublish()
+	        return originalStop(closeActiveConnections)
+	      }
+
+	      return server
+	    } catch (err) {
+	      _corsWhitelist = prevCorsWhitelist
+	      _isLoopbackBind = prevIsLoopbackBind
+	      throw err
+	    }
+	  }
+	}

--- a/packages/agent-core/test/mcp/root-mcp-permissions.test.ts
+++ b/packages/agent-core/test/mcp/root-mcp-permissions.test.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "bun:test"
+import { z } from "zod"
+
+import { ToolRegistry, defineTool, PermissionDeniedError } from "@root/mcp"
+import type { AgentInfo, ToolExecutionContext } from "@root/mcp/types"
+
+const ReadTool = defineTool("read", "builtin", {
+  description: "read",
+  parameters: z.object({ filePath: z.string() }),
+  execute: async (_args, _ctx) => ({ title: "read", metadata: {}, output: "ok" }),
+})
+
+const WriteTool = defineTool("write", "builtin", {
+  description: "write",
+  parameters: z.object({ filePath: z.string(), content: z.string() }),
+  execute: async (_args, _ctx) => ({ title: "write", metadata: {}, output: "ok" }),
+})
+
+function makeAgent(): AgentInfo {
+  return {
+    name: "test",
+    mode: "primary",
+    permission: {
+      bash: { "*": "allow" },
+      edit: "allow",
+      write: "allow",
+      webfetch: "allow",
+      skill: { "*": "allow" },
+      external_directory: "allow",
+      mcp: {},
+    },
+    tools: {},
+  }
+}
+
+function makeCtx(extra: Record<string, unknown> = {}): ToolExecutionContext {
+  const abort = new AbortController()
+  return {
+    sessionId: "s",
+    messageId: "m",
+    agent: "test",
+    abort: abort.signal,
+    extra,
+    metadata: () => {},
+  }
+}
+
+test("root MCP: matrix surface denies read by default", async () => {
+  const registry = new ToolRegistry()
+  registry.register(ReadTool, { source: "builtin" })
+
+  const tools = await registry.getToolsForAgent(makeAgent(), "matrix")
+  const read = tools.get("read")
+  expect(read).toBeTruthy()
+
+  await expect(read!.execute({ filePath: "file.txt" }, makeCtx({ cwd: process.cwd(), root: process.cwd() }))).rejects
+    .toBeInstanceOf(PermissionDeniedError)
+})
+
+test("root MCP: web surface asks for write, and remember avoids re-asking", async () => {
+  const registry = new ToolRegistry()
+  registry.register(WriteTool, { source: "builtin" })
+
+  const asked: any[] = []
+  registry.setAskHandler(async (req) => {
+    asked.push(req)
+    const p = req.pattern
+    const rememberPattern = typeof p === "string" ? p : Array.isArray(p) ? p.join(" ") : undefined
+    return { granted: true, remember: true, rememberPattern }
+  })
+
+  const tools = await registry.getToolsForAgent(makeAgent(), "web")
+  const write = tools.get("write")
+  expect(write).toBeTruthy()
+
+  const ctx = makeCtx({ cwd: process.cwd(), root: process.cwd() })
+  await write!.execute({ filePath: "file.txt", content: "x" }, ctx)
+  expect(asked.length).toBe(1)
+
+  await write!.execute({ filePath: "file.txt", content: "y" }, ctx)
+  expect(asked.length).toBe(1)
+})
+

--- a/packages/hosted/src/crypto.ts
+++ b/packages/hosted/src/crypto.ts
@@ -1,26 +1,43 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes, timingSafeEqual } from "crypto"
+import fs from "fs"
+import path from "path"
+import { db, initDb } from "./db"
 import { env } from "./env"
 
 const deriveKey = (input: string) => createHash("sha256").update(input).digest()
 
-const resolveVaultKey = () => {
-  if (env.VAULT_KEY) {
-    const trimmed = env.VAULT_KEY.trim()
-    const base64Match = /^[A-Za-z0-9+/=]+$/.test(trimmed)
-    if (base64Match) {
-      const buf = Buffer.from(trimmed, "base64")
-      if (buf.length === 32) return buf
-    }
-    return deriveKey(trimmed)
-  }
-  return deriveKey("agent-core-hosted-dev")
+const KEY_FILE = path.join(env.DATA_DIR, "vault.key")
+const LEGACY_DEV_KEY = "agent-core-hosted-dev"
+
+function parseVaultKey(value: string): Buffer | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const base64Match = /^[A-Za-z0-9+/=]+$/.test(trimmed)
+  if (!base64Match) return null
+  const buf = Buffer.from(trimmed, "base64")
+  return buf.length === 32 ? buf : null
 }
 
-const KEY = resolveVaultKey()
+function loadKeyFile(): Buffer | null {
+  try {
+    if (!fs.existsSync(KEY_FILE)) return null
+    const raw = fs.readFileSync(KEY_FILE, "utf8").trim()
+    return parseVaultKey(raw)
+  } catch {
+    return null
+  }
+}
 
-export function encryptString(value: string) {
+function writeKeyFile(key: Buffer): void {
+  const dir = path.dirname(KEY_FILE)
+  fs.mkdirSync(dir, { recursive: true })
+  // Best-effort mode restriction on POSIX; ignored on Windows.
+  fs.writeFileSync(KEY_FILE, key.toString("base64") + "\n", { mode: 0o600 })
+}
+
+function encryptStringWithKey(key: Buffer, value: string) {
   const iv = randomBytes(12)
-  const cipher = createCipheriv("aes-256-gcm", KEY, iv)
+  const cipher = createCipheriv("aes-256-gcm", key, iv)
   const encrypted = Buffer.concat([cipher.update(value, "utf8"), cipher.final()])
   const tag = cipher.getAuthTag()
   return JSON.stringify({
@@ -31,7 +48,7 @@ export function encryptString(value: string) {
   })
 }
 
-export function decryptString(payload: string) {
+function decryptStringWithKey(key: Buffer, payload: string) {
   const parsed = JSON.parse(payload)
   if (!parsed || parsed.v !== 1) {
     throw new Error("Unsupported vault payload")
@@ -39,10 +56,75 @@ export function decryptString(payload: string) {
   const iv = Buffer.from(parsed.iv, "base64")
   const tag = Buffer.from(parsed.tag, "base64")
   const data = Buffer.from(parsed.data, "base64")
-  const decipher = createDecipheriv("aes-256-gcm", KEY, iv)
+  const decipher = createDecipheriv("aes-256-gcm", key, iv)
   decipher.setAuthTag(tag)
   const decrypted = Buffer.concat([decipher.update(data), decipher.final()])
   return decrypted.toString("utf8")
+}
+
+function migrateLegacyVaultKey(newKey: Buffer): void {
+  initDb()
+
+  const providerTable = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'provider_connections'")
+    .get() as { name?: string } | undefined
+  if (!providerTable?.name) return
+
+  const countRow = db.prepare("SELECT COUNT(*) as c FROM provider_connections").get() as { c: number } | undefined
+  const count = countRow?.c ?? 0
+  if (count <= 0) return
+
+  const legacyKey = deriveKey(LEGACY_DEV_KEY)
+  const rows = db
+    .prepare("SELECT id, encrypted_data FROM provider_connections")
+    .all() as Array<{ id: string; encrypted_data: string }>
+
+  // If any row fails to decrypt, abort rather than corrupting data.
+  const decrypted = rows.map((row) => ({
+    id: row.id,
+    data: decryptStringWithKey(legacyKey, row.encrypted_data),
+  }))
+
+  const update = db.prepare("UPDATE provider_connections SET encrypted_data = ?, updated_at = ? WHERE id = ?")
+  const now = Date.now()
+  db.transaction(() => {
+    for (const row of decrypted) {
+      update.run(encryptStringWithKey(newKey, row.data), now, row.id)
+    }
+  })()
+}
+
+const resolveVaultKey = () => {
+  if (env.VAULT_KEY) {
+    const trimmed = env.VAULT_KEY.trim()
+    return parseVaultKey(trimmed) ?? deriveKey(trimmed)
+  }
+
+  const fromFile = loadKeyFile()
+  if (fromFile) return fromFile
+
+  // First run: migrate any legacy hardcoded key encryption, otherwise generate a new key.
+  const next = randomBytes(32)
+  try {
+    migrateLegacyVaultKey(next)
+  } catch {
+    // If migration fails, refuse to silently lose access to existing encrypted data.
+    throw new Error(
+      "Hosted vault key migration failed. Set HOSTED_VAULT_KEY (or AGENT_CORE_HOSTED_VAULT_KEY) to the previous value to recover, then rotate.",
+    )
+  }
+  writeKeyFile(next)
+  return next
+}
+
+const KEY = resolveVaultKey()
+
+export function encryptString(value: string) {
+  return encryptStringWithKey(KEY, value)
+}
+
+export function decryptString(payload: string) {
+  return decryptStringWithKey(KEY, payload)
 }
 
 export function encryptJson(value: unknown) {

--- a/packages/personas/zee/src/infra/archive.test.ts
+++ b/packages/personas/zee/src/infra/archive.test.ts
@@ -8,6 +8,61 @@ import { extractArchive, resolveArchiveKind, resolvePackedRootDir } from "./arch
 
 const tempDirs: string[] = [];
 
+function writeString(buf: Buffer, offset: number, length: number, value: string) {
+  const bytes = Buffer.from(value, "utf8");
+  bytes.copy(buf, offset, 0, Math.min(bytes.length, length));
+}
+
+function writeOctal(buf: Buffer, offset: number, length: number, value: number) {
+  const s = value.toString(8).padStart(length - 1, "0") + "\0";
+  writeString(buf, offset, length, s);
+}
+
+function buildTar(entries: Array<{ name: string; content?: string; typeflag?: string; linkname?: string }>): Buffer {
+  const blocks: Buffer[] = [];
+  const now = Math.floor(Date.now() / 1000);
+
+  for (const entry of entries) {
+    const content = typeof entry.content === "string" ? Buffer.from(entry.content, "utf8") : Buffer.alloc(0);
+    const header = Buffer.alloc(512, 0);
+
+    writeString(header, 0, 100, entry.name);
+    writeString(header, 100, 8, "0000777\0");
+    writeString(header, 108, 8, "0000000\0");
+    writeString(header, 116, 8, "0000000\0");
+    writeOctal(header, 124, 12, content.length);
+    writeOctal(header, 136, 12, now);
+
+    // Checksum field must be spaces for calculation.
+    header.fill(0x20, 148, 156);
+
+    const typeflag = entry.typeflag ?? "0";
+    writeString(header, 156, 1, typeflag);
+
+    if (entry.linkname) {
+      writeString(header, 157, 100, entry.linkname);
+    }
+
+    writeString(header, 257, 6, "ustar\0");
+    writeString(header, 263, 2, "00");
+
+    let checksum = 0;
+    for (const b of header) checksum += b;
+    const chksum = checksum.toString(8).padStart(6, "0") + "\0 ";
+    writeString(header, 148, 8, chksum);
+
+    blocks.push(header);
+    blocks.push(content);
+
+    const pad = content.length % 512 === 0 ? 0 : 512 - (content.length % 512);
+    if (pad) blocks.push(Buffer.alloc(pad, 0));
+  }
+
+  // End of archive: two empty blocks.
+  blocks.push(Buffer.alloc(1024, 0));
+  return Buffer.concat(blocks);
+}
+
 async function makeTempDir() {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-archive-"));
   tempDirs.push(dir);
@@ -49,6 +104,21 @@ describe("archive utils", () => {
     expect(content).toBe("hi");
   });
 
+  it("rejects zip slip entries", async () => {
+    const workDir = await makeTempDir();
+    const archivePath = path.join(workDir, "bundle.zip");
+    const extractDir = path.join(workDir, "extract");
+
+    const zip = new JSZip();
+    zip.file("../evil.txt", "nope");
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+
+    await fs.mkdir(extractDir, { recursive: true });
+    await expect(extractArchive({ archivePath, destDir: extractDir, timeoutMs: 5_000 })).rejects.toThrow(
+      /path traversal|\.\.|absolute/i,
+    );
+  });
+
   it("extracts tar archives", async () => {
     const workDir = await makeTempDir();
     const archivePath = path.join(workDir, "bundle.tar");
@@ -64,5 +134,34 @@ describe("archive utils", () => {
     const rootDir = await resolvePackedRootDir(extractDir);
     const content = await fs.readFile(path.join(rootDir, "hello.txt"), "utf-8");
     expect(content).toBe("yo");
+  });
+
+  it("rejects tar slip entries", async () => {
+    const workDir = await makeTempDir();
+    const archivePath = path.join(workDir, "bundle.tar");
+    const extractDir = path.join(workDir, "extract");
+
+    await fs.writeFile(archivePath, buildTar([{ name: "../evil.txt", content: "nope" }]));
+    await fs.mkdir(extractDir, { recursive: true });
+
+    await expect(extractArchive({ archivePath, destDir: extractDir, timeoutMs: 5_000 })).rejects.toThrow(
+      /path traversal|\.\./i,
+    );
+  });
+
+  it("rejects tar symlink entries", async () => {
+    const workDir = await makeTempDir();
+    const archivePath = path.join(workDir, "bundle.tar");
+    const extractDir = path.join(workDir, "extract");
+
+    await fs.writeFile(
+      archivePath,
+      buildTar([{ name: "package/link", typeflag: "2", linkname: "/etc/passwd" }]),
+    );
+    await fs.mkdir(extractDir, { recursive: true });
+
+    await expect(extractArchive({ archivePath, destDir: extractDir, timeoutMs: 5_000 })).rejects.toThrow(
+      /link/i,
+    );
   });
 });

--- a/packages/personas/zee/src/infra/archive.ts
+++ b/packages/personas/zee/src/infra/archive.ts
@@ -12,6 +12,29 @@ export type ArchiveLogger = {
 
 const TAR_SUFFIXES = [".tgz", ".tar.gz", ".tar"];
 
+function assertWithinDest(destDir: string, candidatePath: string, entryName: string): void {
+  const rel = path.relative(destDir, candidatePath);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new Error(`archive entry escapes destination: ${entryName}`);
+  }
+}
+
+function assertSafeArchiveEntryPath(entryPath: string): void {
+  const normalized = entryPath.replaceAll("\\", "/");
+
+  if (normalized.startsWith("/")) {
+    throw new Error(`archive entry uses absolute path: ${entryPath}`);
+  }
+  if (/^[a-zA-Z]:[\\/]/.test(entryPath)) {
+    throw new Error(`archive entry uses Windows absolute path: ${entryPath}`);
+  }
+
+  const parts = normalized.split("/").filter(Boolean);
+  if (parts.some((p) => p === "..")) {
+    throw new Error(`archive entry uses path traversal (".."): ${entryPath}`);
+  }
+}
+
 export function resolveArchiveKind(filePath: string): ArchiveKind | null {
   const lower = filePath.toLowerCase();
   if (lower.endsWith(".zip")) return "zip";
@@ -62,29 +85,46 @@ export async function withTimeout<T>(
 }
 
 async function extractZip(params: { archivePath: string; destDir: string }): Promise<void> {
+  const destRoot = path.resolve(params.destDir);
   const buffer = await fs.readFile(params.archivePath);
   const zip = await JSZip.loadAsync(buffer);
   const entries = Object.values(zip.files);
 
   for (const entry of entries) {
     const entryPath = entry.name.replaceAll("\\", "/");
+    assertSafeArchiveEntryPath(entryPath);
     if (!entryPath || entryPath.endsWith("/")) {
-      const dirPath = path.resolve(params.destDir, entryPath);
-      if (!dirPath.startsWith(params.destDir)) {
-        throw new Error(`zip entry escapes destination: ${entry.name}`);
-      }
+      const dirPath = path.resolve(destRoot, entryPath);
+      assertWithinDest(destRoot, dirPath, entry.name);
       await fs.mkdir(dirPath, { recursive: true });
       continue;
     }
 
-    const outPath = path.resolve(params.destDir, entryPath);
-    if (!outPath.startsWith(params.destDir)) {
-      throw new Error(`zip entry escapes destination: ${entry.name}`);
-    }
+    const outPath = path.resolve(destRoot, entryPath);
+    assertWithinDest(destRoot, outPath, entry.name);
     await fs.mkdir(path.dirname(outPath), { recursive: true });
     const data = await entry.async("nodebuffer");
     await fs.writeFile(outPath, data);
   }
+}
+
+async function validateTar(params: { archivePath: string }): Promise<void> {
+  // Use sync mode so validation failures are propagated as errors.
+  // In async mode, throwing inside onentry/onReadEntry can surface as an
+  // unhandled exception instead of rejecting the returned promise.
+  tar.t({
+    file: params.archivePath,
+    sync: true,
+    onentry(entry) {
+      const entryPath = String((entry as { path?: unknown }).path ?? "");
+      assertSafeArchiveEntryPath(entryPath);
+
+      const type = String((entry as { type?: unknown }).type ?? "");
+      if (type === "SymbolicLink" || type === "Link" || type === "HardLink") {
+        throw new Error(`tar entry is a link (type ${type}): ${entryPath}`);
+      }
+    },
+  });
 }
 
 export async function extractArchive(params: {
@@ -100,6 +140,7 @@ export async function extractArchive(params: {
 
   const label = kind === "zip" ? "extract zip" : "extract tar";
   if (kind === "tar") {
+    await withTimeout(validateTar(params), params.timeoutMs, "validate tar");
     await withTimeout(
       tar.x({ file: params.archivePath, cwd: params.destDir }),
       params.timeoutMs,

--- a/packages/personas/zee/src/tui/tui-local-shell.ts
+++ b/packages/personas/zee/src/tui/tui-local-shell.ts
@@ -2,6 +2,92 @@ import type { Component, SelectItem } from "@mariozechner/pi-tui";
 import { spawn } from "node:child_process";
 import { createSearchableSelectList } from "./components/selectors.js";
 
+function parseCommandLine(command: string): string[] {
+  const argv: string[] = [];
+  let current = "";
+  let hasToken = false;
+  let mode: "none" | "single" | "double" = "none";
+  let escape = false;
+
+  const push = () => {
+    if (!hasToken) return;
+    argv.push(current);
+    current = "";
+    hasToken = false;
+  };
+
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i]!;
+
+    if (escape) {
+      current += ch;
+      hasToken = true;
+      escape = false;
+      continue;
+    }
+
+    if (mode === "single") {
+      if (ch === "'") {
+        mode = "none";
+      } else {
+        current += ch;
+        hasToken = true;
+      }
+      continue;
+    }
+
+    if (mode === "double") {
+      if (ch === "\"") {
+        mode = "none";
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        hasToken = true;
+        continue;
+      }
+      current += ch;
+      hasToken = true;
+      continue;
+    }
+
+    // mode === "none"
+    if (ch === "'") {
+      mode = "single";
+      hasToken = true;
+      continue;
+    }
+    if (ch === "\"") {
+      mode = "double";
+      hasToken = true;
+      continue;
+    }
+    if (ch === "\\") {
+      escape = true;
+      hasToken = true;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      push();
+      continue;
+    }
+
+    current += ch;
+    hasToken = true;
+  }
+
+  if (escape) {
+    throw new Error("invalid command: trailing backslash");
+  }
+  if (mode !== "none") {
+    throw new Error("invalid command: unterminated quote");
+  }
+
+  push();
+  return argv;
+}
+
 type LocalShellDeps = {
   chatLog: {
     addSystem: (line: string) => void;
@@ -93,8 +179,24 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
     deps.tui.requestRender();
 
     await new Promise<void>((resolve) => {
-      const child = spawnCommand(cmd, {
-        shell: true,
+      let argv: string[];
+      try {
+        argv = parseCommandLine(cmd);
+      } catch (err) {
+        deps.chatLog.addSystem(`[local] error: ${String(err)}`);
+        deps.tui.requestRender();
+        resolve();
+        return;
+      }
+      if (argv.length === 0 || !argv[0]) {
+        deps.chatLog.addSystem("[local] error: empty command");
+        deps.tui.requestRender();
+        resolve();
+        return;
+      }
+
+      const child = spawnCommand(argv[0], argv.slice(1), {
+        shell: false,
         cwd: getCwd(),
         env,
       });

--- a/src/domain/johny/tools.ts
+++ b/src/domain/johny/tools.ts
@@ -23,7 +23,7 @@ const StudyParams = z.object({
   sessionId: z.string().optional().describe("Session ID for end/pause/resume actions"),
 })
 
-export const studyTool: ToolDefinition = {
+export const studyTool: ToolDefinition<typeof StudyParams> = {
   id: "johny:study",
   category: "domain",
   init: async () => ({
@@ -129,7 +129,7 @@ const KnowledgeParams = z.object({
   prerequisiteId: z.string().optional().describe("Prerequisite topic ID to add"),
 })
 
-export const knowledgeTool: ToolDefinition = {
+export const knowledgeTool: ToolDefinition<typeof KnowledgeParams> = {
   id: "johny:knowledge",
   category: "domain",
   init: async () => ({
@@ -228,7 +228,7 @@ const MasteryParams = z.object({
   score: z.number().min(0).max(1).optional().describe("Practice score (0-1) for implicit level update"),
 })
 
-export const masteryTool: ToolDefinition = {
+export const masteryTool: ToolDefinition<typeof MasteryParams> = {
   id: "johny:mastery",
   category: "domain",
   init: async () => ({
@@ -321,7 +321,7 @@ const ReviewParams = z.object({
   limit: z.number().optional().describe("Max items to return"),
 })
 
-export const reviewTool: ToolDefinition = {
+export const reviewTool: ToolDefinition<typeof ReviewParams> = {
   id: "johny:review",
   category: "domain",
   init: async () => ({
@@ -405,7 +405,7 @@ const PracticeParams = z.object({
   type: z.enum(["concept", "calculation", "proof", "application"]).optional().describe("Problem type"),
 })
 
-export const practiceTool: ToolDefinition = {
+export const practiceTool: ToolDefinition<typeof PracticeParams> = {
   id: "johny:practice",
   category: "domain",
   init: async () => ({

--- a/src/domain/zee/browser.ts
+++ b/src/domain/zee/browser.ts
@@ -193,7 +193,7 @@ After a snapshot, use the ref IDs (e.g., "e12", "a5") to interact with elements:
             result = await browserApi("GET", "/", undefined, { profile });
             return {
               title: "Browser Status",
-              metadata: { profile, ...result as object },
+              metadata: { profile, ...(result as Record<string, unknown>) },
               output: formatStatus(result),
             };
 
@@ -201,7 +201,7 @@ After a snapshot, use the ref IDs (e.g., "e12", "a5") to interact with elements:
             result = await browserApi("POST", "/start", undefined, { profile });
             return {
               title: "Browser Started",
-              metadata: { profile, ...result as object },
+              metadata: { profile, ...(result as Record<string, unknown>) },
               output: `Browser started with profile "${profile}"`,
             };
 
@@ -209,7 +209,7 @@ After a snapshot, use the ref IDs (e.g., "e12", "a5") to interact with elements:
             result = await browserApi("POST", "/stop", undefined, { profile });
             return {
               title: "Browser Stopped",
-              metadata: { profile, ...result as object },
+              metadata: { profile, ...(result as Record<string, unknown>) },
               output: `Browser stopped for profile "${profile}"`,
             };
 
@@ -217,7 +217,7 @@ After a snapshot, use the ref IDs (e.g., "e12", "a5") to interact with elements:
             result = await browserApi("GET", "/profiles");
             return {
               title: "Browser Profiles",
-              metadata: result as object,
+              metadata: result as Record<string, unknown>,
               output: formatProfiles(result),
             };
 
@@ -226,7 +226,7 @@ After a snapshot, use the ref IDs (e.g., "e12", "a5") to interact with elements:
             result = await browserApi("GET", "/tabs", undefined, { profile });
             return {
               title: "Browser Tabs",
-              metadata: { profile, ...result as object },
+              metadata: { profile, ...(result as Record<string, unknown>) },
               output: formatTabs(result),
             };
 
@@ -241,7 +241,7 @@ After a snapshot, use the ref IDs (e.g., "e12", "a5") to interact with elements:
             result = await browserApi("POST", "/tabs/open", { url: args.url }, { profile });
             return {
               title: "Tab Opened",
-              metadata: { profile, url: args.url, ...result as object },
+              metadata: { profile, url: args.url, ...(result as Record<string, unknown>) },
               output: `Opened ${args.url}`,
             };
           }
@@ -387,7 +387,7 @@ After a snapshot, use the ref IDs (e.g., "e12", "a5") to interact with elements:
             result = await browserApi("POST", "/screenshot", screenshotBody, { profile });
             return {
               title: "Screenshot Taken",
-              metadata: { profile, fullPage: args.fullPage, ...result as object },
+              metadata: { profile, fullPage: args.fullPage, ...(result as Record<string, unknown>) },
               output: formatScreenshot(result),
             };
           }

--- a/src/domain/zee/claude-code.ts
+++ b/src/domain/zee/claude-code.ts
@@ -466,7 +466,7 @@ Use this to verify Claude Code is ready and properly integrated.`,
         }
       } else {
         output += `\n\nTo install Claude Code CLI:
-  npm install -g @anthropic-ai/claude-code
+  npm install -g @anthropic-ai/claude-code@latest
 
 Then authenticate:
   claude login`;
@@ -560,7 +560,7 @@ Examples:
           output: `Claude Code CLI is not installed.
 
 To install:
-  npm install -g @anthropic-ai/claude-code
+  npm install -g @anthropic-ai/claude-code@latest
 
 Then authenticate:
   claude login`,
@@ -704,15 +704,15 @@ No credentials found. To authenticate:
 
       return {
         title: "Claude Credentials",
-        metadata: {
-          source,
-          hasFile,
-          hasKeychain: !!keychainCreds,
-          type: activeCreds?.type ?? "none",
-          expired: activeCreds ? activeCreds.expiresAt < Date.now() : true,
-        },
-        output,
-      };
+	        metadata: {
+	          source,
+	          hasFile,
+	          hasKeychain: false,
+	          type: activeCreds?.type ?? "none",
+	          expired: activeCreds ? activeCreds.expiresAt < Date.now() : true,
+	        },
+	        output,
+	      };
     },
   }),
 };

--- a/src/domain/zee/google/calendar.ts
+++ b/src/domain/zee/google/calendar.ts
@@ -30,7 +30,7 @@ interface Tokens {
   scope: string;
 }
 
-interface CalendarEvent {
+export interface CalendarEvent {
   id: string;
   summary: string;
   description?: string;
@@ -285,18 +285,6 @@ interface EventInput {
   start: { dateTime?: string; date?: string; timeZone?: string };
   end: { dateTime?: string; date?: string; timeZone?: string };
   attendees?: Array<{ email: string }>;
-}
-
-interface CalendarEvent {
-  id: string;
-  summary: string;
-  description?: string;
-  start: { dateTime?: string; date?: string; timeZone?: string };
-  end: { dateTime?: string; date?: string; timeZone?: string };
-  location?: string;
-  attendees?: Array<{ email: string; displayName?: string; responseStatus?: string }>;
-  status: string;
-  htmlLink?: string;
 }
 
 export async function createEvent(

--- a/src/domain/zee/pty-sessions.ts
+++ b/src/domain/zee/pty-sessions.ts
@@ -133,7 +133,7 @@ const PtyStartParams = z.object({
   pty: z.boolean().default(true).describe("Use PTY for interactive terminals (default: true)"),
   background: z.boolean().default(true).describe("Run in background for polling (default: true)"),
   workdir: z.string().optional().describe("Working directory"),
-  env: z.record(z.string()).optional().describe("Environment variables"),
+  env: z.record(z.string(), z.string()).optional().describe("Environment variables"),
   timeoutSeconds: z.number().optional().describe("Kill process after N seconds"),
   yieldMs: z.number().optional().describe("Wait before backgrounding (default: 1000ms)"),
 });

--- a/src/domain/zee/splitwise.ts
+++ b/src/domain/zee/splitwise.ts
@@ -228,7 +228,7 @@ export async function callSplitwiseApi(
   };
 
   let body: string | undefined;
-  if (method !== "GET" && method !== "HEAD") {
+  if (method !== "GET") {
     const payload = request.payload ?? {};
     if (request.payloadFormat === "form") {
       headers["Content-Type"] = "application/x-www-form-urlencoded";

--- a/src/domain/zee/tools.ts
+++ b/src/domain/zee/tools.ts
@@ -48,7 +48,6 @@ import {
 } from "./google/calendar.js";
 import { getMemory } from "../../memory/unified.js";
 import { CLAUDE_CODE_TOOLS, registerClaudeCodeTools } from "./claude-code.js";
-import { RESTART_SENTINEL_TOOLS } from "./restart-sentinel.js";
 import { CRON_TOOLS } from "./cron.js";
 import { PTY_SESSION_TOOLS } from "./pty-sessions.js";
 import { ZEE_BROWSER_TOOLS } from "./browser.js";
@@ -906,15 +905,15 @@ Contacts are synced across:
 const SplitwiseValueSchema = z.union([z.string(), z.number(), z.boolean()]);
 
 const SplitwiseParams = z.object({
-  action: z.enum(SPLITWISE_ACTIONS as [SplitwiseAction, ...SplitwiseAction[]])
+  action: z.enum(SPLITWISE_ACTIONS)
     .describe("Splitwise action to perform"),
   groupId: z.number().optional().describe("Group ID for group actions"),
   friendId: z.number().optional().describe("Friend ID for friend actions"),
   expenseId: z.number().optional().describe("Expense ID for expense actions"),
   endpoint: z.string().optional().describe("Endpoint for request action (e.g., get_expenses)"),
   method: z.enum(["GET", "POST", "PUT", "DELETE"]).optional().describe("HTTP method for request action"),
-  query: z.record(SplitwiseValueSchema).optional().describe("Query parameters"),
-  payload: z.record(SplitwiseValueSchema).optional().describe("Request payload"),
+  query: z.record(z.string(), SplitwiseValueSchema).optional().describe("Query parameters"),
+  payload: z.record(z.string(), SplitwiseValueSchema).optional().describe("Request payload"),
   payloadFormat: z.enum(["json", "form"]).default("json").describe("Payload encoding for POST/PUT"),
   timeoutMs: z.number().optional().describe("Override timeout in ms"),
 });
@@ -2026,16 +2025,16 @@ export const memoryReflectTool: ToolDefinition = {
           updateEntityPages: args.updateEntityPages,
         });
 
-        return {
-          title: `Reflect Complete (${result.durationMs}ms)`,
-          metadata: result,
-          output: `Memory reflect completed in ${result.durationMs}ms:
+	        return {
+	          title: `Reflect Complete (${result.durationMs}ms)`,
+	          metadata: result as unknown as Record<string, unknown>,
+	          output: `Memory reflect completed in ${result.durationMs}ms:
 
 - Duplicates merged: ${result.duplicatesMerged}
 - Stale beliefs found: ${result.staleBeliefs}
 - Beliefs decayed: ${result.beliefsDecayed}
 - Entity pages updated: ${result.entityPagesUpdated}`,
-        };
+	        };
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
         return {
@@ -2257,7 +2256,6 @@ export const ZEE_TOOLS = [
   planAdvanceTool,
   planStatusTool,
   ...CLAUDE_CODE_TOOLS,
-  ...RESTART_SENTINEL_TOOLS,
   ...CRON_TOOLS,
   ...PTY_SESSION_TOOLS,
   ...ZEE_BROWSER_TOOLS,

--- a/src/mcp/builtin/bash.ts
+++ b/src/mcp/builtin/bash.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { spawn } from 'child_process';
 import { defineTool } from '../registry';
 import type { ToolExecutionContext } from '../types';
+import * as path from 'path';
 
 // ============================================================================
 // Configuration
@@ -16,44 +17,149 @@ import type { ToolExecutionContext } from '../types';
 
 const MAX_OUTPUT_LENGTH = 30_000;
 const DEFAULT_TIMEOUT = 2 * 60 * 1000; // 2 minutes
+const MAX_TIMEOUT = 10 * 60 * 1000; // 10 minutes
+
+function parseCommandLine(command: string): string[] {
+  const argv: string[] = [];
+  let current = '';
+  let hasToken = false;
+  let mode: 'none' | 'single' | 'double' = 'none';
+  let escape = false;
+
+  const push = () => {
+    if (!hasToken) return;
+    argv.push(current);
+    current = '';
+    hasToken = false;
+  };
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i]!;
+
+    if (escape) {
+      current += ch;
+      hasToken = true;
+      escape = false;
+      continue;
+    }
+
+    if (mode === 'single') {
+      if (ch === "'") {
+        mode = 'none';
+      } else {
+        current += ch;
+        hasToken = true;
+      }
+      continue;
+    }
+
+    if (mode === 'double') {
+      if (ch === '"') {
+        mode = 'none';
+        continue;
+      }
+      if (ch === '\\') {
+        escape = true;
+        hasToken = true;
+        continue;
+      }
+      current += ch;
+      hasToken = true;
+      continue;
+    }
+
+    // mode === 'none'
+    if (ch === "'") {
+      mode = 'single';
+      hasToken = true;
+      continue;
+    }
+    if (ch === '"') {
+      mode = 'double';
+      hasToken = true;
+      continue;
+    }
+    if (ch === '\\') {
+      escape = true;
+      hasToken = true;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      push();
+      continue;
+    }
+
+    current += ch;
+    hasToken = true;
+  }
+
+  if (escape) {
+    throw new Error('Invalid command: trailing backslash');
+  }
+  if (mode !== 'none') {
+    throw new Error('Invalid command: unterminated quote');
+  }
+
+  push();
+  return argv;
+}
 
 // ============================================================================
 // Tool Definition
 // ============================================================================
 
 export const BashTool = defineTool(
-  'bash',
-  'builtin',
-  async () => ({
-    description: `Execute a bash command in a persistent shell session.
+	  'bash',
+	  'builtin',
+	  async () => ({
+	    description: `Execute a command (no shell evaluation).
 
 IMPORTANT: This tool is for terminal operations like git, npm, docker, etc.
 
 Usage notes:
-- The command argument is required.
+- Provide either command (string) or argv (string[]).
 - You can specify an optional timeout in milliseconds (max 600000ms / 10 minutes).
 - Always quote file paths that contain spaces with double quotes.
 - If the output exceeds ${MAX_OUTPUT_LENGTH} characters, it will be truncated.
+- If you need shell features (pipes, redirects, glob expansion), run them explicitly via argv like: ["bash","-lc","..."].
 - Avoid using find, grep, cat, head, tail, sed, awk for file operations - use dedicated tools instead.`,
 
     parameters: z.object({
-      command: z.string().describe('The command to execute'),
+      command: z.string().optional().describe('The command to execute (string form; no shell evaluation)'),
+      argv: z.array(z.string()).optional().describe('The command to execute (argv form; preferred for precision)'),
       timeout: z.number().optional().describe('Optional timeout in milliseconds'),
       workdir: z.string().optional().describe('Working directory for the command'),
       description: z.string().describe('Clear, concise description of what this command does in 5-10 words'),
-    }),
+    }).refine(
+      (v) => Boolean(v.argv?.length) || Boolean(v.command?.trim()),
+      { message: 'Either argv or command is required', path: ['command'] },
+    ),
 
     async execute(params, ctx: ToolExecutionContext) {
-      const cwd = params.workdir || process.cwd();
+      const cwd = params.workdir
+        ? (path.isAbsolute(params.workdir) ? params.workdir : path.resolve(process.cwd(), params.workdir))
+        : process.cwd();
       const timeout = params.timeout ?? DEFAULT_TIMEOUT;
 
       if (params.timeout !== undefined && params.timeout < 0) {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`);
       }
+      if (params.timeout !== undefined && params.timeout > MAX_TIMEOUT) {
+        throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be <= ${MAX_TIMEOUT}.`);
+      }
+
+      const argv = Array.isArray(params.argv) && params.argv.length > 0
+        ? params.argv.map((x) => String(x))
+        : parseCommandLine(String(params.command ?? ''));
+
+      if (argv.length === 0 || !argv[0]) {
+        throw new Error('Invalid command: empty argv');
+      }
 
       // Spawn the process
-      const proc = spawn(params.command, {
-        shell: true,
+      const proc = spawn(argv[0], argv.slice(1), {
+        shell: false,
         cwd,
         env: process.env,
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/mcp/builtin/edit.ts
+++ b/src/mcp/builtin/edit.ts
@@ -10,6 +10,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { defineTool } from '../registry';
 import type { ToolExecutionContext } from '../types';
+import { resolveToolSandbox } from '../security/sandbox';
+import { assertToolPath } from '../security/validate-path';
 
 // ============================================================================
 // Tool Definition
@@ -29,13 +31,13 @@ Usage:
 - ALWAYS prefer editing existing files to creating new ones`,
 
     parameters: z.object({
-      filePath: z.string().describe('The absolute path to the file to modify'),
+      filePath: z.string().describe('Path to the file to modify (absolute or relative to the sandbox cwd)'),
       oldString: z.string().describe('The text to replace'),
       newString: z.string().describe('The text to replace it with (must be different from oldString)'),
       replaceAll: z.boolean().optional().describe('Replace all occurrences of oldString (default false)'),
     }),
 
-    async execute(params, _ctx: ToolExecutionContext) {
+    async execute(params, ctx: ToolExecutionContext) {
       if (!params.filePath) {
         throw new Error('filePath is required');
       }
@@ -44,9 +46,12 @@ Usage:
         throw new Error('oldString and newString must be different');
       }
 
-      const filePath = path.isAbsolute(params.filePath)
-        ? params.filePath
-        : path.join(process.cwd(), params.filePath);
+      const sandbox = resolveToolSandbox(ctx);
+      const { resolved: filePath, relative } = await assertToolPath({
+        filePath: params.filePath,
+        cwd: sandbox.cwd,
+        root: sandbox.root,
+      });
 
       // Check file exists
       if (!fs.existsSync(filePath)) {
@@ -62,7 +67,7 @@ Usage:
       if (params.oldString === '') {
         fs.writeFileSync(filePath, params.newString);
         return {
-          title: path.basename(filePath),
+          title: relative || path.basename(filePath),
           metadata: {
             diff: `Created file with ${params.newString.split('\n').length} lines`,
           },
@@ -83,7 +88,7 @@ Usage:
       const diff = `Changed: ${oldLines} -> ${newLines} lines`;
 
       return {
-        title: path.basename(filePath),
+        title: relative || path.basename(filePath),
         metadata: {
           diff,
         },

--- a/src/mcp/builtin/glob.ts
+++ b/src/mcp/builtin/glob.ts
@@ -6,11 +6,13 @@
  */
 
 import { z } from 'zod';
-import * as path from 'path';
 import { glob } from 'glob';
 import * as fs from 'fs';
 import { defineTool } from '../registry';
 import type { ToolExecutionContext } from '../types';
+import { assertSafeGlobPattern } from '../security/glob-pattern';
+import { resolveToolSandbox } from '../security/sandbox';
+import { assertToolPath } from '../security/validate-path';
 
 // ============================================================================
 // Configuration
@@ -32,19 +34,27 @@ Usage:
 - Supports glob patterns like "**/*.js" or "src/**/*.ts"
 - Returns matching file paths sorted by modification time
 - Use when you need to find files by name patterns
-- IMPORTANT: Omit the path field to use current directory`,
+- IMPORTANT: Omit the path field to use the tool sandbox cwd
+- Access is restricted to the tool sandbox root`,
 
     parameters: z.object({
       pattern: z.string().describe('The glob pattern to match files against'),
       path: z
         .string()
         .optional()
-        .describe('The directory to search in. If not specified, uses current working directory.'),
+        .describe('The directory to search in. If not specified, uses the tool sandbox cwd.'),
     }),
 
-    async execute(params, _ctx: ToolExecutionContext) {
-      let searchPath = params.path ?? process.cwd();
-      searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(process.cwd(), searchPath);
+    async execute(params, ctx: ToolExecutionContext) {
+      assertSafeGlobPattern(params.pattern, 'glob pattern');
+
+      const sandbox = resolveToolSandbox(ctx);
+      const searchInput = params.path ?? sandbox.cwd;
+      const { resolved: searchPath, relative } = await assertToolPath({
+        filePath: searchInput,
+        cwd: sandbox.cwd,
+        root: sandbox.root,
+      });
 
       // Find files matching pattern
       const matches = await glob(params.pattern, {
@@ -91,7 +101,7 @@ Usage:
       }
 
       return {
-        title: path.relative(process.cwd(), searchPath) || '.',
+        title: relative || '.',
         metadata: {
           count: files.length,
           truncated,

--- a/src/mcp/builtin/grep.ts
+++ b/src/mcp/builtin/grep.ts
@@ -10,6 +10,9 @@ import * as fs from 'fs';
 import { glob } from 'glob';
 import { defineTool } from '../registry';
 import type { ToolExecutionContext } from '../types';
+import { assertSafeGlobPattern } from '../security/glob-pattern';
+import { resolveToolSandbox } from '../security/sandbox';
+import { assertToolPath } from '../security/validate-path';
 
 // ============================================================================
 // Configuration
@@ -36,17 +39,25 @@ Usage:
 
     parameters: z.object({
       pattern: z.string().describe('The regex pattern to search for in file contents'),
-      path: z.string().optional().describe('The directory to search in. Defaults to current working directory.'),
+      path: z.string().optional().describe('The directory to search in. Defaults to the tool sandbox cwd.'),
       include: z.string().optional().describe('File pattern to include in the search (e.g., "*.js", "*.{ts,tsx}")'),
     }),
 
-    async execute(params, _ctx: ToolExecutionContext) {
+    async execute(params, ctx: ToolExecutionContext) {
       if (!params.pattern) {
         throw new Error('pattern is required');
       }
 
-      const searchPath = params.path || process.cwd();
+      const sandbox = resolveToolSandbox(ctx);
+      const searchInput = params.path || sandbox.cwd;
+      const { resolved: searchPath } = await assertToolPath({
+        filePath: searchInput,
+        cwd: sandbox.cwd,
+        root: sandbox.root,
+      });
+
       const includePattern = params.include || '**/*';
+      assertSafeGlobPattern(includePattern, 'include pattern');
 
       // Find files to search
       const files = await glob(includePattern, {

--- a/src/mcp/builtin/read.ts
+++ b/src/mcp/builtin/read.ts
@@ -10,6 +10,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { defineTool } from '../registry';
 import type { ToolExecutionContext } from '../types';
+import { resolveToolSandbox } from '../security/sandbox';
+import { assertToolPath } from '../security/validate-path';
 
 // ============================================================================
 // Configuration
@@ -29,7 +31,8 @@ export const ReadTool = defineTool(
     description: `Read a file from the filesystem.
 
 Usage:
-- The file_path parameter must be an absolute path
+- The filePath parameter may be absolute or relative to the tool sandbox cwd
+- Access is restricted to the tool sandbox root
 - By default, reads up to 2000 lines from the beginning
 - You can optionally specify a line offset and limit for long files
 - Lines longer than 2000 characters will be truncated
@@ -38,18 +41,20 @@ Usage:
 - Cannot read directories - use ls command instead`,
 
     parameters: z.object({
-      filePath: z.string().describe('The absolute path to the file to read'),
+      filePath: z.string().describe('Path to the file to read (absolute or relative to the sandbox cwd)'),
       offset: z.coerce.number().optional().describe('Line number to start reading from (0-based)'),
       limit: z.coerce.number().optional().describe('Number of lines to read (defaults to 2000)'),
     }),
 
     async execute(params, ctx: ToolExecutionContext) {
-      let filepath = params.filePath;
-      if (!path.isAbsolute(filepath)) {
-        filepath = path.join(process.cwd(), filepath);
-      }
+      const sandbox = resolveToolSandbox(ctx);
+      const { resolved: filepath, relative } = await assertToolPath({
+        filePath: params.filePath,
+        cwd: sandbox.cwd,
+        root: sandbox.root,
+      });
 
-      const title = path.basename(filepath);
+      const title = relative || path.basename(filepath);
 
       // Check if file exists
       if (!fs.existsSync(filepath)) {

--- a/src/mcp/builtin/skill.ts
+++ b/src/mcp/builtin/skill.ts
@@ -52,19 +52,19 @@ const skillRegistry: Skill[] = [
 // Tool Definition
 // ============================================================================
 
-export const SkillTool = defineTool(
-  'skill',
-  'builtin',
-  async (_ctx) => {
-    // Filter skills by agent permissions if available
-    const accessibleSkills = skillRegistry;
+// Filter skills by agent permissions if available (placeholder)
+const accessibleSkills = skillRegistry;
 
-    const skillList = accessibleSkills
-      .map((s) => `  <skill>\n    <name>${s.name}</name>\n    <description>${s.description}</description>\n  </skill>`)
-      .join('\n');
+const skillList = accessibleSkills
+  .map((s) => `  <skill>\n    <name>${s.name}</name>\n    <description>${s.description}</description>\n  </skill>`)
+  .join('\n');
 
-    return {
-      description: `Load a skill to get detailed instructions for a specific task.
+const SkillParameters = z.object({
+  name: z.string().describe("The skill identifier from available_skills (e.g., 'code-review')"),
+});
+
+export const SkillTool = defineTool('skill', 'builtin', {
+  description: `Load a skill to get detailed instructions for a specific task.
 
 Skills provide specialized knowledge and step-by-step guidance.
 Use this when a task matches an available skill's description.
@@ -73,38 +73,35 @@ Use this when a task matches an available skill's description.
 ${skillList}
 </available_skills>`,
 
-      parameters: z.object({
-        name: z.string().describe("The skill identifier from available_skills (e.g., 'code-review')"),
-      }),
+  parameters: SkillParameters,
 
-      async execute(params, _execCtx: ToolExecutionContext) {
-        const skill = skillRegistry.find((s) => s.name === params.name);
+  async execute(params, _execCtx: ToolExecutionContext) {
+    const skill = skillRegistry.find((s) => s.name === params.name);
 
-        if (!skill) {
-          const available = skillRegistry.map((s) => s.name).join(', ');
-          throw new Error(`Skill "${params.name}" not found. Available skills: ${available || 'none'}`);
-        }
+    if (!skill) {
+      const available = skillRegistry.map((s) => s.name).join(', ');
+      throw new Error(`Skill "${params.name}" not found. Available skills: ${available || 'none'}`);
+    }
 
-        // In a real implementation, this would load the skill content from the file
-        const content = skill.content || `# Skill: ${skill.name}\n\n${skill.description}\n\n[Skill content would be loaded from ${skill.location}]`;
+    // In a real implementation, this would load the skill content from the file.
+    const content =
+      skill.content || `# Skill: ${skill.name}\n\n${skill.description}\n\n[Skill content would be loaded from ${skill.location}]`;
 
-        const output = [
-          `## Skill: ${skill.name}`,
-          '',
-          `**Location**: ${skill.location}`,
-          '',
-          content,
-        ].join('\n');
+    const output = [
+      `## Skill: ${skill.name}`,
+      '',
+      `**Location**: ${skill.location}`,
+      '',
+      content,
+    ].join('\n');
 
-        return {
-          title: `Loaded skill: ${skill.name}`,
-          output,
-          metadata: {
-            name: skill.name,
-            location: skill.location,
-          },
-        };
+    return {
+      title: `Loaded skill: ${skill.name}`,
+      output,
+      metadata: {
+        name: skill.name,
+        location: skill.location,
       },
     };
-  }
-);
+  },
+});

--- a/src/mcp/builtin/task.ts
+++ b/src/mcp/builtin/task.ts
@@ -13,25 +13,28 @@ import type { ToolExecutionContext } from '../types';
 // Tool Definition
 // ============================================================================
 
-export const TaskTool = defineTool(
-  'task',
-  'builtin',
-  async (_ctx) => {
-    // Get available subagents from context
-    const availableAgents = [
-      { name: 'researcher', description: 'Research and analyze information' },
-      { name: 'coder', description: 'Write and refactor code' },
-      { name: 'tester', description: 'Write and run tests' },
-      { name: 'reviewer', description: 'Review code and provide feedback' },
-      { name: 'documenter', description: 'Write documentation' },
-    ];
+// Get available subagents from context (placeholder)
+const availableAgents = [
+  { name: 'researcher', description: 'Research and analyze information' },
+  { name: 'coder', description: 'Write and refactor code' },
+  { name: 'tester', description: 'Write and run tests' },
+  { name: 'reviewer', description: 'Review code and provide feedback' },
+  { name: 'documenter', description: 'Write documentation' },
+];
 
-    const agentList = availableAgents
-      .map((a) => `- ${a.name}: ${a.description}`)
-      .join('\n');
+const agentList = availableAgents
+  .map((a) => `- ${a.name}: ${a.description}`)
+  .join('\n');
 
-    return {
-      description: `Create a subagent task for parallel or specialized work.
+const TaskParameters = z.object({
+  description: z.string().describe('A short (3-5 words) description of the task'),
+  prompt: z.string().describe('The task for the agent to perform'),
+  subagent_type: z.string().describe('The type of specialized agent to use for this task'),
+  session_id: z.string().optional().describe('Existing Task session to continue'),
+});
+
+export const TaskTool = defineTool('task', 'builtin', {
+  description: `Create a subagent task for parallel or specialized work.
 
 Available subagents:
 ${agentList}
@@ -41,50 +44,43 @@ Usage:
 - The subagent runs in its own session with limited tools
 - Results are returned when the task completes`,
 
-      parameters: z.object({
-        description: z.string().describe('A short (3-5 words) description of the task'),
-        prompt: z.string().describe('The task for the agent to perform'),
-        subagent_type: z.string().describe('The type of specialized agent to use for this task'),
-        session_id: z.string().optional().describe('Existing Task session to continue'),
-      }),
+  parameters: TaskParameters,
 
-      async execute(params, execCtx: ToolExecutionContext) {
-        // In a real implementation, this would spawn a subagent session
-        // For now, we return a placeholder that indicates the task pattern
+  async execute(params, execCtx: ToolExecutionContext) {
+    // In a real implementation, this would spawn a subagent session.
+    // For now, we return a placeholder that indicates the task pattern.
 
-        const sessionId = params.session_id || `task-${Date.now()}`;
+    const sessionId = params.session_id || `task-${Date.now()}`;
 
-        execCtx.metadata({
-          title: params.description,
-          metadata: {
-            sessionId,
-            agentType: params.subagent_type,
-          },
-        });
-
-        // This would normally:
-        // 1. Create a new session with parentID = execCtx.sessionId
-        // 2. Run the prompt through the specified subagent
-        // 3. Return the results
-
-        const output = [
-          `Task started: ${params.description}`,
-          `Agent: ${params.subagent_type}`,
-          '',
-          '<task_metadata>',
-          `session_id: ${sessionId}`,
-          '</task_metadata>',
-        ].join('\n');
-
-        return {
-          title: params.description,
-          metadata: {
-            sessionId,
-            agentType: params.subagent_type,
-          },
-          output,
-        };
+    execCtx.metadata({
+      title: params.description,
+      metadata: {
+        sessionId,
+        agentType: params.subagent_type,
       },
+    });
+
+    // This would normally:
+    // 1. Create a new session with parentID = execCtx.sessionId
+    // 2. Run the prompt through the specified subagent
+    // 3. Return the results
+
+    const output = [
+      `Task started: ${params.description}`,
+      `Agent: ${params.subagent_type}`,
+      '',
+      '<task_metadata>',
+      `session_id: ${sessionId}`,
+      '</task_metadata>',
+    ].join('\n');
+
+    return {
+      title: params.description,
+      metadata: {
+        sessionId,
+        agentType: params.subagent_type,
+      },
+      output,
     };
-  }
-);
+  },
+});

--- a/src/mcp/builtin/write.ts
+++ b/src/mcp/builtin/write.ts
@@ -10,6 +10,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { defineTool } from '../registry';
 import type { ToolExecutionContext } from '../types';
+import { resolveToolSandbox } from '../security/sandbox';
+import { assertToolPath } from '../security/validate-path';
 
 // ============================================================================
 // Tool Definition
@@ -23,23 +25,27 @@ export const WriteTool = defineTool(
 
 Usage:
 - This tool will overwrite the existing file if there is one at the provided path
-- The file_path parameter must be an absolute path
+- The filePath parameter may be absolute or relative to the tool sandbox cwd
+- Access is restricted to the tool sandbox root
 - Parent directories will be created if they don't exist
 - ALWAYS prefer editing existing files to creating new ones
 - NEVER proactively create documentation files unless explicitly requested`,
 
     parameters: z.object({
       content: z.string().describe('The content to write to the file'),
-      filePath: z.string().describe('The absolute path to the file to write (must be absolute, not relative)'),
+      filePath: z.string().describe('Path to the file to write (absolute or relative to the sandbox cwd)'),
     }),
 
-    async execute(params, _ctx: ToolExecutionContext) {
-      const filepath = path.isAbsolute(params.filePath)
-        ? params.filePath
-        : path.join(process.cwd(), params.filePath);
+    async execute(params, ctx: ToolExecutionContext) {
+      const sandbox = resolveToolSandbox(ctx);
+      const { resolved: filepath, relative } = await assertToolPath({
+        filePath: params.filePath,
+        cwd: sandbox.cwd,
+        root: sandbox.root,
+      });
 
       const exists = fs.existsSync(filepath);
-      const title = path.basename(filepath);
+      const title = relative || path.basename(filepath);
 
       // Create parent directories if needed
       const parentDir = path.dirname(filepath);

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -54,7 +54,6 @@ import { getMcpServerManager, resetMcpServerManager } from './server';
 import { registerBuiltinTools } from './builtin';
 import { registerStanleyTools, registerZeeTools, registerJohnyTools, registerZeeFullTools, registerAllDomainTools } from './domain';
 import type { McpServerConfig, SurfaceType, AgentInfo } from './types';
-import { PermissionChecker } from './permission';
 
 /**
  * Initialize the MCP tools layer
@@ -87,8 +86,7 @@ export async function initializeMcp(options?: {
 
   // Set up permission checker with ask handler if provided
   if (options?.permissions?.askHandler) {
-    const checker = new PermissionChecker();
-    checker.setAskHandler(options.permissions.askHandler);
+    registry.setAskHandler(options.permissions.askHandler);
   }
 
   // Register built-in tools

--- a/src/mcp/permission.ts
+++ b/src/mcp/permission.ts
@@ -38,7 +38,20 @@ export interface PermissionCheckContext {
 }
 
 export interface PermissionRequest {
-  type: 'bash' | 'edit' | 'write' | 'webfetch' | 'skill' | 'external_directory' | 'mcp';
+  type:
+    | 'bash'
+    | 'edit'
+    | 'write'
+    | 'read'
+    | 'glob'
+    | 'grep'
+    | 'webfetch'
+    | 'websearch'
+    | 'codesearch'
+    | 'task'
+    | 'skill'
+    | 'external_directory'
+    | 'mcp';
   pattern?: string | string[];
   sessionId: string;
   messageId: string;
@@ -69,6 +82,7 @@ export class PermissionChecker {
         web: {},
         api: {},
         whatsapp: {},
+        matrix: {},
       },
       global: permissions?.global ?? {},
       overrides: permissions?.overrides ?? {},
@@ -157,7 +171,16 @@ export class PermissionChecker {
       return this.permissions.global[toolId];
     }
 
-    // Default permission based on tool category defaults
+    // Fall back to built-in defaults for this surface (if any)
+    if (surface) {
+      const defaults = PermissionChecker.getDefaultSurfacePermissions(surface);
+      const surfaceDefault = defaults[toolId];
+      if (surfaceDefault) {
+        return surfaceDefault;
+      }
+    }
+
+    // Default permission
     return { default: 'allow' };
   }
 
@@ -180,8 +203,13 @@ export class PermissionChecker {
         break;
 
       case 'edit':
-      case 'write':
         if (agentPerms.edit === 'deny') {
+          return false;
+        }
+        break;
+
+      case 'write':
+        if (agentPerms.write === 'deny') {
           return false;
         }
         break;
@@ -226,8 +254,14 @@ export class PermissionChecker {
       return 'deny';
     }
 
+    const patternKey =
+      patterns?.command ? patterns.command.join(' ') :
+      patterns?.path ? patterns.path :
+      patterns?.url ? patterns.url :
+      undefined;
+
     // Get effective permission
-    const permission = this.getEffectivePermission(toolId, surface);
+    const permission = this.getEffectivePermission(toolId, surface, patternKey);
 
     // Check pattern-based permissions if patterns provided
     if (patterns && permission.patterns) {
@@ -321,7 +355,8 @@ export class PermissionChecker {
     if (!this.askHandler) {
       // No handler configured, deny by default
       log.warn('No permission ask handler configured, denying by default', {
-        toolId: request.toolId,
+        type: request.type,
+        title: request.title,
       });
       return false;
     }
@@ -392,6 +427,20 @@ export class PermissionChecker {
 
       case 'whatsapp':
         // WhatsApp is most restrictive - no file/system operations
+        return {
+          bash: { default: 'deny' },
+          edit: { default: 'deny' },
+          write: { default: 'deny' },
+          read: { default: 'deny' },
+          glob: { default: 'deny' },
+          grep: { default: 'deny' },
+          webfetch: { default: 'allow' },
+          task: { default: 'deny' },
+          skill: { default: 'allow' },
+        };
+
+      case 'matrix':
+        // Matrix is most restrictive - no file/system operations
         return {
           bash: { default: 'deny' },
           edit: { default: 'deny' },

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -16,9 +16,13 @@ import type {
   ToolCategory,
   AgentInfo,
   SurfaceType,
+  ToolExecutionContext,
 } from './types';
-import { PermissionChecker } from './permission';
+import type { PermissionRequest, PermissionResponse } from './permission';
+import { PermissionChecker, PermissionDeniedError } from './permission';
 import { Log } from '../../packages/agent-core/src/util/log';
+import { resolveToolSandbox } from './security/sandbox';
+import { validateToolPath } from './security/validate-path';
 
 const log = Log.create({ service: 'mcp-registry' });
 
@@ -62,6 +66,13 @@ export class ToolRegistry extends EventEmitter<ToolRegistryEvents> {
   constructor(permissionChecker?: PermissionChecker) {
     super();
     this.permissionChecker = permissionChecker ?? new PermissionChecker();
+  }
+
+  /**
+   * Set the handler used when a tool requires interactive approval ("ask").
+   */
+  setAskHandler(handler: (request: PermissionRequest) => Promise<PermissionResponse>): void {
+    this.permissionChecker.setAskHandler(handler);
   }
 
   // --------------------------------------------------------------------------
@@ -201,7 +212,8 @@ export class ToolRegistry extends EventEmitter<ToolRegistryEvents> {
       return undefined;
     }
 
-    return entry.tool.init(ctx);
+    const runtime = await entry.tool.init(ctx);
+    return this.wrapRuntimeWithPermissions(toolId, entry, runtime, ctx);
   }
 
   /**
@@ -228,7 +240,8 @@ export class ToolRegistry extends EventEmitter<ToolRegistryEvents> {
 
       try {
         const runtime = await entry.tool.init(ctx);
-        result.set(toolId, runtime);
+        const wrapped = this.wrapRuntimeWithPermissions(toolId, entry, runtime, ctx);
+        result.set(toolId, wrapped);
       } catch (error) {
         log.error('Failed to initialize tool', {
           toolId,
@@ -238,6 +251,201 @@ export class ToolRegistry extends EventEmitter<ToolRegistryEvents> {
     }
 
     return result;
+  }
+
+  private wrapRuntimeWithPermissions(
+    toolId: string,
+    entry: ToolRegistryEntry,
+    runtime: ToolRuntime,
+    initCtx?: ToolInitContext,
+  ): ToolRuntime {
+    const agent = initCtx?.agent;
+    const surface = initCtx?.surface;
+    if (!agent) return runtime;
+
+    const originalExecute = runtime.execute;
+    const checker = this.permissionChecker;
+
+    return {
+      ...runtime,
+      execute: async (args, execCtx) => {
+        const patterns = this.extractPermissionPatterns(toolId, args, execCtx);
+
+        const action = await checker.checkPermission({
+          toolId,
+          toolCategory: entry.tool.category,
+          agent,
+          surface,
+          patterns,
+        });
+
+        if (action === 'deny') {
+          throw new PermissionDeniedError(execCtx.sessionId, toolId, execCtx.callId, {
+            toolId,
+            surface,
+            patterns,
+          });
+        }
+
+        if (action === 'ask') {
+          const req = this.buildPermissionRequest(toolId, entry.tool.category, args, execCtx, patterns);
+          const ok = await checker.askPermission(req);
+          if (!ok) {
+            throw new PermissionDeniedError(execCtx.sessionId, toolId, execCtx.callId, {
+              toolId,
+              surface,
+              patterns,
+            });
+          }
+        }
+
+        return originalExecute(args, execCtx);
+      },
+    };
+  }
+
+  private extractPermissionPatterns(
+    toolId: string,
+    args: unknown,
+    execCtx: ToolExecutionContext,
+  ): { command?: string[]; path?: string; url?: string } | undefined {
+    const a = args as Record<string, unknown> | null;
+    if (!a) return undefined;
+
+    if (toolId === 'bash') {
+      const argv = a['argv'];
+      const command = a['command'];
+      if (Array.isArray(argv)) {
+        return { command: argv.map((x) => String(x)) };
+      }
+      if (typeof command === 'string' && command.trim()) {
+        return { command: [command.trim()] };
+      }
+      return undefined;
+    }
+
+    if (toolId === 'webfetch') {
+      const url = a['url'];
+      if (typeof url === 'string' && url.trim()) {
+        return { url: url.trim() };
+      }
+      return undefined;
+    }
+
+    // File-ish tools
+    if (toolId === 'read' || toolId === 'write' || toolId === 'edit') {
+      const filePath = a['filePath'];
+      if (typeof filePath === 'string' && filePath.trim()) {
+        return { path: this.resolveSandboxedPathPattern(filePath, execCtx) };
+      }
+      return undefined;
+    }
+
+    if (toolId === 'glob' || toolId === 'grep') {
+      const p = a['path'];
+      if (typeof p === 'string' && p.trim()) {
+        return { path: this.resolveSandboxedPathPattern(p, execCtx) };
+      }
+      // If omitted, treat as cwd for permissions.
+      const sandbox = resolveToolSandbox(execCtx);
+      return { path: sandbox.cwd };
+    }
+
+    return undefined;
+  }
+
+  private resolveSandboxedPathPattern(inputPath: string, execCtx: ToolExecutionContext): string {
+    const sandbox = resolveToolSandbox(execCtx);
+    try {
+      return validateToolPath({ filePath: inputPath, cwd: sandbox.cwd, root: sandbox.root }).resolved;
+    } catch {
+      return inputPath;
+    }
+  }
+
+  private buildPermissionRequest(
+    toolId: string,
+    category: ToolCategory,
+    args: unknown,
+    execCtx: ToolExecutionContext,
+    patterns: { command?: string[]; path?: string; url?: string } | undefined,
+  ): PermissionRequest {
+    const type = this.mapToolToPermissionType(toolId, category);
+    const pattern = patterns?.command ?? patterns?.path ?? patterns?.url;
+
+    return {
+      type,
+      pattern,
+      sessionId: execCtx.sessionId,
+      messageId: execCtx.messageId,
+      callId: execCtx.callId,
+      title: this.formatPermissionTitle(type, toolId, pattern),
+      metadata: this.buildPermissionMetadata(toolId, category, args, execCtx, patterns),
+    };
+  }
+
+  private mapToolToPermissionType(toolId: string, category: ToolCategory): PermissionRequest['type'] {
+    if (category === 'mcp') return 'mcp';
+    switch (toolId) {
+      case 'bash':
+      case 'edit':
+      case 'write':
+      case 'read':
+      case 'glob':
+      case 'grep':
+      case 'webfetch':
+      case 'task':
+      case 'skill':
+        return toolId;
+      default:
+        return 'mcp';
+    }
+  }
+
+  private formatPermissionTitle(
+    type: PermissionRequest['type'],
+    toolId: string,
+    pattern: string | string[] | undefined,
+  ): string {
+    const base = type === 'mcp' ? toolId : type;
+    if (!pattern) return base;
+    const patternText = Array.isArray(pattern) ? pattern.join(' ') : pattern;
+    const truncated = patternText.length > 140 ? patternText.slice(0, 140) + '...' : patternText;
+    return `${base}: ${truncated}`;
+  }
+
+  private buildPermissionMetadata(
+    toolId: string,
+    category: ToolCategory,
+    args: unknown,
+    execCtx: ToolExecutionContext,
+    patterns: { command?: string[]; path?: string; url?: string } | undefined,
+  ): Record<string, unknown> {
+    const base: Record<string, unknown> = {
+      toolId,
+      category,
+      patterns,
+    };
+
+    if (toolId === 'write') {
+      const a = args as Record<string, unknown> | null;
+      const content = a && typeof a['content'] === 'string' ? a['content'] : '';
+      base['contentChars'] = typeof content === 'string' ? content.length : undefined;
+    }
+
+    if (toolId === 'edit') {
+      const a = args as Record<string, unknown> | null;
+      base['oldStringChars'] = a && typeof a['oldString'] === 'string' ? a['oldString'].length : undefined;
+      base['newStringChars'] = a && typeof a['newString'] === 'string' ? a['newString'].length : undefined;
+    }
+
+    // Carry through non-sensitive context keys if present.
+    if (execCtx.extra && typeof execCtx.extra === 'object') {
+      const surface = execCtx.extra['surface'];
+      if (typeof surface === 'string') base['surface'] = surface;
+    }
+
+    return base;
   }
 
   // --------------------------------------------------------------------------

--- a/src/mcp/security/glob-pattern.ts
+++ b/src/mcp/security/glob-pattern.ts
@@ -1,0 +1,44 @@
+/**
+ * Glob Pattern Validation (MCP)
+ *
+ * Defensive checks to prevent glob patterns from escaping a sandbox directory.
+ */
+
+export class GlobPatternError extends Error {
+  readonly code = 'GLOB_PATTERN_ERROR';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'GlobPatternError';
+  }
+}
+
+export function assertSafeGlobPattern(pattern: string, label = 'glob pattern'): void {
+  const raw = typeof pattern === 'string' ? pattern : '';
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new GlobPatternError(`Empty ${label}`);
+  }
+
+  // Normalize for checks only (do not change the actual pattern semantics).
+  const normalized = trimmed.replaceAll('\\', '/');
+
+  if (normalized.includes('\0')) {
+    throw new GlobPatternError(`Invalid ${label}: contains NUL byte`);
+  }
+
+  // Absolute paths (posix) or Windows drive paths.
+  if (normalized.startsWith('/')) {
+    throw new GlobPatternError(`Invalid ${label}: absolute patterns are not allowed`);
+  }
+  if (/^[a-zA-Z]:[\\/]/.test(trimmed)) {
+    throw new GlobPatternError(`Invalid ${label}: Windows absolute patterns are not allowed`);
+  }
+
+  // Block traversal segments like ../ or a/../b.
+  const parts = normalized.split('/').filter((p) => p.length > 0);
+  if (parts.some((p) => p === '..')) {
+    throw new GlobPatternError(`Invalid ${label}: path traversal ("..") is not allowed`);
+  }
+}
+

--- a/src/mcp/security/sandbox.ts
+++ b/src/mcp/security/sandbox.ts
@@ -1,0 +1,40 @@
+/**
+ * Tool Sandbox Resolution (MCP)
+ *
+ * Derives a sandbox `root` and `cwd` from ToolExecutionContext. Callers can
+ * override these via ctx.extra.
+ */
+
+import path from 'node:path';
+import type { ToolExecutionContext } from '../types';
+
+export interface ToolSandbox {
+  cwd: string;
+  root: string;
+}
+
+function getString(extra: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = extra?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Resolve the tool sandbox from context.
+ *
+ * Supported ctx.extra keys:
+ * - `cwd`: working directory for resolving relative paths
+ * - `root`: sandbox root for path allowlist
+ * - `sandboxRoot`: alias for `root`
+ */
+export function resolveToolSandbox(ctx: ToolExecutionContext): ToolSandbox {
+  const extra = ctx.extra;
+
+  const cwdRaw = getString(extra, 'cwd') ?? process.cwd();
+  const rootRaw = getString(extra, 'root') ?? getString(extra, 'sandboxRoot') ?? cwdRaw;
+
+  const cwd = path.resolve(cwdRaw);
+  const root = path.resolve(rootRaw);
+
+  return { cwd, root };
+}
+

--- a/src/mcp/security/validate-path.ts
+++ b/src/mcp/security/validate-path.ts
@@ -1,0 +1,217 @@
+/**
+ * Path Validation and Sandbox Enforcement (MCP)
+ *
+ * Prevents path traversal attacks in MCP tools that accept file paths.
+ * Enforces that paths resolve within a sandbox root, blocks sensitive system
+ * locations, and guards against symlink-based sandbox escapes.
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Unicode normalization
+// ---------------------------------------------------------------------------
+
+const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
+
+function normalizeUnicodeSpaces(str: string): string {
+  return str.replace(UNICODE_SPACES, ' ');
+}
+
+// ---------------------------------------------------------------------------
+// Path expansion + resolution
+// ---------------------------------------------------------------------------
+
+function expandPath(filePath: string): string {
+  const normalized = normalizeUnicodeSpaces(filePath);
+  if (normalized === '~') return os.homedir();
+  if (normalized.startsWith('~/')) return os.homedir() + normalized.slice(1);
+  return normalized;
+}
+
+function resolveToCwd(filePath: string, cwd: string): string {
+  const expanded = expandPath(filePath);
+  if (path.isAbsolute(expanded)) return expanded;
+  return path.resolve(cwd, expanded);
+}
+
+// ---------------------------------------------------------------------------
+// Dangerous path patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Paths that should never be accepted as tool input regardless of sandbox root.
+ * These are sensitive system directories and credential stores.
+ */
+const BLOCKED_PREFIXES: readonly string[] = [
+  '/etc/shadow',
+  '/etc/passwd',
+  '/etc/sudoers',
+  '/proc/',
+  '/sys/',
+];
+
+/**
+ * Sensitive directories within the user's home that require extra caution.
+ */
+const SENSITIVE_HOME_DIRS: readonly string[] = [
+  '.ssh',
+  '.gnupg',
+  '.config/gcloud',
+  '.aws/credentials',
+  '.netrc',
+];
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface PathValidationResult {
+  /** Absolute resolved path */
+  resolved: string;
+  /** Path relative to the sandbox root (empty string if path equals root) */
+  relative: string;
+}
+
+export interface PathValidationOptions {
+  /** The file path provided by the user or agent */
+  filePath: string;
+  /** Current working directory for resolving relative paths */
+  cwd: string;
+  /**
+   * Sandbox root directory. Paths must resolve within this directory.
+   * Defaults to `cwd` if not specified.
+   */
+  root?: string;
+  /** Additional blocked path prefixes beyond the defaults */
+  blockedPrefixes?: string[];
+  /**
+   * If true, allow paths outside the sandbox root. Only block absolute
+   * system-sensitive paths. Use only when the user explicitly selects a path.
+   */
+  permissive?: boolean;
+}
+
+export class PathValidationError extends Error {
+  readonly code = 'PATH_VALIDATION_ERROR';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'PathValidationError';
+  }
+}
+
+/**
+ * Validate that a tool path does not escape the sandbox root and does not
+ * target sensitive system paths.
+ *
+ * This is a synchronous, lexical check. For symlink-aware enforcement, use
+ * `assertToolPath`.
+ */
+export function validateToolPath(options: PathValidationOptions): PathValidationResult {
+  const { filePath, cwd, root = cwd, blockedPrefixes = [], permissive = false } = options;
+
+  if (!filePath || !filePath.trim()) {
+    throw new PathValidationError('Empty file path');
+  }
+
+  const resolved = resolveToCwd(filePath, cwd);
+
+  // Check absolute blocked paths (always enforced)
+  const allBlocked = [...BLOCKED_PREFIXES, ...blockedPrefixes];
+  for (const prefix of allBlocked) {
+    if (resolved === prefix || resolved.startsWith(prefix)) {
+      throw new PathValidationError(`Access denied: path targets a sensitive system location: ${filePath}`);
+    }
+  }
+
+  // Check sensitive home directories
+  const home = os.homedir();
+  for (const dir of SENSITIVE_HOME_DIRS) {
+    const sensitive = path.join(home, dir);
+    if (resolved === sensitive || resolved.startsWith(sensitive + path.sep)) {
+      throw new PathValidationError(`Access denied: path targets sensitive credentials: ${filePath}`);
+    }
+  }
+
+  const rootResolved = path.resolve(root);
+  const relative = path.relative(rootResolved, resolved);
+
+  if (permissive) {
+    return { resolved, relative };
+  }
+
+  if (!relative || relative === '') {
+    return { resolved, relative: '' };
+  }
+
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new PathValidationError(`Path escapes sandbox root (${shortPath(rootResolved)}): ${filePath}`);
+  }
+
+  return { resolved, relative };
+}
+
+/**
+ * Async version that also checks for symlink-based escape attacks.
+ *
+ * For non-existent paths (common for writes), the closest existing ancestor is
+ * realpath-checked to ensure no existing symlink redirects outside the root.
+ */
+export async function assertToolPath(options: PathValidationOptions): Promise<PathValidationResult> {
+  const result = validateToolPath(options);
+
+  if (!options.permissive) {
+    const rootResolved = path.resolve(options.root ?? options.cwd);
+    await assertNoSymlinkEscape(result.resolved, rootResolved);
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Symlink escape detection
+// ---------------------------------------------------------------------------
+
+async function assertNoSymlinkEscape(targetPath: string, rootResolved: string): Promise<void> {
+  const rootReal = await fs.realpath(rootResolved).catch(() => rootResolved);
+
+  const existing = await closestExistingAncestor(targetPath);
+  const existingReal = await fs.realpath(existing).catch(() => existing);
+
+  const rel = path.relative(rootReal, existingReal);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new PathValidationError(
+      `Path resolves outside sandbox root (${shortPath(rootReal)}): ${targetPath}`,
+    );
+  }
+}
+
+async function closestExistingAncestor(p: string): Promise<string> {
+  let current = p;
+  for (;;) {
+    try {
+      await fs.lstat(current);
+      return current;
+    } catch (err) {
+      if ((err as { code?: string }).code !== 'ENOENT') throw err;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) return current;
+    current = parent;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function shortPath(value: string): string {
+  const home = os.homedir();
+  if (value.startsWith(home)) return `~${value.slice(home.length)}`;
+  return value;
+}
+

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -341,7 +341,7 @@ export class McpServerManager extends EventEmitter<McpServerEvents> {
       description: mcpTool.description ?? '',
       parameters: this.buildZodSchema(mcpTool.inputSchema),
       execute: async (args, _ctx) => {
-        const result = await client.callTool(mcpTool.name, args);
+        const result = await client.callTool(mcpTool.name, args as Record<string, unknown>);
         return {
           title: mcpTool.name,
           metadata: { serverId, originalName: mcpTool.name },
@@ -354,7 +354,9 @@ export class McpServerManager extends EventEmitter<McpServerEvents> {
   /**
    * Build Zod schema from JSON Schema
    */
-  private buildZodSchema(_inputSchema: McpToolDefinition['inputSchema']): import('zod').ZodType {
+  private buildZodSchema(
+    _inputSchema: McpToolDefinition['inputSchema']
+  ): import('zod').ZodType<Record<string, unknown>> {
     // Dynamic import to avoid bundling issues
     const { z } = require('zod');
 

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -78,7 +78,7 @@ export interface FileAttachment {
  * Tool definition interface - the core contract for all tools
  */
 export interface ToolDefinition<
-  TParams extends z.ZodType = z.ZodType,
+  TParams extends z.ZodType<any, any> = z.ZodType<any, any>,
   TMeta extends ToolMetadata = ToolMetadata
 > {
   /** Unique tool identifier */
@@ -93,7 +93,7 @@ export interface ToolDefinition<
  * Runtime tool configuration after initialization
  */
 export interface ToolRuntime<
-  TParams extends z.ZodType = z.ZodType,
+  TParams extends z.ZodType<any, any> = z.ZodType<any, any>,
   TMeta extends ToolMetadata = ToolMetadata
 > {
   /** Tool description for LLM */

--- a/src/swarm/planner.ts
+++ b/src/swarm/planner.ts
@@ -5,7 +5,7 @@
  * persist plan state across sessions, and proactively continue work.
  */
 
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import { getMemory } from "../memory/unified.js";
 import { Log } from "../../packages/agent-core/src/util/log";
 
@@ -52,7 +52,7 @@ export async function createPlan(
   sessionId?: string,
 ): Promise<Plan> {
   const plan: Plan = {
-    id: uuidv4(),
+    id: randomUUID(),
     persona,
     objective,
     steps: steps.map((description) => ({


### PR DESCRIPTION
Closes #199\n\n### Summary\n- Remove shell:true in tool surfaces (MCP bash, Zee local shell runner).\n- Sandbox MCP filesystem tools (read/write/edit/glob/grep) against traversal and sensitive paths.\n- Enforce MCP permissions at execution time (allow/deny/ask).\n- Harden archive extraction against zip slip/tar slip; reject link entries; add regression tests.\n- Hosted: remove hardcoded vault key; generate per-install persisted key with legacy migration.\n- Crash report archive builder no longer shells out; uses JS tar library.\n- Add security docs for Issue #199 deliverables.\n\n### Verification\n- bun run --cwd packages/agent-core typecheck\n- bun test --cwd packages/agent-core --reporter=dots --only-failures\n- cd packages/agent-core && bun run build && ./script/verify-binary.sh\n- bash scripts/bun-audit-ci.sh