### PR TITLE
[Gap 6] Make auth profile login/switch/rotation first-class via zee auth

### DIFF
--- a/packages/zee/Swabble/docs/cli/auth.md
+++ b/packages/zee/Swabble/docs/cli/auth.md
@@ -1,0 +1,78 @@
+---
+summary: "CLI reference for `zee auth` (OAuth/token login, profile switching, rotation)"
+read_when:
+  - You need a first-class auth workflow without `zee models auth`
+  - You want to switch or rotate provider auth profiles
+  - You need to inspect active profile and fallback order
+---
+
+# `zee auth`
+
+Manage provider auth profiles (OAuth/API key/token) directly from a top-level
+CLI surface.
+
+## Common commands
+
+```bash
+zee auth status
+zee auth login --provider anthropic
+zee auth use --provider anthropic --profile anthropic:default
+zee auth rotate --provider anthropic
+```
+
+## `auth status`
+
+Shows:
+- active profile per provider
+- current fallback order
+- profile health (`ready`, `cooldown`, `disabled:*`, `expired`)
+
+Flags:
+- `--provider <id>`: filter to one provider.
+- `--agent <id>`: inspect a specific agent.
+- `--json`: machine-readable output.
+
+## `auth login`
+
+Runs provider plugin auth flow (OAuth/API key/token).
+
+Flags:
+- `--provider <id>`: provider id.
+- `--method <id>`: auth method id.
+- `--set-default`: apply provider default model recommendation.
+
+## `auth use`
+
+Pins a profile to the front of fallback order for a provider.
+
+Flags:
+- `--provider <id>`: provider id.
+- `--profile <id>`: profile id to activate.
+- `--agent <id>`: target agent.
+- `--json`: machine-readable output.
+
+## `auth rotate`
+
+Rotates to the next profile in fallback order.
+
+Flags:
+- `--provider <id>`: provider id.
+- `--agent <id>`: target agent.
+- `--json`: machine-readable output.
+
+## Token helpers
+
+```bash
+zee auth setup-token --provider anthropic
+zee auth paste-token --provider anthropic --profile-id anthropic:manual --expires-in 365d
+```
+
+## Order overrides
+
+```bash
+zee auth order get --provider anthropic
+zee auth order set --provider anthropic anthropic:default anthropic:backup
+zee auth order clear --provider anthropic
+```
+
+These commands update per-agent order overrides and make fallback precedence explicit.

--- a/packages/zee/Swabble/docs/cli/index.md
+++ b/packages/zee/Swabble/docs/cli/index.md
@@ -29,6 +29,7 @@ This page describes the current CLI behavior. If commands change, update this do
 - [`gateway`](/cli/gateway)
 - [`logs`](/cli/logs)
 - [`system`](/cli/system)
+- [`auth`](/cli/auth)
 - [`models`](/cli/models)
 - [`memory`](/cli/memory)
 - [`nodes`](/cli/nodes)
@@ -148,6 +149,15 @@ zee [--dev] [--profile <name>] <command>
     event
     heartbeat last|enable|disable
     presence
+  auth
+    status
+    login
+    setup-token
+    paste-token
+    add
+    use
+    rotate
+    order get|set|clear
   models
     list
     status

