### PR TITLE
[Gap 7] Add selectable local-indexing memory profile

### DIFF
--- a/packages/zee/Swabble/docs/cli/index.md
+++ b/packages/zee/Swabble/docs/cli/index.md
@@ -119,6 +119,7 @@ zee [--dev] [--profile <name>] <command>
     doctor
   memory
     status
+    profile show|set
     index
     search
   message

--- a/packages/zee/Swabble/docs/cli/memory.md
+++ b/packages/zee/Swabble/docs/cli/memory.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `zee memory` (status/index/search)"
+summary: "CLI reference for `zee memory` (status/profile/index/search)"
 read_when:
   - You want to index or search semantic memory
   - You’re debugging memory availability or indexing
@@ -21,6 +21,8 @@ zee memory status
 zee memory status --deep
 zee memory status --deep --index
 zee memory status --deep --index --verbose
+zee memory profile show
+zee memory profile set local
 zee memory index
 zee memory index --verbose
 zee memory search "release checklist"
@@ -40,3 +42,15 @@ Notes:
 - `memory status --deep --index` runs a reindex if the store is dirty.
 - `memory index --verbose` prints per-phase details (provider, model, sources, batch activity).
 - `memory status` includes any extra paths configured via `memorySearch.extraPaths`.
+
+## Local profile
+
+Use the built-in local indexing profile (SQLite-backed):
+
+```bash
+zee memory profile set local
+zee memory profile show
+zee memory index
+```
+
+This profile keeps memory search local and does not require an external vector DB service.

--- a/packages/zee/Swabble/src/cli/memory-cli.test.ts
+++ b/packages/zee/Swabble/src/cli/memory-cli.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const getMemorySearchManager = vi.fn();
 const loadConfig = vi.fn(() => ({}));
