### PR TITLE
feat(gateway): add first-class web operator readiness checks

### DIFF
--- a/packages/zee/Swabble/docs/cli/gateway.md
+++ b/packages/zee/Swabble/docs/cli/gateway.md
@@ -79,6 +79,30 @@ Shared options (where supported):
 zee gateway health --url ws://127.0.0.1:18789
 ```
 
+### `gateway web`
+
+`gateway web` is the first-class readiness check for Control UI/WebChat operator flows.
+It validates core workflows (health, sessions, approvals, pairing, channels) and prints
+proxy/auth guidance for secure deployment.
+
+```bash
+zee gateway web
+zee gateway web --json
+```
+
+Checks included:
+- `health`
+- `sessions.list`
+- `exec.approvals.get`
+- `node.pair.list`
+- `device.pair.list`
+- `channels.status`
+
+Security guidance included:
+- Gateway auth secret presence (`gateway.auth.*`)
+- Origin allowlist posture (`gateway.allowedOrigins`)
+- Trusted reverse proxies (`gateway.trustedProxies`)
+
 ### `gateway status`
 
 `gateway status` shows the Gateway service (systemd/schtasks) plus an optional RPC probe.

--- a/packages/zee/Swabble/src/cli/gateway-cli.coverage.test.ts
+++ b/packages/zee/Swabble/src/cli/gateway-cli.coverage.test.ts
@@ -14,6 +14,7 @@ const forceFreePortAndWait = vi.fn(async () => ({
 const serviceIsLoaded = vi.fn().mockResolvedValue(true);
 const discoverGatewayBeacons = vi.fn(async () => []);
 const gatewayStatusCommand = vi.fn(async () => {});
+const loadConfig = vi.fn(() => ({ gateway: {} }));
 
 const runtimeLogs: string[] = [];
 const runtimeErrors: string[] = [];
@@ -99,6 +100,14 @@ vi.mock("../commands/gateway-status.js", () => ({
   gatewayStatusCommand: (opts: unknown) => gatewayStatusCommand(opts),
 }));
 
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => loadConfig(),
+  };
+});
+
 describe("gateway-cli coverage", () => {
   it("registers call/health commands and routes to callGateway", async () => {
     runtimeLogs.length = 0;
@@ -132,6 +141,66 @@ describe("gateway-cli coverage", () => {
 
     expect(gatewayStatusCommand).toHaveBeenCalledTimes(1);
   }, 30_000);
+
+  it("registers gateway web and runs readiness checks", async () => {
+    runtimeLogs.length = 0;
+    runtimeErrors.length = 0;
+    callGateway.mockReset();
+    callGateway.mockImplementation(async (opts: unknown) => {
+      const method =
+        opts && typeof opts === "object" ? (opts as { method?: string }).method : undefined;
+      switch (method) {
+        case "health":
+          return { ok: true, durationMs: 8 };
+        case "sessions.list":
+          return { count: 2 };
+        case "exec.approvals.get":
+          return { exists: true };
+        case "node.pair.list":
+          return { pending: [], paired: [] };
+        case "device.pair.list":
+          return { pending: [], paired: [] };
+        case "channels.status":
+          return { channels: {} };
+        default:
+          return {};
+      }
+    });
+    loadConfig.mockReset();
+    loadConfig.mockReturnValueOnce({
+      gateway: {
+        port: 18789,
+        auth: { mode: "token", token: "test-token-123" },
+        allowedOrigins: ["https://ui.example.com"],
+        trustedProxies: ["127.0.0.1"],
+      },
+    });
+
+    const { registerGatewayCli } = await import("./gateway-cli.js");
+    const program = new Command();
+    program.exitOverride();
+    registerGatewayCli(program);
+
+    await program.parseAsync(["gateway", "web", "--json"], { from: "user" });
+
+    const calledMethods = callGateway.mock.calls.map((call) =>
+      String(
+        call[0] && typeof call[0] === "object" ? (call[0] as { method?: string }).method : "",
+      ),
+    );
+    expect(calledMethods).toEqual(
+      expect.arrayContaining([
+        "health",
+        "sessions.list",
+        "exec.approvals.get",
+        "node.pair.list",
+        "device.pair.list",
+        "channels.status",
+      ]),
+    );
+    expect(runtimeLogs.join("\n")).toContain('"checks"');
+    expect(runtimeLogs.join("\n")).toContain('"warnings"');
+  });
 
   it("registers gateway discover and prints JSON", async () => {
     runtimeLogs.length = 0;

--- a/packages/zee/Swabble/src/cli/gateway-cli/register.ts
+++ b/packages/zee/Swabble/src/cli/gateway-cli/register.ts
@@ -1,6 +1,8 @@
 import type { Command } from "commander";
 import { gatewayStatusCommand } from "../../commands/gateway-status.js";
 import { formatHealthChannelLines, type HealthSummary } from "../../commands/health.js";
+import { loadConfig } from "../../config/config.js";
+import { resolveGatewayAuth } from "../../gateway/auth.js";
 import { discoverGatewayBeacons } from "../../infra/bonjour-discovery.js";
 import type { CostUsageSummary } from "../../infra/session-cost-usage.js";
 import { WIDE_AREA_DISCOVERY_DOMAIN } from "../../infra/widearea-dns.js";
@@ -93,6 +95,140 @@ function renderCostUsageSummary(summary: CostUsageSummary, days: number, rich: b
   }
 
   return lines;
+}
+
+type WebWorkflowCheck = {
+  id: string;
+  label: string;
+  method: string;
+  ok: boolean;
+  error?: string;
+};
+
+type GatewayWebSummary = {
+  wsUrl: string;
+  checks: WebWorkflowCheck[];
+  warnings: string[];
+  auth: {
+    mode: "token" | "password";
+    hasSharedSecret: boolean;
+    tailscaleMode: string;
+    allowTailscale: boolean;
+  };
+  proxy: {
+    allowedOrigins: string[];
+    trustedProxies: string[];
+  };
+};
+
+const WEB_WORKFLOW_CHECKS: Array<Pick<WebWorkflowCheck, "id" | "label" | "method">> = [
+  { id: "health", label: "Gateway health", method: "health" },
+  { id: "sessions", label: "Session visibility", method: "sessions.list" },
+  { id: "approvals", label: "Approval controls", method: "exec.approvals.get" },
+  { id: "pairing-nodes", label: "Node pairing", method: "node.pair.list" },
+  { id: "pairing-devices", label: "Device pairing", method: "device.pair.list" },
+  { id: "channels", label: "Channel state", method: "channels.status" },
+];
+
+function resolveGatewayWsUrlFromConfig(): string {
+  const cfg = loadConfig();
+  const remoteUrl = cfg.gateway?.remote?.url?.trim();
+  if (remoteUrl) return remoteUrl;
+  const port = cfg.gateway?.port ?? 18789;
+  return `ws://127.0.0.1:${port}`;
+}
+
+function buildWebOperatorWarnings(params: {
+  auth: GatewayWebSummary["auth"];
+  proxy: GatewayWebSummary["proxy"];
+}): string[] {
+  const warnings: string[] = [];
+  if (
+    !params.auth.hasSharedSecret &&
+    !(params.auth.allowTailscale && params.auth.tailscaleMode === "serve")
+  ) {
+    warnings.push(
+      "Gateway auth secret is missing. Set gateway.auth.token/password before exposing web operator clients.",
+    );
+  }
+  if (params.proxy.allowedOrigins.length === 0) {
+    warnings.push(
+      "gateway.allowedOrigins is empty. Add explicit web UI origins when running Control UI/WebChat on a different host/port.",
+    );
+  }
+  if (params.proxy.trustedProxies.length === 0) {
+    warnings.push(
+      "gateway.trustedProxies is empty. Configure reverse-proxy IPs before relying on X-Forwarded-For/X-Real-IP.",
+    );
+  }
+  return warnings;
+}
+
+async function buildGatewayWebSummary(opts: {
+  url?: string;
+  token?: string;
+  password?: string;
+  timeout?: string;
+  expectFinal?: boolean;
+  json?: boolean;
+}): Promise<GatewayWebSummary> {
+  const cfg = loadConfig();
+  const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
+  const auth = resolveGatewayAuth({
+    authConfig: cfg.gateway?.auth,
+    tailscaleMode,
+    env: process.env,
+  });
+  const hasSharedSecret =
+    (auth.mode === "token" && typeof auth.token === "string" && auth.token.trim().length > 0) ||
+    (auth.mode === "password" &&
+      typeof auth.password === "string" &&
+      auth.password.trim().length > 0);
+  const proxy = {
+    allowedOrigins:
+      cfg.gateway?.allowedOrigins?.map((value) => value.trim()).filter(Boolean) ?? [],
+    trustedProxies:
+      cfg.gateway?.trustedProxies?.map((value) => value.trim()).filter(Boolean) ?? [],
+  };
+
+  const checks: WebWorkflowCheck[] = [];
+  for (const check of WEB_WORKFLOW_CHECKS) {
+    try {
+      const params = check.method === "channels.status" ? { probe: false } : {};
+      await callGatewayCli(check.method, opts, params);
+      checks.push({
+        ...check,
+        ok: true,
+      });
+    } catch (err) {
+      checks.push({
+        ...check,
+        ok: false,
+        error: String(err),
+      });
+    }
+  }
+
+  return {
+    wsUrl: opts.url?.trim() || resolveGatewayWsUrlFromConfig(),
+    checks,
+    warnings: buildWebOperatorWarnings({
+      auth: {
+        mode: auth.mode,
+        hasSharedSecret,
+        tailscaleMode,
+        allowTailscale: auth.allowTailscale === true,
+      },
+      proxy,
+    }),
+    auth: {
+      mode: auth.mode,
+      hasSharedSecret,
+      tailscaleMode,
+      allowTailscale: auth.allowTailscale === true,
+    },
+    proxy,
+  };
 }
 
 export function registerGatewayCli(program: Command) {
@@ -244,6 +380,52 @@ export function registerGatewayCli(program: Command) {
             }
           }
         });
