### PR TITLE
[Gap 3] Add first-class voice wake/talk mode CLI controls

### DIFF
--- a/packages/zee/Swabble/docs/cli/system.md
+++ b/packages/zee/Swabble/docs/cli/system.md
@@ -4,6 +4,7 @@ read_when:
   - You want to enqueue a system event without creating a cron job
   - You need to enable or disable heartbeats
   - You want to inspect system presence entries
+  - You want to control always-on voice wake mode
 ---
 
 # `zee system`
@@ -18,6 +19,9 @@ zee system event --text "Check for urgent follow-ups" --mode now
 zee system heartbeat enable
 zee system heartbeat last
 zee system presence
+zee system voicewake status
+zee system voicewake set zee assistant
+zee system voicewake disable
 ```
 
 ## `system event`
@@ -49,7 +53,23 @@ instances, and similar status lines).
 Flags:
 - `--json`: machine-readable output.
 
+## `system voicewake`
+
+Always-on voice wake controls (state + trigger words).
+
+Commands:
+- `status`: show enabled/disabled state and configured/active triggers.
+- `set <triggers...>`: replace triggers and enable voice wake.
+- `enable`: enable voice wake with existing triggers (or pass `--trigger` repeatedly to set them).
+- `disable`: disable voice wake without deleting configured triggers.
+- `reset`: restore default triggers and enable.
+
+Flags:
+- `--json`: machine-readable output.
+- `--trigger <word>` (for `enable`): add a trigger; repeatable.
+
 ## Notes
 
 - Requires a running Gateway reachable by your current config (local or remote).
 - System events are ephemeral and not persisted across restarts.
+- Voice wake state persists across restarts via `~/.zee/settings/voicewake.json`.

--- a/packages/zee/Swabble/src/cli/system-cli.test.ts
+++ b/packages/zee/Swabble/src/cli/system-cli.test.ts
@@ -1,0 +1,87 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayFromCli = vi.fn();
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(() => {
+    throw new Error("exit");
+  }),
+};
+
+vi.mock("./gateway-rpc.js", () => ({
+  addGatewayClientOptions: (cmd: Command) => cmd,
+  callGatewayFromCli,
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: runtime,
+}));
+
+describe("system cli", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disables voice wake", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      enabled: false,
+      triggers: ["zee", "computer"],
+      effectiveTriggers: [],
+    });
+    const { registerSystemCli } = await import("./system-cli.js");
+    const program = new Command();
+    registerSystemCli(program);
+
+    await program.parseAsync(["system", "voicewake", "disable"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "voicewake.set",
+      expect.objectContaining({ json: false }),
+      { enabled: false },
+      { expectFinal: false },
+    );
+  });
+
+  it("sets custom voice wake triggers", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      enabled: true,
+      triggers: ["zee", "assistant"],
+      effectiveTriggers: ["zee", "assistant"],
+    });
+    const { registerSystemCli } = await import("./system-cli.js");
+    const program = new Command();
+    registerSystemCli(program);
+
+    await program.parseAsync(["system", "voicewake", "set", "zee", "assistant"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "voicewake.set",
+      expect.objectContaining({ json: false }),
+      { enabled: true, triggers: ["zee", "assistant"] },
+      { expectFinal: false },
+    );
+  });
+
+  it("shows voice wake status summary", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      enabled: false,
+      triggers: ["zee", "claude"],
+      effectiveTriggers: [],
+    });
+    const { registerSystemCli } = await import("./system-cli.js");
+    const program = new Command();
+    registerSystemCli(program);
+
+    await program.parseAsync(["system", "voicewake", "status"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "voicewake.get",
+      expect.objectContaining({ json: false }),
+      undefined,
+      { expectFinal: false },
+    );
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("voice wake: disabled"));
+  });
+});

--- a/packages/zee/Swabble/src/cli/system-cli.ts
+++ b/packages/zee/Swabble/src/cli/system-cli.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { danger } from "../globals.js";
+import { defaultVoiceWakeTriggers } from "../infra/voicewake.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
@@ -8,6 +9,16 @@ import type { GatewayRpcOpts } from "./gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "./gateway-rpc.js";
 
 type SystemEventOpts = GatewayRpcOpts & { text?: string; mode?: string; json?: boolean };
+type VoiceWakeState = {
+  enabled?: boolean;
+  triggers?: unknown;
+  effectiveTriggers?: unknown;
+};
+
+function collectRepeatableOption(value: string, previous: string[] = []) {
+  previous.push(value);
+  return previous;
+}
 
 const normalizeWakeMode = (raw: unknown) => {
   const mode = typeof raw === "string" ? raw.trim() : "";
@@ -15,6 +26,35 @@ const normalizeWakeMode = (raw: unknown) => {
   if (mode === "now" || mode === "next-heartbeat") return mode;
   throw new Error("--mode must be now or next-heartbeat");
 };
+
+function normalizeTriggerList(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const resolved = raw
+    .flatMap((entry) => String(entry).split(/[,\n]+/g))
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .slice(0, 32);
+  return resolved;
+}
+
+function readVoiceWakeState(payload: unknown): Required<VoiceWakeState> {
+  const state = (payload ?? {}) as VoiceWakeState;
+  const triggers = Array.isArray(state.triggers) ? state.triggers : [];
+  const effectiveTriggers = Array.isArray(state.effectiveTriggers) ? state.effectiveTriggers : [];
+  const enabled = state.enabled !== false;
+  return { enabled, triggers, effectiveTriggers };
+}
+
+function formatVoiceWakeStatusLines(payload: unknown): string[] {
+  const state = readVoiceWakeState(payload);
+  const configured = normalizeTriggerList(state.triggers);
+  const effective = normalizeTriggerList(state.effectiveTriggers);
+  return [
+    `voice wake: ${state.enabled ? "enabled" : "disabled"}`,
+    `configured triggers: ${configured.length > 0 ? configured.join(", ") : "(none)"}`,
+    `active triggers: ${effective.length > 0 ? effective.join(", ") : "(none)"}`,
+  ];
+}
 
 export function registerSystemCli(program: Command) {
   const system = program
@@ -100,6 +140,123 @@ export function registerSystemCli(program: Command) {
         { expectFinal: false },
       );
       defaultRuntime.log(JSON.stringify(result, null, 2));
+    } catch (err) {
+      defaultRuntime.error(danger(String(err)));
+      defaultRuntime.exit(1);
+    }
+  });
+
+  const voicewake = system.command("voicewake").description("Voice wake controls");
+
+  addGatewayClientOptions(
+    voicewake
+      .command("status")
+      .description("Show voice wake enabled state + triggers")
+      .option("--json", "Output JSON", false),
+  ).action(async (opts: GatewayRpcOpts & { json?: boolean }) => {
+    try {
+      const result = await callGatewayFromCli("voicewake.get", opts, undefined, {
+        expectFinal: false,
+      });
+      if (opts.json) {
+        defaultRuntime.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      defaultRuntime.log(formatVoiceWakeStatusLines(result).join("\n"));
+    } catch (err) {
+      defaultRuntime.error(danger(String(err)));
+      defaultRuntime.exit(1);
+    }
+  });
+
+  addGatewayClientOptions(
+    voicewake
+      .command("set")
+      .description("Set wake triggers and enable voice wake")
+      .argument("<triggers...>", "Trigger words/phrases")
+      .option("--json", "Output JSON", false),
+  ).action(async (triggers: string[], opts: GatewayRpcOpts & { json?: boolean }) => {
+    try {
+      const normalized = normalizeTriggerList(triggers);
+      if (normalized.length === 0) {
+        throw new Error("At least one trigger is required.");
+      }
+      const result = await callGatewayFromCli(
+        "voicewake.set",
+        opts,
+        { enabled: true, triggers: normalized },
+        { expectFinal: false },
+      );
+      if (opts.json) defaultRuntime.log(JSON.stringify(result, null, 2));
+      else defaultRuntime.log(formatVoiceWakeStatusLines(result).join("\n"));
+    } catch (err) {
+      defaultRuntime.error(danger(String(err)));
+      defaultRuntime.exit(1);
+    }
+  });
+
+  addGatewayClientOptions(
+    voicewake
+      .command("enable")
+      .description("Enable voice wake (optionally set triggers)")
+      .option("--trigger <word>", "Add wake trigger (repeatable)", collectRepeatableOption, [])
+      .option("--json", "Output JSON", false),
+  ).action(async (opts: GatewayRpcOpts & { trigger?: string[]; json?: boolean }) => {
+    try {
+      const triggerList = normalizeTriggerList(opts.trigger);
+      const params =
+        triggerList.length > 0
+          ? { enabled: true, triggers: triggerList }
+          : {
+              enabled: true,
+            };
+      const result = await callGatewayFromCli("voicewake.set", opts, params, {
+        expectFinal: false,
+      });
+      if (opts.json) defaultRuntime.log(JSON.stringify(result, null, 2));
+      else defaultRuntime.log(formatVoiceWakeStatusLines(result).join("\n"));
+    } catch (err) {
+      defaultRuntime.error(danger(String(err)));
+      defaultRuntime.exit(1);
+    }
+  });
+
+  addGatewayClientOptions(
+    voicewake
+      .command("disable")
+      .description("Disable voice wake without deleting configured triggers")
+      .option("--json", "Output JSON", false),
+  ).action(async (opts: GatewayRpcOpts & { json?: boolean }) => {
+    try {
+      const result = await callGatewayFromCli(
+        "voicewake.set",
+        opts,
+        { enabled: false },
+        { expectFinal: false },
+      );
+      if (opts.json) defaultRuntime.log(JSON.stringify(result, null, 2));
+      else defaultRuntime.log(formatVoiceWakeStatusLines(result).join("\n"));
+    } catch (err) {
+      defaultRuntime.error(danger(String(err)));
+      defaultRuntime.exit(1);
+    }
+  });
+
+  addGatewayClientOptions(
+    voicewake
+      .command("reset")
+      .description("Reset to default triggers and enable voice wake")
+      .option("--json", "Output JSON", false),
+  ).action(async (opts: GatewayRpcOpts & { json?: boolean }) => {
+    try {
+      const result = await callGatewayFromCli(
+        "voicewake.set",
+        opts,
+        { enabled: true, triggers: defaultVoiceWakeTriggers() },
+        { expectFinal: false },
+      );
+      if (opts.json) defaultRuntime.log(JSON.stringify(result, null, 2));
+      else defaultRuntime.log(formatVoiceWakeStatusLines(result).join("\n"));
     } catch (err) {
       defaultRuntime.error(danger(String(err)));
       defaultRuntime.exit(1);

--- a/packages/zee/Swabble/src/gateway/server-methods/voicewake.ts
+++ b/packages/zee/Swabble/src/gateway/server-methods/voicewake.ts
@@ -1,4 +1,8 @@
-import { loadVoiceWakeConfig, setVoiceWakeTriggers } from "../../infra/voicewake.js";
+import {
+  loadVoiceWakeConfig,
+  resolveEffectiveVoiceWakeTriggers,
+  setVoiceWakeConfig,
+} from "../../infra/voicewake.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
 import { normalizeVoiceWakeTriggers } from "../server-utils.js";
 import { formatForLog } from "../ws-log.js";
@@ -8,25 +12,46 @@ export const voicewakeHandlers: GatewayRequestHandlers = {
   "voicewake.get": async ({ respond }) => {
     try {
       const cfg = await loadVoiceWakeConfig();
-      respond(true, { triggers: cfg.triggers });
+      respond(true, {
+        enabled: cfg.enabled,
+        triggers: cfg.triggers,
+        effectiveTriggers: resolveEffectiveVoiceWakeTriggers(cfg),
+      });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
     }
   },
   "voicewake.set": async ({ params, respond, context }) => {
-    if (!Array.isArray(params.triggers)) {
+    const hasEnabled = typeof params.enabled === "boolean";
+    const hasTriggers = Array.isArray(params.triggers);
+    if (!hasEnabled && !hasTriggers) {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "voicewake.set requires triggers: string[]"),
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "voicewake.set requires enabled:boolean and/or triggers:string[]",
+        ),
       );
       return;
     }
     try {
-      const triggers = normalizeVoiceWakeTriggers(params.triggers);
-      const cfg = await setVoiceWakeTriggers(triggers);
-      context.broadcastVoiceWakeChanged(cfg.triggers);
-      respond(true, { triggers: cfg.triggers });
+      const triggers = hasTriggers
+        ? normalizeVoiceWakeTriggers(params.triggers, {
+            allowEmpty: hasEnabled && params.enabled === false,
+          })
+        : undefined;
+      const cfg = await setVoiceWakeConfig({
+        ...(hasEnabled ? { enabled: Boolean(params.enabled) } : {}),
+        ...(hasTriggers ? { triggers } : {}),
+      });
+      const effectiveTriggers = resolveEffectiveVoiceWakeTriggers(cfg);
+      context.broadcastVoiceWakeChanged(effectiveTriggers);
+      respond(true, {
+        enabled: cfg.enabled,
+        triggers: cfg.triggers,
+        effectiveTriggers,
+      });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
     }

--- a/packages/zee/Swabble/src/gateway/server-utils.test.ts
+++ b/packages/zee/Swabble/src/gateway/server-utils.test.ts
@@ -8,6 +8,10 @@ describe("normalizeVoiceWakeTriggers", () => {
     expect(normalizeVoiceWakeTriggers(null)).toEqual(defaultVoiceWakeTriggers());
   });
 
+  test("allows empty list when requested", () => {
+    expect(normalizeVoiceWakeTriggers([], { allowEmpty: true })).toEqual([]);
+  });
+
   test("trims and limits entries", () => {
     const result = normalizeVoiceWakeTriggers(["  hello  ", "", "world"]);
     expect(result).toEqual(["hello", "world"]);

--- a/packages/zee/Swabble/src/gateway/server-utils.ts
+++ b/packages/zee/Swabble/src/gateway/server-utils.ts
@@ -1,12 +1,16 @@
 import { defaultVoiceWakeTriggers } from "../infra/voicewake.js";
 
-export function normalizeVoiceWakeTriggers(input: unknown): string[] {
+export function normalizeVoiceWakeTriggers(
+  input: unknown,
+  options?: { allowEmpty?: boolean },
+): string[] {
   const raw = Array.isArray(input) ? input : [];
   const cleaned = raw
     .map((v) => (typeof v === "string" ? v.trim() : ""))
     .filter((v) => v.length > 0)
     .slice(0, 32)
     .map((v) => v.slice(0, 64));
+  if (options?.allowEmpty === true) return cleaned;
   return cleaned.length > 0 ? cleaned : defaultVoiceWakeTriggers();
 }
 

--- a/packages/zee/Swabble/src/gateway/server/ws-connection/message-handler.ts
+++ b/packages/zee/Swabble/src/gateway/server/ws-connection/message-handler.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../infra/device-pairing.js";
 import { updatePairedNodeMetadata } from "../../../infra/node-pairing.js";
 import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../../infra/skills-remote.js";
-import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
+import { loadVoiceWakeConfig, resolveEffectiveVoiceWakeTriggers } from "../../../infra/voicewake.js";
 import { upsertPresence } from "../../../infra/system-presence.js";
 import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
@@ -855,7 +855,7 @@ export function attachGatewayWsMessageHandler(params: {
           void loadVoiceWakeConfig()
             .then((cfg) => {
               context.nodeRegistry.sendEvent(nodeSession.nodeId, "voicewake.changed", {
-                triggers: cfg.triggers,
+                triggers: resolveEffectiveVoiceWakeTriggers(cfg),
               });
             })
             .catch((err) =>

--- a/packages/zee/Swabble/src/infra/voicewake.test.ts
+++ b/packages/zee/Swabble/src/infra/voicewake.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it } from "vitest";
 import {
   defaultVoiceWakeTriggers,
   loadVoiceWakeConfig,
+  resolveEffectiveVoiceWakeTriggers,
+  setVoiceWakeEnabled,
   setVoiceWakeTriggers,
 } from "./voicewake.js";
 
@@ -14,17 +16,21 @@ describe("voicewake store", () => {
   it("returns defaults when missing", async () => {
     const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-voicewake-"));
     const cfg = await loadVoiceWakeConfig(baseDir);
+    expect(cfg.enabled).toBe(true);
     expect(cfg.triggers).toEqual(defaultVoiceWakeTriggers());
+    expect(resolveEffectiveVoiceWakeTriggers(cfg)).toEqual(defaultVoiceWakeTriggers());
     expect(cfg.updatedAtMs).toBe(0);
   });
 
   it("sanitizes and persists triggers", async () => {
     const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-voicewake-"));
     const saved = await setVoiceWakeTriggers(["  hi  ", "", "  there "], baseDir);
+    expect(saved.enabled).toBe(true);
     expect(saved.triggers).toEqual(["hi", "there"]);
     expect(saved.updatedAtMs).toBeGreaterThan(0);
 
     const loaded = await loadVoiceWakeConfig(baseDir);
+    expect(loaded.enabled).toBe(true);
     expect(loaded.triggers).toEqual(["hi", "there"]);
     expect(loaded.updatedAtMs).toBeGreaterThan(0);
   });
@@ -33,5 +39,18 @@ describe("voicewake store", () => {
     const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-voicewake-"));
     const saved = await setVoiceWakeTriggers(["", "   "], baseDir);
     expect(saved.triggers).toEqual(defaultVoiceWakeTriggers());
+  });
+
+  it("preserves configured triggers when disabling voice wake", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-voicewake-"));
+    await setVoiceWakeTriggers(["zee", "assistant"], baseDir);
+    const disabled = await setVoiceWakeEnabled(false, baseDir);
+    expect(disabled.enabled).toBe(false);
+    expect(disabled.triggers).toEqual(["zee", "assistant"]);
+    expect(resolveEffectiveVoiceWakeTriggers(disabled)).toEqual([]);
+
+    const enabled = await setVoiceWakeEnabled(true, baseDir);
+    expect(enabled.enabled).toBe(true);
+    expect(resolveEffectiveVoiceWakeTriggers(enabled)).toEqual(["zee", "assistant"]);
   });
 });

--- a/packages/zee/Swabble/src/infra/voicewake.ts
+++ b/packages/zee/Swabble/src/infra/voicewake.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 
 export type VoiceWakeConfig = {
+  enabled: boolean;
   triggers: string[];
   updatedAtMs: number;
 };
@@ -15,10 +16,14 @@ function resolvePath(baseDir?: string) {
   return path.join(root, "settings", "voicewake.json");
 }
 
-function sanitizeTriggers(triggers: string[] | undefined | null): string[] {
+function sanitizeTriggers(
+  triggers: string[] | undefined | null,
+  options?: { allowEmpty?: boolean },
+): string[] {
   const cleaned = (triggers ?? [])
     .map((w) => (typeof w === "string" ? w.trim() : ""))
     .filter((w) => w.length > 0);
+  if (options?.allowEmpty === true) return cleaned;
   return cleaned.length > 0 ? cleaned : DEFAULT_TRIGGERS;
 }
 
@@ -58,14 +63,24 @@ export function defaultVoiceWakeTriggers() {
   return [...DEFAULT_TRIGGERS];
 }
 
+export function resolveEffectiveVoiceWakeTriggers(cfg: VoiceWakeConfig): string[] {
+  return cfg.enabled === false ? [] : sanitizeTriggers(cfg.triggers);
+}
+
 export async function loadVoiceWakeConfig(baseDir?: string): Promise<VoiceWakeConfig> {
   const filePath = resolvePath(baseDir);
   const existing = await readJSON<VoiceWakeConfig>(filePath);
   if (!existing) {
-    return { triggers: defaultVoiceWakeTriggers(), updatedAtMs: 0 };
+    return {
+      enabled: true,
+      triggers: defaultVoiceWakeTriggers(),
+      updatedAtMs: 0,
+    };
   }
+  const enabled = existing.enabled !== false;
   return {
-    triggers: sanitizeTriggers(existing.triggers),
+    enabled,
+    triggers: sanitizeTriggers(existing.triggers, { allowEmpty: !enabled }),
     updatedAtMs:
       typeof existing.updatedAtMs === "number" && existing.updatedAtMs > 0
         ? existing.updatedAtMs
@@ -73,18 +88,38 @@ export async function loadVoiceWakeConfig(baseDir?: string): Promise<VoiceWakeCo
   };
 }
 
+export async function setVoiceWakeConfig(
+  next: Partial<Pick<VoiceWakeConfig, "enabled" | "triggers">>,
+  baseDir?: string,
+): Promise<VoiceWakeConfig> {
+  const filePath = resolvePath(baseDir);
+  return await withLock(async () => {
+    const previous = await loadVoiceWakeConfig(baseDir);
+    const enabled = typeof next.enabled === "boolean" ? next.enabled : previous.enabled;
+    const triggersInput = next.triggers ?? previous.triggers;
+    const normalized = sanitizeTriggers(triggersInput, { allowEmpty: !enabled });
+    const resolvedTriggers =
+      enabled && normalized.length === 0 ? defaultVoiceWakeTriggers() : normalized;
+    const saved: VoiceWakeConfig = {
+      enabled,
+      triggers: resolvedTriggers,
+      updatedAtMs: Date.now(),
+    };
+    await writeJSONAtomic(filePath, saved);
+    return saved;
+  });
+}
+
 export async function setVoiceWakeTriggers(
   triggers: string[],
   baseDir?: string,
 ): Promise<VoiceWakeConfig> {
-  const sanitized = sanitizeTriggers(triggers);
-  const filePath = resolvePath(baseDir);
-  return await withLock(async () => {
-    const next: VoiceWakeConfig = {
-      triggers: sanitized,
-      updatedAtMs: Date.now(),
-    };
-    await writeJSONAtomic(filePath, next);
-    return next;
-  });
+  return await setVoiceWakeConfig({ enabled: true, triggers }, baseDir);
+}
+
+export async function setVoiceWakeEnabled(
+  enabled: boolean,
+  baseDir?: string,
+): Promise<VoiceWakeConfig> {
+  return await setVoiceWakeConfig({ enabled }, baseDir);
 }


### PR DESCRIPTION
## Summary
- add first-class `zee system voicewake` controls for always-on voice wake state and trigger lifecycle
- make voice wake state explicitly persistent (`enabled` + configured triggers) instead of inferring from trigger presence
- extend gateway voicewake methods to support deterministic enable/disable while preserving configured triggers

## What changed
- `zee system voicewake` now supports:
  - `status`
  - `set <triggers...>`
  - `enable` (optional `--trigger` repeats)
  - `disable`
  - `reset`
- gateway `voicewake.get` now returns enabled/configured/effective trigger state
- gateway `voicewake.set` now accepts `enabled` and/or `triggers`
- node voicewake snapshot broadcast now uses effective triggers (empty when disabled)
- docs updated for the new voicewake command surface

## Tests
- `cd packages/zee/Swabble && ./node_modules/.bin/vitest run src/infra/voicewake.test.ts src/gateway/server-utils.test.ts src/cli/system-cli.test.ts`

Closes #266