+const writeConfigFile = vi.fn(async () => {});
 const resolveDefaultAgentId = vi.fn(() => "main");
 
 vi.mock("../memory/index.js", () => ({
@@ -11,6 +12,7 @@ vi.mock("../memory/index.js", () => ({
 
 vi.mock("../config/config.js", () => ({
   loadConfig,
+  writeConfigFile,
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -20,6 +22,7 @@ vi.mock("../agents/agent-scope.js", () => ({
 afterEach(async () => {
   vi.restoreAllMocks();
   getMemorySearchManager.mockReset();
+  writeConfigFile.mockReset();
   process.exitCode = undefined;
   const { setVerbose } = await import("../globals.js");
   setVerbose(false);
@@ -363,5 +366,57 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
     expect(error).toHaveBeenCalledWith(expect.stringContaining("Memory search failed: boom"));
     expect(process.exitCode).toBe(1);
+  });
+
+  it("shows local profile state", async () => {
+    const { registerMemoryCli } = await import("./memory-cli.js");
+    const { defaultRuntime } = await import("../runtime.js");
+    loadConfig.mockReturnValueOnce({
+      agents: { defaults: { memorySearch: { enabled: true, store: { driver: "sqlite" } } } },
+      plugins: { slots: { memory: "zee" } },
+    });
+
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const program = new Command();
+    program.name("test");
+    registerMemoryCli(program);
+    await program.parseAsync(["memory", "profile", "show"], { from: "user" });
+
+    expect(log).toHaveBeenCalledWith("Profile: local-index");
+    expect(log).toHaveBeenCalledWith("Memory slot: zee");
+  });
+
+  it("sets local profile config", async () => {
+    const { registerMemoryCli } = await import("./memory-cli.js");
+    const { defaultRuntime } = await import("../runtime.js");
+    loadConfig.mockReturnValueOnce({
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: false,
+            store: {
+              driver: "sqlite",
+              vector: { enabled: false },
+            },
+          },
+        },
+      },
+      plugins: { slots: { memory: "none" } },
+    });
+
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const program = new Command();
+    program.name("test");
+    registerMemoryCli(program);
+    await program.parseAsync(["memory", "profile", "set", "local"], { from: "user" });
+
+    expect(writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: expect.objectContaining({
+          slots: expect.objectContaining({ memory: "zee" }),
+        }),
+      }),
+    );
+    expect(log).toHaveBeenCalledWith("Memory profile set: local-index");
   });
 });

--- a/packages/zee/Swabble/src/cli/memory-cli.ts
+++ b/packages/zee/Swabble/src/cli/memory-cli.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import type { Command } from "commander";
 
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { loadConfig } from "../config/config.js";
+import { loadConfig, type ZeeConfig, writeConfigFile } from "../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import { setVerbose } from "../globals.js";
 import { withProgress, withProgressTotals } from "./progress.js";
@@ -30,6 +30,7 @@ type MemoryCommandOptions = {
 type MemoryManager = NonNullable<MemorySearchManagerResult["manager"]>;
 
 type MemorySourceName = "memory" | "sessions";
+type MemoryProfileName = "local" | "local-index";
 
 type SourceScan = {
   source: MemorySourceName;
@@ -76,6 +77,61 @@ function resolveAgentIds(cfg: ReturnType<typeof loadConfig>, agent?: string): st
 
 function formatExtraPaths(workspaceDir: string, extraPaths: string[]): string[] {
   return normalizeExtraMemoryPaths(workspaceDir, extraPaths).map((entry) => shortenHomePath(entry));
+}
+
+function normalizeMemoryProfile(raw: string): MemoryProfileName | null {
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "local" || normalized === "local-index") {
+    return normalized;
+  }
+  return null;
+}
+
+function resolveLocalProfileState(cfg: ZeeConfig): {
+  active: boolean;
+  slot: string;
+  driver: string;
+  enabled: boolean;
+} {
+  const slot = cfg.plugins?.slots?.memory ?? "zee";
+  const driver = cfg.agents?.defaults?.memorySearch?.store?.driver ?? "sqlite";
+  const enabled = cfg.agents?.defaults?.memorySearch?.enabled !== false;
+  const active = enabled && slot !== "none" && driver === "sqlite";
+  return { active, slot, driver, enabled };
+}
+
+function applyLocalMemoryProfile(cfg: ZeeConfig): ZeeConfig {
+  const defaults = cfg.agents?.defaults ?? {};
+  const memorySearch = defaults.memorySearch ?? {};
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...defaults,
+        memorySearch: {
+          ...memorySearch,
+          enabled: true,
+          provider: "google",
+          store: {
+            ...memorySearch.store,
+            driver: "sqlite",
+            vector: {
+              ...memorySearch.store?.vector,
+              enabled: true,
+            },
+          },
+        },
+      },
+    },
+    plugins: {
+      ...cfg.plugins,
+      slots: {
+        ...cfg.plugins?.slots,
+        memory: "zee",
+      },
+    },
+  };
 }
 
 async function checkReadableFile(pathname: string): Promise<{ exists: boolean; issue?: string }> {
@@ -462,6 +518,74 @@ export function registerMemoryCli(program: Command) {
     .option("--verbose", "Verbose logging", false)
     .action(async (opts: MemoryCommandOptions) => {
       await runMemoryStatus(opts);
+    });
+
+  const profile = memory.command("profile").description("Manage memory backend profiles");
+
+  profile
+    .command("show")
+    .description("Show active memory backend profile")
+    .option("--json", "Print JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const cfg = loadConfig();
+      const state = resolveLocalProfileState(cfg);
+      const payload = {
+        profile: state.active ? "local-index" : "custom",
+        localIndex: state.active,
+        details: {
+          enabled: state.enabled,
+          memorySlot: state.slot,
+          storeDriver: state.driver,
+        },
+      };
+      if (opts.json) {
+        defaultRuntime.log(JSON.stringify(payload, null, 2));
+        return;
+      }
+      defaultRuntime.log(`Profile: ${payload.profile}`);
+      defaultRuntime.log(`Enabled: ${state.enabled ? "yes" : "no"}`);
+      defaultRuntime.log(`Memory slot: ${state.slot}`);
+      defaultRuntime.log(`Store driver: ${state.driver}`);
+    });
+
+  profile
+    .command("set")
+    .description("Select memory backend profile")
+    .argument("<name>", "Profile name (local|local-index)")
+    .option("--json", "Print JSON")
+    .action(async (name: string, opts: { json?: boolean }) => {
+      const profileName = normalizeMemoryProfile(name);
+      if (!profileName) {
+        defaultRuntime.error(`Unknown memory profile: ${name}`);
+        defaultRuntime.error("Supported profiles: local, local-index");
+        defaultRuntime.exit(1);
+        return;
+      }
+      const cfg = loadConfig();
+      const next = applyLocalMemoryProfile(cfg);
+      await writeConfigFile(next);
+      const state = resolveLocalProfileState(next);
+      if (opts.json) {
+        defaultRuntime.log(
+          JSON.stringify(
+            {
+              ok: true,
+              profile: "local-index",
+              details: {
+                enabled: state.enabled,
+                memorySlot: state.slot,
+                storeDriver: state.driver,
+              },
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+      defaultRuntime.log("Memory profile set: local-index");
+      defaultRuntime.log("Local SQLite index is enabled (no external vector DB required).");
+      defaultRuntime.log("Next: run `zee memory index` to build/update the local index.");
     });
 
   memory


### PR DESCRIPTION
## Summary
- add an official selectable local memory profile in the CLI (`zee memory profile set local`)
- expose profile status via `zee memory profile show`
- document local profile workflow and migration path in memory docs

## What changed
- `zee memory profile show`
  - reports current profile state (`local-index` or `custom`)
  - shows memory slot + store driver details
- `zee memory profile set <name>`
  - supports `local` / `local-index`
  - applies a local-indexing profile:
    - enables memory search
    - pins memory slot to `zee`
    - enforces SQLite store/vec defaults
- Updated docs:
  - `docs/cli/memory.md`
  - `docs/cli/index.md`

## Tests
- `cd packages/zee/Swabble && ./node_modules/.bin/vitest run src/cli/memory-cli.test.ts`

Closes #270
