### PR TITLE
feat: add onboarding assistant-mode preset

### DIFF
--- a/packages/zee/Swabble/docs/cli/onboard.md
+++ b/packages/zee/Swabble/docs/cli/onboard.md
@@ -16,6 +16,7 @@ Related:
 ```bash
 zee onboard
 zee onboard --flow quickstart
+zee onboard --flow quickstart --assistant-mode
 zee onboard --flow manual
 zee onboard --mode remote --remote-url ws://gateway-host:18789
 ```
@@ -23,4 +24,5 @@ zee onboard --mode remote --remote-url ws://gateway-host:18789
 Flow notes:
 - `quickstart`: minimal prompts, auto-generates a gateway token.
 - `manual`: full prompts for port/bind/auth (alias of `advanced`).
+- `--assistant-mode`: applies single-user assistant defaults (main DM session, allowlist-first group policy, cross-provider sends off).
 - Fastest first chat: finish onboarding and connect WhatsApp or WhatsApp.

--- a/packages/zee/Swabble/src/cli/program/register.onboard.ts
+++ b/packages/zee/Swabble/src/cli/program/register.onboard.ts
@@ -41,6 +41,11 @@ export function registerOnboardCommand(program: Command) {
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/onboard", "zee-bot.com/cli/onboard")}\n`,
     )
     .option("--workspace <dir>", "Agent workspace directory (default: ~/zee)")
