### PR TITLE
feat(gateway): add operator dashboard method

### DIFF
--- a/packages/zee/Swabble/docs/cli/gateway.md
+++ b/packages/zee/Swabble/docs/cli/gateway.md
@@ -135,7 +135,11 @@ Low-level RPC helper.
 ```bash
 zee gateway call status
 zee gateway call logs.tail --params '{"sinceMs": 60000}'
+zee gateway call operator.dashboard
 ```
+
+`operator.dashboard` returns an app-friendly operator snapshot (sessions, pairing queues,
+pending exec approvals, and current security warnings) for desktop/web companion clients.
 
 ## Manage the Gateway service
 

--- a/packages/zee/Swabble/src/gateway/exec-approval-manager.ts
+++ b/packages/zee/Swabble/src/gateway/exec-approval-manager.ts
@@ -78,4 +78,13 @@ export class ExecApprovalManager {
     const entry = this.pending.get(recordId);
     return entry?.record ?? null;
   }
+
+  listPending(): ExecApprovalRecord[] {
+    return [...this.pending.values()]
+      .map((entry) => ({
+        ...entry.record,
+        request: { ...entry.record.request },
+      }))
+      .sort((a, b) => a.createdAtMs - b.createdAtMs);
+  }
 }

--- a/packages/zee/Swabble/src/gateway/server-methods-list.ts
+++ b/packages/zee/Swabble/src/gateway/server-methods-list.ts
@@ -78,6 +78,7 @@ const BASE_METHODS = [
   "agent.identity.get",
   "agent.wait",
   "browser.request",
+  "operator.dashboard",
   // Internal WebSocket-native chat methods
   "chat.history",
   "chat.abort",

--- a/packages/zee/Swabble/src/gateway/server-methods.ts
+++ b/packages/zee/Swabble/src/gateway/server-methods.ts
@@ -13,6 +13,7 @@ import { healthHandlers } from "./server-methods/health.js";
 import { logsHandlers } from "./server-methods/logs.js";
 import { modelsHandlers } from "./server-methods/models.js";
 import { nodeHandlers } from "./server-methods/nodes.js";
+import { operatorHandlers } from "./server-methods/operator.js";
 import { sendHandlers } from "./server-methods/send.js";
 import { sessionsHandlers } from "./server-methods/sessions.js";
 import { skillsHandlers } from "./server-methods/skills.js";
@@ -72,6 +73,7 @@ const READ_METHODS = new Set([
   "node.list",
   "node.describe",
   "chat.history",
+  "operator.dashboard",
 ]);
 const WRITE_METHODS = new Set([
   "send",
@@ -168,6 +170,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...nodeHandlers,
   ...sendHandlers,
   ...usageHandlers,
+  ...operatorHandlers,
   ...agentHandlers,
   ...agentsHandlers,
   ...browserHandlers,

--- a/packages/zee/Swabble/src/gateway/server-methods/operator.test.ts
+++ b/packages/zee/Swabble/src/gateway/server-methods/operator.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ExecApprovalManager } from "../exec-approval-manager.js";
+
+const loadConfig = vi.fn(() => ({}));
+const getStatusSummary = vi.fn(async () => ({
+  sessions: { count: 3 },
+  channelSummary: {},
+}));
+const listNodePairing = vi.fn(async () => ({ pending: [], paired: [] }));
+const listDevicePairing = vi.fn(async () => ({ pending: [], paired: [] }));
+const runSecurityAudit = vi.fn(async () => ({
+  summary: { critical: 1, warn: 1, info: 0 },
+  findings: [
+    {
+      checkId: "security.test",
+      severity: "warn",
+      title: "Warning",
+      detail: "x".repeat(320),
+      remediation: "fix",
+    },
+  ],
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => loadConfig(),
+}));
+
+vi.mock("../../commands/status.js", () => ({
+  getStatusSummary: () => getStatusSummary(),
+}));
+
+vi.mock("../../infra/node-pairing.js", () => ({
+  listNodePairing: () => listNodePairing(),
+}));
+
+vi.mock("../../infra/device-pairing.js", () => ({
+  listDevicePairing: () => listDevicePairing(),
+  summarizeDeviceTokens: () => [],
+}));
+
+vi.mock("../../security/audit.js", () => ({
+  runSecurityAudit: (opts: unknown) => runSecurityAudit(opts),
+}));
+
+const { operatorHandlers } = await import("./operator.js");
+
+describe("operator.dashboard handler", () => {
+  it("returns dashboard payload with pending approvals and security findings", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create(
+      {
+        command: "npm publish",
+        sessionKey: "main",
+      },
+      60_000,
+      "approval-1",
+    );
+    const waitForDecision = manager.waitForDecision(record, 60_000);
+
+    const respond = vi.fn();
+    await operatorHandlers["operator.dashboard"]({
+      req: { id: "1", method: "operator.dashboard" } as never,
+      params: {},
+      client: null,
+      respond,
+      context: { execApprovalManager: manager } as never,
+    });
+
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    const payload = respond.mock.calls[0]?.[1] as {
+      approvals: { pendingCount: number; pending: Array<{ id: string }> };
+      security: { findings: Array<{ detail: string }> };
+    };
+    expect(payload.approvals.pendingCount).toBe(1);
+    expect(payload.approvals.pending[0]?.id).toBe("approval-1");
+    expect(payload.security.findings[0]?.detail.length).toBeLessThanOrEqual(240);
+    expect(runSecurityAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeFilesystem: false,
+        includeChannelSecurity: true,
+        deep: false,
+      }),
+    );
+
+    manager.resolve("approval-1", "deny");
+    await waitForDecision;
+  });
+
+  it("responds unavailable on handler error", async () => {
+    getStatusSummary.mockRejectedValueOnce(new Error("status boom"));
+    const respond = vi.fn();
+    const manager = new ExecApprovalManager();
+
+    await operatorHandlers["operator.dashboard"]({
+      req: { id: "2", method: "operator.dashboard" } as never,
+      params: {},
+      client: null,
+      respond,
+      context: { execApprovalManager: manager } as never,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "UNAVAILABLE" }),
+    );
+  });
+});