+      }),
+  );
+
+  gatewayCallOpts(
+    gateway
+      .command("web")
+      .description(
+        "Validate web operator readiness (sessions, approvals, pairing, health, channel state)",
+      )
+      .action(async (opts) => {
+        await runGatewayCommand(async () => {
+          const summary = await buildGatewayWebSummary(opts);
+          if (opts.json) {
+            defaultRuntime.log(JSON.stringify(summary, null, 2));
+            return;
+          }
+          const rich = isRich();
+          defaultRuntime.log(colorize(rich, theme.heading, "Gateway Web Operator"));
+          defaultRuntime.log(`${colorize(rich, theme.muted, "WS URL:")} ${summary.wsUrl}`);
+          defaultRuntime.log(
+            `${colorize(rich, theme.muted, "Auth:")} ${summary.auth.mode} · ${
+              summary.auth.hasSharedSecret ? "configured" : "missing secret"
+            }`,
+          );
+          defaultRuntime.log(
+            `${colorize(rich, theme.muted, "Proxy:")} origins=${summary.proxy.allowedOrigins.length} trustedProxies=${summary.proxy.trustedProxies.length}`,
+          );
+          defaultRuntime.log("");
+          defaultRuntime.log(colorize(rich, theme.heading, "Workflow checks"));
+          for (const check of summary.checks) {
+            const status = check.ok
+              ? colorize(rich, theme.success, "ok")
+              : colorize(rich, theme.error, "failed");
+            defaultRuntime.log(`- ${check.label}: ${status}`);
+            if (!check.ok && check.error) {
+              defaultRuntime.log(`  ${colorize(rich, theme.muted, check.error)}`);
+            }
+          }
+          if (summary.warnings.length > 0) {
+            defaultRuntime.log("");
+            defaultRuntime.log(colorize(rich, theme.warn, "Security guidance"));
+            for (const warning of summary.warnings) {
+              defaultRuntime.log(`- ${warning}`);
+            }
+          }
+        }, "Gateway web readiness check failed");
       }),
   );
 


### PR DESCRIPTION
## Summary
- add a new `zee gateway web` command as a first-class operator entrypoint for Control UI/WebChat readiness
- run workflow checks for health, sessions, approvals, pairing, and channel status
- surface explicit proxy/auth guidance for `gateway.allowedOrigins`, `gateway.trustedProxies`, and gateway auth
- document the new command in the gateway CLI docs

## Validation
- `cd packages/zee/Swabble && ./node_modules/.bin/vitest run src/cli/gateway-cli.coverage.test.ts`

Refs #268