+    .option(
+      "--assistant-mode",
+      "Apply assistant-first single-user defaults (channel-first, secure-by-default)",
+      false,
+    )
     .option("--reset", "Reset config + credentials + sessions + workspace before running wizard")
     .option("--non-interactive", "Run without prompts", false)
     .option(
@@ -105,6 +110,7 @@ export function registerOnboardCommand(program: Command) {
         await onboardCommand(
           {
             workspace: opts.workspace as string | undefined,
+            assistantMode: Boolean(opts.assistantMode),
             nonInteractive: Boolean(opts.nonInteractive),
             acceptRisk: Boolean(opts.acceptRisk),
             flow: opts.flow as "quickstart" | "advanced" | "manual" | undefined,

--- a/packages/zee/Swabble/src/commands/onboard-assistant-mode.test.ts
+++ b/packages/zee/Swabble/src/commands/onboard-assistant-mode.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { applyAssistantModePreset } from "./onboard-assistant-mode.js";
+
+describe("applyAssistantModePreset", () => {
+  it("applies assistant-first defaults without dropping existing config", () => {
+    const next = applyAssistantModePreset({
+      gateway: { mode: "local" },
+      session: { dmScope: "per-peer" },
+      tools: {
+        message: {
+          crossContext: {
+            allowWithinProvider: true,
+            allowAcrossProviders: true,
+          },
+        },
+      },
+      channels: {
+        defaults: {
+          heartbeat: { showOk: true },
+        },
+      },
+    });
+
+    expect(next.gateway?.mode).toBe("local");
+    expect(next.session?.dmScope).toBe("main");
+    expect(next.channels?.defaults).toMatchObject({
+      groupPolicy: "allowlist",
+      heartbeat: { showOk: true },
+    });
+    expect(next.tools?.message?.crossContext).toMatchObject({
+      allowWithinProvider: true,
+      allowAcrossProviders: false,
+    });
+  });
+});

--- a/packages/zee/Swabble/src/commands/onboard-assistant-mode.ts
+++ b/packages/zee/Swabble/src/commands/onboard-assistant-mode.ts
@@ -1,0 +1,31 @@
+import type { ZeeConfig } from "../config/config.js";
+
+export function applyAssistantModePreset(cfg: ZeeConfig): ZeeConfig {
+  return {
+    ...cfg,
+    session: {
+      ...cfg.session,
+      // Single-user default: keep DM continuity in the main session.
+      dmScope: "main",
+    },
+    channels: {
+      ...cfg.channels,
+      defaults: {
+        ...cfg.channels?.defaults,
+        // Keep group activation explicit unless allowlisted.
+        groupPolicy: "allowlist",
+      },
+    },
+    tools: {
+      ...cfg.tools,
+      // Keep channel sends scoped unless explicitly allowed.
+      message: {
+        ...cfg.tools?.message,
+        crossContext: {
+          ...cfg.tools?.message?.crossContext,
+          allowAcrossProviders: false,
+        },
+      },
+    },
+  };
+}

--- a/packages/zee/Swabble/src/commands/onboard-non-interactive/local.ts
+++ b/packages/zee/Swabble/src/commands/onboard-non-interactive/local.ts
@@ -12,6 +12,7 @@ import {
   resolveGatewayUrls,
   waitForGatewayReachable,
 } from "../onboard-helpers.js";
+import { applyAssistantModePreset } from "../onboard-assistant-mode.js";
 import type { OnboardOptions } from "../onboard-types.js";
 
 import { applyNonInteractiveAuthChoice } from "./local/auth-choice.js";
@@ -72,6 +73,9 @@ export async function runNonInteractiveOnboardingLocal(params: {
   nextConfig = gatewayResult.nextConfig;
 
   nextConfig = applyNonInteractiveSkillsConfig({ nextConfig, opts, runtime });
+  if (opts.assistantMode) {
+    nextConfig = applyAssistantModePreset(nextConfig);
+  }
 
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });
   await writeConfigFile(nextConfig);

--- a/packages/zee/Swabble/src/commands/onboard-non-interactive/remote.ts
+++ b/packages/zee/Swabble/src/commands/onboard-non-interactive/remote.ts
@@ -4,6 +4,7 @@ import { logConfigUpdated } from "../../config/logging.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { applyWizardMetadata } from "../onboard-helpers.js";
+import { applyAssistantModePreset } from "../onboard-assistant-mode.js";
 import type { OnboardOptions } from "../onboard-types.js";
 
 export async function runNonInteractiveOnboardingRemote(params: {
@@ -32,6 +33,9 @@ export async function runNonInteractiveOnboardingRemote(params: {
       },
     },
   };
+  if (opts.assistantMode) {
+    nextConfig = applyAssistantModePreset(nextConfig);
+  }
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });
   await writeConfigFile(nextConfig);
   logConfigUpdated(runtime);

--- a/packages/zee/Swabble/src/commands/onboard-types.ts
+++ b/packages/zee/Swabble/src/commands/onboard-types.ts
@@ -45,6 +45,8 @@ export type OnboardOptions = {
   mode?: OnboardMode;
   /** "manual" is an alias for "advanced". */
   flow?: "quickstart" | "advanced" | "manual";
+  /** Apply assistant-first single-user defaults during onboarding. */
+  assistantMode?: boolean;
   workspace?: string;
   nonInteractive?: boolean;
   /** Required for non-interactive onboarding; skips the interactive risk prompt when true. */

--- a/packages/zee/Swabble/src/wizard/onboarding.ts
+++ b/packages/zee/Swabble/src/wizard/onboarding.ts
@@ -20,6 +20,7 @@ import {
 import { promptRemoteGatewayConfig } from "../commands/onboard-remote.js";
 import { setupSkills } from "../commands/onboard-skills.js";
 import { setupInternalHooks } from "../commands/onboard-hooks.js";
+import { applyAssistantModePreset } from "../commands/onboard-assistant-mode.js";
 import type {
   GatewayAuthChoice,
   OnboardMode,
@@ -417,6 +418,19 @@ export async function runOnboardingWizard(
       skipConfirm: flow === "quickstart",
       quickstartDefaults: flow === "quickstart",
     });
+  }
+
+  if (opts.assistantMode) {
+    nextConfig = applyAssistantModePreset(nextConfig);
+    await prompter.note(
+      [
+        "Applied assistant mode preset:",
+        "- session.dmScope=main",
+        "- channels.defaults.groupPolicy=allowlist",
+        "- tools.message.crossContext.allowAcrossProviders=false",
+      ].join("\n"),
+      "Assistant mode",
+    );
   }
 
   await writeConfigFile(nextConfig);


### PR DESCRIPTION
## Summary
- add `--assistant-mode` to `zee onboard`
- apply assistant-first defaults in interactive and non-interactive onboarding
- add focused unit test for preset merge behavior
- document the new onboarding flag

## Issue
Refs #272

## Testing
- Not run in this worktree (pnpm/vitest dependencies are not installed in the temporary worktree environment).