--- a/packages/zee/Swabble/src/gateway/server-methods/operator.ts
+++ b/packages/zee/Swabble/src/gateway/server-methods/operator.ts
@@ -1,0 +1,86 @@
+import { getStatusSummary } from "../../commands/status.js";
+import { loadConfig } from "../../config/config.js";
+import { listDevicePairing, summarizeDeviceTokens } from "../../infra/device-pairing.js";
+import { listNodePairing } from "../../infra/node-pairing.js";
+import { runSecurityAudit } from "../../security/audit.js";
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+import { formatForLog } from "../ws-log.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+function truncateDetail(detail: string, max = 240): string {
+  if (detail.length <= max) return detail;
+  return `${detail.slice(0, max - 3)}...`;
+}
+
+export const operatorHandlers: GatewayRequestHandlers = {
+  "operator.dashboard": async ({ respond, context }) => {
+    try {
+      const cfg = loadConfig();
+      const [status, nodePairing, devicePairing, security] = await Promise.all([
+        getStatusSummary(),
+        listNodePairing(),
+        listDevicePairing(),
+        runSecurityAudit({
+          config: cfg,
+          includeFilesystem: false,
+          includeChannelSecurity: true,
+          deep: false,
+        }),
+      ]);
+
+      const pendingApprovals = context.execApprovalManager.listPending().map((record) => ({
+        id: record.id,
+        createdAtMs: record.createdAtMs,
+        expiresAtMs: record.expiresAtMs,
+        request: record.request,
+      }));
+
+      const securityFindings = security.findings
+        .filter((finding) => finding.severity === "critical" || finding.severity === "warn")
+        .slice(0, 8)
+        .map((finding) => ({
+          checkId: finding.checkId,
+          severity: finding.severity,
+          title: finding.title,
+          detail: truncateDetail(finding.detail),
+          remediation: finding.remediation,
+        }));
+
+      respond(
+        true,
+        {
+          ts: Date.now(),
+          status,
+          approvals: {
+            pendingCount: pendingApprovals.length,
+            pending: pendingApprovals,
+          },
+          pairing: {
+            nodes: {
+              pendingCount: nodePairing.pending.length,
+              pairedCount: nodePairing.paired.length,
+              pending: nodePairing.pending,
+              paired: nodePairing.paired.map(({ token, ...node }) => node),
+            },
+            devices: {
+              pendingCount: devicePairing.pending.length,
+              pairedCount: devicePairing.paired.length,
+              pending: devicePairing.pending,
+              paired: devicePairing.paired.map(({ tokens, ...device }) => ({
+                ...device,
+                tokens: summarizeDeviceTokens(tokens),
+              })),
+            },
+          },
+          security: {
+            summary: security.summary,
+            findings: securityFindings,
+          },
+        },
+        undefined,
+      );
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
+    }
+  },
+};

--- a/packages/zee/Swabble/src/gateway/server-methods/types.ts
+++ b/packages/zee/Swabble/src/gateway/server-methods/types.ts
@@ -4,6 +4,7 @@ import type { HealthSummary } from "../../commands/health.js";
 import type { CronService } from "../../cron/service.js";
 import type { WizardSession } from "../../wizard/session.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
+import type { ExecApprovalManager } from "../exec-approval-manager.js";
 import type { NodeRegistry } from "../node-registry.js";
 import type { ConnectParams, ErrorShape, RequestFrame } from "../protocol/index.js";
 import type { ChannelRuntimeSnapshot } from "../server-channels.js";
@@ -58,6 +59,7 @@ export type GatewayRequestContext = {
   nodeUnsubscribe: (nodeId: string, sessionKey: string) => void;
   nodeUnsubscribeAll: (nodeId: string) => void;
   nodeRegistry: NodeRegistry;
+  execApprovalManager: ExecApprovalManager;
   agentRunSeq: Map<string, number>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatAbortedRuns: Map<string, number>;

--- a/packages/zee/Swabble/src/gateway/server.impl.ts
+++ b/packages/zee/Swabble/src/gateway/server.impl.ts
@@ -468,6 +468,7 @@ export async function startGatewayServer(
       nodeUnsubscribe,
       nodeUnsubscribeAll,
       nodeRegistry,
+      execApprovalManager,
       agentRunSeq,
       chatAbortControllers,
       chatAbortedRuns: chatRunState.abortedRuns,


### PR DESCRIPTION
## Summary
- add `operator.dashboard` gateway RPC method for app-facing operator snapshots
- include status summary, node/device pairing queues, pending exec approvals, and trimmed security warnings
- wire `ExecApprovalManager` into request context and expose `listPending()` for safe read access
- document usage in gateway CLI docs (`zee gateway call operator.dashboard`)

## Testing
- `cd packages/zee/Swabble && ./node_modules/.bin/vitest run src/gateway/server-methods/operator.test.ts src/gateway/server-methods/agent.test.ts`

Closes #267
