### PR TITLE
security: control UI auth downgrade guardrails

### DIFF
--- a/packages/zee/Swabble/docs/gateway/configuration.md
+++ b/packages/zee/Swabble/docs/gateway/configuration.md
@@ -2413,6 +2413,12 @@ Notes:
 - The onboarding wizard generates a gateway token by default (even on loopback).
 - `gateway.remote.token` is **only** for remote CLI calls; it does not enable local gateway auth. `gateway.token` is ignored.
 
+Control UI auth guardrails:
+- `gateway.controlUi.enabled`: turn on Control UI surfaces.
+- `gateway.controlUi.allowInsecureAuth` (default `false`): break-glass toggle for non-HTTPS/dev auth flows.
+- `gateway.controlUi.dangerouslyDisableDeviceAuth` (default `false`): break-glass toggle that bypasses Control UI device-auth checks.
+- `zee security audit` reports critical findings when either dangerous toggle is enabled.
+
 Auth and Tailscale:
 - `gateway.auth.mode` sets the handshake requirements (`token` or `password`). When unset, token auth is assumed.
 - `gateway.auth.token` stores the shared token for token auth (used by the CLI on the same machine).

--- a/packages/zee/Swabble/docs/gateway/security/index.md
+++ b/packages/zee/Swabble/docs/gateway/security/index.md
@@ -40,6 +40,7 @@ Start with the smallest access that still works, then widen it as you gain confi
 - **Inbound access** (DM policies, group policies, allowlists): can strangers trigger the bot?
 - **Tool blast radius** (elevated tools + open rooms): could prompt injection turn into shell/file/network actions?
 - **Network exposure** (Gateway bind/auth, Tailscale Serve/Funnel).
+- **Control UI auth downgrade toggles** (`gateway.controlUi.allowInsecureAuth`, `gateway.controlUi.dangerouslyDisableDeviceAuth`).
 - **Browser control exposure** (remote nodes, relay ports, remote CDP endpoints).
 - **Local disk hygiene** (permissions, symlinks, config includes, “synced folder” paths).
 - **Plugins** (extensions exist without an explicit allowlist).
@@ -72,6 +73,12 @@ When the audit prints findings, treat this as a priority order:
 
 Use HTTPS or localhost for HTTP endpoints. Keep gateway auth enabled and avoid
 public exposure for loopback-only services. Prefer Tailscale Serve for remote access.
+
+If you enable Control UI (`gateway.controlUi.enabled`), keep both break-glass flags disabled:
+- `gateway.controlUi.allowInsecureAuth: false`
+- `gateway.controlUi.dangerouslyDisableDeviceAuth: false`
+
+`zee security audit` marks either toggle as a critical finding.
 
 ## Reverse Proxy Configuration
 

