### PR TITLE
🎨 Palette: Make QuestionPrompt tabs accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-10-26 - Accessible Manual Tabs
+**Learning:** The `QuestionPrompt` component uses a manual implementation of tabs for navigating questions. While functional, it lacked standard accessibility roles (`tablist`, `tab`) and states (`aria-selected`), making it opaque to screen readers compared to standard library components like `kobalte/tabs`.
+**Action:** When encountering or building manual tab-like navigation, always ensure `role="tablist"` is applied to the container and `role="tab"` with `aria-selected` is applied to interactive elements to ensure accessibility parity with standard components.

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1446,7 +1446,7 @@ function QuestionPrompt(props: { request: QuestionRequest }) {
   return (
     <div data-component="question-prompt">
       <Show when={!single()}>
-        <div data-slot="question-tabs">
+        <div data-slot="question-tabs" role="tablist" aria-label={i18n.t("ui.tool.questions")}>
           <For each={questions()}>
             {(q, index) => {
               const active = () => index() === store.tab
@@ -1457,13 +1457,21 @@ function QuestionPrompt(props: { request: QuestionRequest }) {
                   data-active={active()}
                   data-answered={answered()}
                   onClick={() => selectTab(index())}
+                  role="tab"
+                  aria-selected={active()}
                 >
                   {q.header}
                 </button>
               )
             }}
           </For>
-          <button data-slot="question-tab" data-active={confirm()} onClick={() => selectTab(questions().length)}>
+          <button
+            data-slot="question-tab"
+            data-active={confirm()}
+            onClick={() => selectTab(questions().length)}
+            role="tab"
+            aria-selected={confirm()}
+          >
             {i18n.t("ui.common.confirm")}
           </button>
         </div>
@@ -1475,11 +1483,7 @@ function QuestionPrompt(props: { request: QuestionRequest }) {
             {question()?.question}
             {multi() ? " " + i18n.t("ui.question.multiHint") : ""}
           </div>
-          <div
-            data-slot="question-options"
-            role={multi() ? "group" : "radiogroup"}
-            aria-labelledby={questionId}
-          >
+          <div data-slot="question-options" role={multi() ? "group" : "radiogroup"} aria-labelledby={questionId}>
             <For each={options()}>
               {(opt, i) => {
                 const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false


### PR DESCRIPTION
💡 What: Added ARIA roles and attributes to the manual tab implementation in `QuestionPrompt` component.
🎯 Why: To make the question navigation accessible to screen reader users, who otherwise wouldn't know these buttons function as tabs.
📸 Before/After: No visual change.
♿ Accessibility: Added `role="tablist"`, `role="tab"`, and `aria-selected` states.


---
*PR created automatically by Jules for task [14056748231771810032](https://jules.google.com/task/14056748231771810032) started by @dolagoartur*