--- a/packages/zee/Swabble/src/cli/auth-cli.test.ts
+++ b/packages/zee/Swabble/src/cli/auth-cli.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+const authStatusCommand = vi.fn();
+const authUseCommand = vi.fn();
+const authRotateCommand = vi.fn();
+
+vi.mock("../commands/auth.js", () => ({
+  authStatusCommand,
+  authUseCommand,
+  authRotateCommand,
+}));
+
+describe("auth cli", () => {
+  it("registers auth command and runs status", async () => {
+    const { Command } = await import("commander");
+    const { registerAuthCli } = await import("./auth-cli.js");
+    const program = new Command();
+    registerAuthCli(program);
+
+    const auth = program.commands.find((cmd) => cmd.name() === "auth");
+    expect(auth).toBeTruthy();
+
+    await program.parseAsync(["auth", "status", "--provider", "anthropic"], { from: "user" });
+
+    expect(authStatusCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "anthropic" }),
+      expect.any(Object),
+    );
+  });
+
+  it("runs auth use", async () => {
+    const { Command } = await import("commander");
+    const { registerAuthCli } = await import("./auth-cli.js");
+    const program = new Command();
+    registerAuthCli(program);
+
+    await program.parseAsync(
+      ["auth", "use", "--provider", "anthropic", "--profile", "anthropic:default"],
+      { from: "user" },
+    );
+
+    expect(authUseCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        profile: "anthropic:default",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("runs auth rotate", async () => {
+    const { Command } = await import("commander");
+    const { registerAuthCli } = await import("./auth-cli.js");
+    const program = new Command();
+    registerAuthCli(program);
+
+    await program.parseAsync(["auth", "rotate", "--provider", "openai"], { from: "user" });
+
+    expect(authRotateCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/zee/Swabble/src/cli/auth-cli.ts
+++ b/packages/zee/Swabble/src/cli/auth-cli.ts
@@ -1,0 +1,222 @@
+import type { Command } from "commander";
+
+import {
+  authRotateCommand,
+  authStatusCommand,
+  authUseCommand,
+} from "../commands/auth.js";
+import {
+  modelsAuthAddCommand,
+  modelsAuthLoginCommand,
+  modelsAuthOrderClearCommand,
+  modelsAuthOrderGetCommand,
+  modelsAuthOrderSetCommand,
+  modelsAuthPasteTokenCommand,
+  modelsAuthSetupTokenCommand,
+} from "../commands/models.js";
+import { danger } from "../globals.js";
+import { defaultRuntime } from "../runtime.js";
+import { formatDocsLink } from "../terminal/links.js";
+import { theme } from "../terminal/theme.js";
+import { runCommandWithRuntime } from "./cli-utils.js";
+
+function runAuthCommand(action: () => Promise<void>) {
+  return runCommandWithRuntime(defaultRuntime, action, (err) => {
+    defaultRuntime.error(danger(`Auth command failed: ${String(err)}`));
+    defaultRuntime.exit(1);
+  });
+}
+
+export function registerAuthCli(program: Command) {
+  const auth = program
+    .command("auth")
+    .description("Manage auth profiles (OAuth, tokens, rotation)")
+    .addHelpText(
+      "after",
+      () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/auth", "zee-bot.com/cli/auth")}\n`,
+    );
+
+  auth
+    .command("status")
+    .description("Show active profile + fallback order per provider")
+    .option("--provider <id>", "Filter to one provider (e.g. anthropic, openai)")
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runAuthCommand(async () => {
+        await authStatusCommand(
+          {
+            provider: opts.provider as string | undefined,
+            agent: opts.agent as string | undefined,
+            json: Boolean(opts.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
+    .command("login")
+    .description("Run a provider auth flow (OAuth/API key)")
+    .option("--provider <id>", "Provider id registered by a plugin")
+    .option("--method <id>", "Provider auth method id")
+    .option("--set-default", "Apply the provider's default model recommendation", false)
+    .action(async (opts) => {
+      await runAuthCommand(async () => {
+        await modelsAuthLoginCommand(
+          {
+            provider: opts.provider as string | undefined,
+            method: opts.method as string | undefined,
+            setDefault: Boolean(opts.setDefault),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
+    .command("setup-token")
+    .description("Run provider CLI token setup (TTY required)")
+    .option("--provider <name>", "Provider id (default: anthropic)")
+    .option("--yes", "Skip confirmation", false)
+    .action(async (opts) => {
+      await runAuthCommand(async () => {
+        await modelsAuthSetupTokenCommand(
+          {
+            provider: opts.provider as string | undefined,
+            yes: Boolean(opts.yes),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
+    .command("paste-token")
+    .description("Paste a token into auth-profiles and update config")
+    .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
+    .option("--profile-id <id>", "Auth profile id (default: <provider>:manual)")
+    .option(
+      "--expires-in <duration>",
+      "Optional expiry duration (e.g. 365d, 12h); stored as absolute expiresAt",
+    )
+    .action(async (opts) => {
+      await runAuthCommand(async () => {
+        await modelsAuthPasteTokenCommand(
+          {
+            provider: opts.provider as string | undefined,
+            profileId: opts.profileId as string | undefined,
+            expiresIn: opts.expiresIn as string | undefined,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
+    .command("add")
+    .description("Interactive auth helper")
+    .action(async () => {
+      await runAuthCommand(async () => {
+        await modelsAuthAddCommand({}, defaultRuntime);
+      });
+    });
+
+  auth
+    .command("use")
+    .description("Set active profile for a provider (updates fallback order)")
+    .requiredOption("--provider <id>", "Provider id (e.g. anthropic, openai)")
+    .requiredOption("--profile <id>", "Profile id to move to the front")
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runAuthCommand(async () => {
+        await authUseCommand(
+          {
+            provider: opts.provider as string,
+            profile: opts.profile as string,
+            agent: opts.agent as string | undefined,
+            json: Boolean(opts.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
+    .command("rotate")
+    .description("Rotate to the next auth profile for a provider")
+    .requiredOption("--provider <id>", "Provider id (e.g. anthropic, openai)")
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runAuthCommand(async () => {
+        await authRotateCommand(
+          {
+            provider: opts.provider as string,
+            agent: opts.agent as string | undefined,
+            json: Boolean(opts.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  const order = auth.command("order").description("Manage per-agent auth profile order overrides");
+
+  order
+    .command("get")
+    .description("Show per-agent auth profile order override")
+    .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runAuthCommand(async () => {
+        await modelsAuthOrderGetCommand(
+          {
+            provider: opts.provider as string,
+            agent: opts.agent as string | undefined,
+            json: Boolean(opts.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  order
+    .command("set")
+    .description("Set per-agent auth profile order override")
+    .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .argument("<profileIds...>", "Auth profile ids")
+    .action(async (profileIds: string[], opts) => {
+      await runAuthCommand(async () => {
+        await modelsAuthOrderSetCommand(
+          {
+            provider: opts.provider as string,
+            agent: opts.agent as string | undefined,
+            order: profileIds,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  order
+    .command("clear")
+    .description("Clear per-agent auth profile order override")
+    .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .action(async (opts) => {
+      await runAuthCommand(async () => {
+        await modelsAuthOrderClearCommand(
+          {
+            provider: opts.provider as string,
+            agent: opts.agent as string | undefined,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+}

--- a/packages/zee/Swabble/src/cli/program/register.subclis.ts
+++ b/packages/zee/Swabble/src/cli/program/register.subclis.ts
@@ -69,6 +69,14 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "auth",
+    description: "Auth profiles and OAuth rotation",
+    register: async (program) => {
+      const mod = await import("../auth-cli.js");
+      mod.registerAuthCli(program);
+    },
+  },
+  {
     name: "models",
     description: "Model configuration",
     register: async (program) => {

--- a/packages/zee/Swabble/src/commands/auth.ts
+++ b/packages/zee/Swabble/src/commands/auth.ts
@@ -1,0 +1,317 @@
+import {
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+  resolveAuthProfileDisplayLabel,
+  resolveAuthProfileOrder,
+  resolveAuthStorePathForDisplay,
+  setAuthProfileOrder,
+} from "../agents/auth-profiles.js";
+import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { normalizeProviderId } from "../agents/model-selection.js";
+import { loadConfig } from "../config/config.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { shortenHomePath } from "../utils.js";
+
+type AuthStatusOptions = {
+  provider?: string;
+  agent?: string;
+  json?: boolean;
+};
+
+type AuthUseOptions = {
+  provider?: string;
+  profile?: string;
+  agent?: string;
+  json?: boolean;
+};
+
+type AuthRotateOptions = {
+  provider?: string;
+  agent?: string;
+  json?: boolean;
+};
+
+function resolveAgentContext(rawAgent?: string) {
+  const cfg = loadConfig();
+  const agentId = rawAgent?.trim()
+    ? normalizeAgentId(rawAgent.trim())
+    : resolveDefaultAgentId(cfg);
+  const agentDir = resolveAgentDir(cfg, agentId);
+  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  return { cfg, agentId, agentDir, store };
+}
+
+function uniqueOrdered(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function resolveProvidersForStatus(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  store: ReturnType<typeof ensureAuthProfileStore>;
+  filterProvider?: string;
+}): string[] {
+  if (params.filterProvider) {
+    return [normalizeProviderId(params.filterProvider)];
+  }
+  const fromStore = Object.values(params.store.profiles).map((cred) =>
+    normalizeProviderId(cred.provider),
+  );
+  const fromConfigProfiles = Object.values(params.cfg.auth?.profiles ?? {}).map((profile) =>
+    normalizeProviderId(profile.provider),
+  );
+  const fromConfigOrder = Object.keys(params.cfg.auth?.order ?? {}).map((provider) =>
+    normalizeProviderId(provider),
+  );
+  const merged = uniqueOrdered([...fromConfigProfiles, ...fromStore, ...fromConfigOrder]);
+  const priority = new Map(
+    ["anthropic", "openai"].map((provider, index) => [provider, index] as const),
+  );
+  return merged.sort((a, b) => {
+    const pa = priority.get(a);
+    const pb = priority.get(b);
+    if (pa != null && pb != null && pa !== pb) return pa - pb;
+    if (pa != null && pb == null) return -1;
+    if (pa == null && pb != null) return 1;
+    return a.localeCompare(b);
+  });
+}
+
+function resolveProfileHealth(params: {
+  profile: {
+    type: "api_key" | "oauth" | "token";
+    expires?: number;
+  };
+  usage?: {
+    cooldownUntil?: number;
+    disabledUntil?: number;
+    disabledReason?: string;
+  };
+}): { status: string; expiresInMs: number | null } {
+  const now = Date.now();
+  if (params.profile.type === "token") {
+    const expires = params.profile.expires;
+    if (typeof expires === "number" && Number.isFinite(expires) && expires > 0) {
+      if (now >= expires) {
+        return { status: "expired", expiresInMs: 0 };
+      }
+      return { status: "ready", expiresInMs: expires - now };
+    }
+  }
+
+  const disabledUntil = params.usage?.disabledUntil;
+  if (
+    typeof disabledUntil === "number" &&
+    Number.isFinite(disabledUntil) &&
+    disabledUntil > now
+  ) {
+    const reason = params.usage?.disabledReason ? `:${params.usage.disabledReason}` : "";
+    return { status: `disabled${reason}`, expiresInMs: disabledUntil - now };
+  }
+
+  const cooldownUntil = params.usage?.cooldownUntil;
+  if (
+    typeof cooldownUntil === "number" &&
+    Number.isFinite(cooldownUntil) &&
+    cooldownUntil > now
+  ) {
+    return { status: "cooldown", expiresInMs: cooldownUntil - now };
+  }
+
+  return { status: "ready", expiresInMs: null };
+}
+
+function formatDurationShort(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) return `${totalHours}h`;
+  const totalDays = Math.floor(totalHours / 24);
+  return `${totalDays}d`;
+}
+
+export async function authStatusCommand(opts: AuthStatusOptions, runtime: RuntimeEnv) {
+  const { cfg, agentId, agentDir, store } = resolveAgentContext(opts.agent);
+  const providers = resolveProvidersForStatus({
+    cfg,
+    store,
+    filterProvider: opts.provider,
+  });
+  const authStorePath = resolveAuthStorePathForDisplay(agentDir);
+
+  const items = providers.map((provider) => {
+    const order = resolveAuthProfileOrder({ cfg, store, provider });
+    const profileIds = listProfilesForProvider(store, provider);
+    const profileItems = uniqueOrdered([...profileIds, ...order]).map((profileId) => {
+      const profile = store.profiles[profileId];
+      if (!profile) return { profileId, kind: "missing", status: "missing", label: profileId };
+      const usage = store.usageStats?.[profileId];
+      const health = resolveProfileHealth({ profile, usage });
+      return {
+        profileId,
+        kind: profile.type,
+        status: health.status,
+        label: resolveAuthProfileDisplayLabel({ cfg, store, profileId }),
+        expiresIn: health.expiresInMs,
+      };
+    });
+
+    return {
+      provider,
+      activeProfile: order[0] ?? null,
+      fallbackOrder: order,
+      profiles: profileItems,
+    };
+  });
+
+  if (opts.json) {
+    runtime.log(
+      JSON.stringify(
+        {
+          agentId,
+          agentDir: shortenHomePath(agentDir),
+          authStorePath: shortenHomePath(authStorePath),
+          providers: items,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  runtime.log(`Agent: ${agentId}`);
+  runtime.log(`Auth store: ${shortenHomePath(authStorePath)}`);
+  if (items.length === 0) {
+    runtime.log("No auth providers configured.");
+    runtime.log("Use: zee auth login --provider anthropic");
+    return;
+  }
+
+  for (const entry of items) {
+    runtime.log("");
+    runtime.log(`${entry.provider}:`);
+    runtime.log(`  active: ${entry.activeProfile ?? "(none)"}`);
+    runtime.log(
+      `  fallback: ${
+        entry.fallbackOrder.length > 0 ? entry.fallbackOrder.join(" -> ") : "(none)"
+      }`,
+    );
+    if (entry.profiles.length === 0) {
+      runtime.log("  profiles: (none)");
+      continue;
+    }
+    runtime.log("  profiles:");
+    for (const profile of entry.profiles) {
+      const expiresSuffix =
+        typeof profile.expiresIn === "number" && profile.expiresIn > 0
+          ? ` (${formatDurationShort(profile.expiresIn)} remaining)`
+          : "";
+      runtime.log(
+        `    - ${profile.profileId} [${profile.kind}] ${profile.status}${expiresSuffix}`,
+      );
+    }
+  }
+}
+
+export async function authUseCommand(opts: AuthUseOptions, runtime: RuntimeEnv) {
+  const providerRaw = opts.provider?.trim();
+  if (!providerRaw) throw new Error("Missing --provider.");
+  const profileId = opts.profile?.trim();
+  if (!profileId) throw new Error("Missing --profile.");
+  const provider = normalizeProviderId(providerRaw);
+
+  const { cfg, agentId, agentDir, store } = resolveAgentContext(opts.agent);
+  const profile = store.profiles[profileId];
+  if (!profile) throw new Error(`Profile not found: ${profileId}`);
+  if (normalizeProviderId(profile.provider) !== provider) {
+    throw new Error(
+      `Profile ${profileId} belongs to ${normalizeProviderId(profile.provider)}, not ${provider}.`,
+    );
+  }
+
+  const currentOrder = resolveAuthProfileOrder({ cfg, store, provider });
+  const knownProfiles = listProfilesForProvider(store, provider);
+  const baseOrder = uniqueOrdered([...currentOrder, ...knownProfiles, profileId]);
+  const nextOrder = uniqueOrdered([profileId, ...baseOrder]);
+
+  const updated = await setAuthProfileOrder({
+    agentDir,
+    provider,
+    order: nextOrder,
+  });
+  if (!updated) throw new Error("Failed to update auth profile order.");
+
+  if (opts.json) {
+    runtime.log(
+      JSON.stringify(
+        {
+          agentId,
+          provider,
+          activeProfile: profileId,
+          fallbackOrder: nextOrder,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  runtime.log(`Agent: ${agentId}`);
+  runtime.log(`Provider: ${provider}`);
+  runtime.log(`Active profile: ${profileId}`);
+  runtime.log(`Fallback order: ${nextOrder.join(" -> ")}`);
+}
+
+export async function authRotateCommand(opts: AuthRotateOptions, runtime: RuntimeEnv) {
+  const providerRaw = opts.provider?.trim();
+  if (!providerRaw) throw new Error("Missing --provider.");
+  const provider = normalizeProviderId(providerRaw);
+
+  const { cfg, agentId, agentDir, store } = resolveAgentContext(opts.agent);
+  const currentOrder = resolveAuthProfileOrder({ cfg, store, provider });
+  if (currentOrder.length < 2) {
+    throw new Error(`Need at least 2 profiles to rotate (provider: ${provider}).`);
+  }
+
+  const nextOrder = [...currentOrder.slice(1), currentOrder[0]];
+  const updated = await setAuthProfileOrder({
+    agentDir,
+    provider,
+    order: nextOrder,
+  });
+  if (!updated) throw new Error("Failed to update auth profile order.");
+
+  if (opts.json) {
+    runtime.log(
+      JSON.stringify(
+        {
+          agentId,
+          provider,
+          previousActiveProfile: currentOrder[0],
+          activeProfile: nextOrder[0],
+          fallbackOrder: nextOrder,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  runtime.log(`Agent: ${agentId}`);
+  runtime.log(`Provider: ${provider}`);
+  runtime.log(`Active profile: ${currentOrder[0]} -> ${nextOrder[0]}`);
+  runtime.log(`Fallback order: ${nextOrder.join(" -> ")}`);
+}


### PR DESCRIPTION
## Summary
- add a first-class top-level `zee auth` command so OAuth/token profile management no longer depends on `zee models auth`
- expose explicit active-profile/fallback visibility via `zee auth status`
- add direct profile switching and rotation workflows (`zee auth use`, `zee auth rotate`)

## What changed
- New top-level CLI: `zee auth`
  - `status` (active profile + fallback order + profile health)
  - `login`
  - `setup-token`
  - `paste-token`
  - `add`
  - `use` (move selected profile to front)
  - `rotate` (cycle to next profile)
  - `order get|set|clear`
- Added auth command implementation in `src/commands/auth.ts`
- Registered `auth` in lazy subcommand registry (`register.subclis`)
- Added docs page: `docs/cli/auth.md` and linked from CLI index

## Tests
- `cd packages/zee/Swabble && ./node_modules/.bin/vitest run src/cli/auth-cli.test.ts src/cli/program/register.subclis.test.ts`

Closes #269