--- a/packages/zee/Swabble/src/config/schema.ts
+++ b/packages/zee/Swabble/src/config/schema.ts
@@ -160,6 +160,9 @@ const FIELD_LABELS: Record<string, string> = {
   "gateway.auth.token": "Gateway Token",
   "gateway.auth.password": "Gateway Password",
   "gateway.allowedOrigins": "Gateway Allowed Origins",
+  "gateway.controlUi.enabled": "Control UI Enabled",
+  "gateway.controlUi.allowInsecureAuth": "Control UI Insecure Auth",
+  "gateway.controlUi.dangerouslyDisableDeviceAuth": "Control UI Device Auth Override",
   canvasHost: "Canvas Host",
   "canvasHost.enabled": "Canvas Host Enabled",
   "canvasHost.root": "Canvas Root Directory",
@@ -390,6 +393,12 @@ const FIELD_HELP: Record<string, string> = {
   "gateway.auth.token":
     "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",
   "gateway.auth.password": "Required for Tailscale funnel.",
+  "gateway.controlUi.enabled":
+    "Enable the Control UI surface for gateway operators (default: false).",
+  "gateway.controlUi.allowInsecureAuth":
+    "Allow Control UI auth over insecure/non-HTTPS contexts (dangerous outside localhost/dev).",
+  "gateway.controlUi.dangerouslyDisableDeviceAuth":
+    "Break-glass: disable Control UI device-auth checks. Use only for temporary local debugging.",
   "gateway.http.endpoints.chatCompletions.enabled":
     "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
   "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',
@@ -602,6 +611,9 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   "gateway.daemonBridge.url": "http://127.0.0.1:3210",
   "gateway.daemonBridge.sessionStore": "~/.zee/gateway/daemon-sessions.json",
   "gateway.allowedOrigins": "http://127.0.0.1:5173",
+  "gateway.controlUi.enabled": true,
+  "gateway.controlUi.allowInsecureAuth": false,
+  "gateway.controlUi.dangerouslyDisableDeviceAuth": false,
   "agents.list[].identity.avatar": "avatars/zee.png",
 };
 

--- a/packages/zee/Swabble/src/config/types.gateway.ts
+++ b/packages/zee/Swabble/src/config/types.gateway.ts
@@ -232,9 +232,20 @@ export type GatewayConfig = {
   tailscale?: GatewayTailscaleConfig;
   remote?: GatewayRemoteConfig;
   daemonBridge?: GatewayDaemonBridgeConfig;
-  /** Optional control UI config (currently unused). */
+  /** Optional Control UI auth policy controls. */
   controlUi?: {
+    /** Enable Control UI surfaces (default: false). */
     enabled?: boolean;
+    /**
+     * Allow non-HTTPS auth flows for Control UI.
+     * Keep false unless you are on a trusted local/dev path.
+     */
+    allowInsecureAuth?: boolean;
+    /**
+     * Break-glass flag: bypass Control UI device-auth checks.
+     * Dangerous for anything beyond localhost testing.
+     */
+    dangerouslyDisableDeviceAuth?: boolean;
   };
   reload?: GatewayReloadConfig;
   tls?: GatewayTlsConfig;

--- a/packages/zee/Swabble/src/config/zod-schema.ts
+++ b/packages/zee/Swabble/src/config/zod-schema.ts
@@ -386,6 +386,8 @@ export const ZeeSchema = z
         controlUi: z
           .object({
             enabled: z.boolean().optional(),
+            allowInsecureAuth: z.boolean().optional(),
+            dangerouslyDisableDeviceAuth: z.boolean().optional(),
           })
           .strict()
           .optional(),

--- a/packages/zee/Swabble/src/security/audit.ts
+++ b/packages/zee/Swabble/src/security/audit.ts
@@ -304,6 +304,35 @@ function collectGatewayConfigFindings(
     });
   }
 
+  const controlUiEnabled = cfg.gateway?.controlUi?.enabled === true;
+  const controlUiInsecureAuth = cfg.gateway?.controlUi?.allowInsecureAuth === true;
+  const controlUiDeviceAuthBypass =
+    cfg.gateway?.controlUi?.dangerouslyDisableDeviceAuth === true;
+
+  if (controlUiEnabled && controlUiInsecureAuth) {
+    findings.push({
+      checkId: "gateway.control_ui_insecure_auth",
+      severity: "critical",
+      title: "Control UI insecure auth enabled",
+      detail:
+        "gateway.controlUi.allowInsecureAuth=true enables auth downgrade paths for the Control UI.",
+      remediation:
+        "Set gateway.controlUi.allowInsecureAuth=false and serve Control UI over HTTPS or trusted localhost only.",
+    });
+  }
+
+  if (controlUiEnabled && controlUiDeviceAuthBypass) {
+    findings.push({
+      checkId: "gateway.control_ui_device_auth_disabled",
+      severity: "critical",
+      title: "Control UI device auth bypass enabled",
+      detail:
+        "gateway.controlUi.dangerouslyDisableDeviceAuth=true disables Control UI device-auth verification.",
+      remediation:
+        "Set gateway.controlUi.dangerouslyDisableDeviceAuth=false and rotate gateway auth credentials if this was enabled outside local debugging.",
+    });
+  }
+
   if (tailscaleMode === "funnel") {
     findings.push({
       checkId: "gateway.tailscale_funnel",


### PR DESCRIPTION
## Summary
- expand `gateway.controlUi` with explicit auth-downgrade flags
- validate new flags in config schema + config metadata labels/help
- add critical `zee security audit` findings when insecure Control UI toggles are enabled
- document safe defaults and break-glass behavior in gateway docs

## Issue
Refs #273

## Testing
- Not run in this worktree (pnpm/vitest dependencies are not installed in the temporary worktree environment).
