### PR TITLE
feat(channels): add first-party telegram slack discord plugins

### DIFF
--- a/docs/architecture/upstream-differences.md
+++ b/docs/architecture/upstream-differences.md
@@ -136,14 +136,15 @@ zee embeds a trimmed “OpenClaw-like” gateway inside the Zee persona package:
 - Compared to `openclaw/src/`, Zee’s copy is missing these top-level subsystems:
   - `canvas-host/`
   - `compat/`
-  - `discord/`
   - `extensionAPI.ts`
   - `feishu/`
   - `imessage/`
   - `line/`
   - `macos/`
   - `signal/`
-  - `slack/`
+
+Zee now ships bundled first-party channel plugins for Slack/Discord/Telegram under
+`packages/zee/Swabble/extensions/` (instead of mirroring OpenClaw's original top-level source layout).
 
 Operationally, Zee’s gateway is launched by zee only when explicitly enabled (for example `zee daemon --gateway`).
 

--- a/packages/zee/Swabble/docs/channels/discord.md
+++ b/packages/zee/Swabble/docs/channels/discord.md
@@ -1,0 +1,57 @@
+---
+summary: "Discord channel plugin: setup, policy, and operations"
+read_when:
+  - You want to run Zee on Discord
+  - You need Discord DM/group policy guidance
+---
+# Discord
+
+Discord support is provided by the bundled `@zee/discord` channel plugin.
+
+## Quick setup
+
+```bash
+zee channels add --channel discord --botToken <TOKEN> --audience <channel_id>
+zee channels status
+```
+
+Minimal config:
+
+```json5
+{
+  channels: {
+    discord: {
+      botToken: "<token>",
+      defaultChannel: "123456789012345678",
+      dmPolicy: "pairing",
+      allowFrom: []
+    }
+  }
+}
+```
+
+## Security policy
+
+- DM access is controlled by `channels.discord.dmPolicy` + `channels.discord.allowFrom`.
+- `open` requires `allowFrom` to include `"*"`.
+- Channel/group behavior is controlled by `channels.discord.groupPolicy` and `channels.discord.requireMention`.
+- Safer defaults: `dmPolicy="pairing"`, `groupPolicy="allowlist"`, `requireMention=true`.
+
+Approve pairing requests:
+
+```bash
+zee pairing list discord
+zee pairing approve discord <code>
+```
+
+## Status and health
+
+Use:
+
+```bash
+zee channels status --channel discord
+zee security audit
+zee doctor
+```
+
+These commands surface token/config issues, DM policy mistakes, and risky group policy combinations.

--- a/packages/zee/Swabble/docs/channels/index.md
+++ b/packages/zee/Swabble/docs/channels/index.md
@@ -6,20 +6,29 @@ read_when:
 ---
 # Chat Channels
 
-Zee can talk to you on any chat app you already use. Each channel connects via the Gateway.
-Text is supported everywhere; media and reactions vary by channel.
+Zee can run multiple channels at the same time via the Gateway.
 
-## Supported channels
+## First-party channels
 
-- [WhatsApp](/channels/whatsapp) — Most popular; uses Baileys and requires QR pairing.
-- [WhatsApp](/channels/whatsapp) — WhatsApp homeserver; supports rooms (and optional E2EE).
+- [WhatsApp](/channels/whatsapp) - QR-linked WhatsApp Web runtime.
+- [Telegram](/channels/telegram) - Telegram Bot API token + target routing.
+- [Slack](/channels/slack) - Slack bot token + channel routing.
+- [Discord](/channels/discord) - Discord bot token + channel routing.
 
-## Notes
+## Security defaults
 
-- Channels can run simultaneously; configure multiple and Zee will route per chat.
-- Fastest setup is usually **WhatsApp** (access token + homeserver). WhatsApp requires QR pairing and
-  stores more state on disk.
-- Group behavior varies by channel; see [Groups](/concepts/groups).
-- DM pairing and allowlists are enforced for safety; see [Security](/gateway/security).
-- Troubleshooting: [Channel troubleshooting](/channels/troubleshooting).
-- Model providers are documented separately; see [Model Providers](/providers/models).
+- DM access defaults to pairing-style controls.
+- `dmPolicy="open"` requires `allowFrom=["*"]`.
+- Group access should normally stay `groupPolicy="allowlist"` with mention gating enabled.
+- Review warnings with `zee security audit` and `zee doctor`.
+
+## Operational commands
+
+```bash
+zee channels list
+zee channels status
+zee security audit
+zee doctor
+```
+
+See [Channel troubleshooting](/channels/troubleshooting) for runtime and auth debugging.

--- a/packages/zee/Swabble/docs/channels/slack.md
+++ b/packages/zee/Swabble/docs/channels/slack.md
@@ -1,0 +1,57 @@
+---
+summary: "Slack channel plugin: setup, policy, and operations"
+read_when:
+  - You want to run Zee on Slack
+  - You need Slack DM/group policy guidance
+---
+# Slack
+
+Slack support is provided by the bundled `@zee/slack` channel plugin.
+
+## Quick setup
+
+```bash
+zee channels add --channel slack --botToken <TOKEN> --audience <channel_id>
+zee channels status
+```
+
+Minimal config:
+
+```json5
+{
+  channels: {
+    slack: {
+      botToken: "xoxb-...",
+      defaultChannel: "C0123456789",
+      dmPolicy: "pairing",
+      allowFrom: []
+    }
+  }
+}
+```
+
+## Security policy
+
+- DM access is controlled by `channels.slack.dmPolicy` + `channels.slack.allowFrom`.
+- `open` requires `allowFrom` to include `"*"`.
+- Channel/group behavior is controlled by `channels.slack.groupPolicy` and `channels.slack.requireMention`.
+- Safer defaults: `dmPolicy="pairing"`, `groupPolicy="allowlist"`, `requireMention=true`.
+
+Approve pairing requests:
+
+```bash
+zee pairing list slack
+zee pairing approve slack <code>
+```
+
+## Status and health
+
+Use:
+
+```bash
+zee channels status --channel slack
+zee security audit
+zee doctor
+```
+
+These commands surface token/config issues, DM policy mistakes, and risky group policy combinations.

--- a/packages/zee/Swabble/docs/channels/telegram.md
+++ b/packages/zee/Swabble/docs/channels/telegram.md
@@ -1,0 +1,57 @@
+---
+summary: "Telegram channel plugin: setup, policy, and operations"
+read_when:
+  - You want to run Zee on Telegram
+  - You need Telegram DM/group policy guidance
+---
+# Telegram
+
+Telegram support is provided by the bundled `@zee/telegram` channel plugin.
+
+## Quick setup
+
+```bash
+zee channels add --channel telegram --botToken <TOKEN> --audience <chat_id>
+zee channels status
+```
+
+Minimal config:
+
+```json5
+{
+  channels: {
+    telegram: {
+      botToken: "<token>",
+      defaultTarget: "-1001234567890",
+      dmPolicy: "pairing",
+      allowFrom: []
+    }
+  }
+}
+```
+
+## Security policy
+
+- DM access is controlled by `channels.telegram.dmPolicy` + `channels.telegram.allowFrom`.
+- `open` requires `allowFrom` to include `"*"`.
+- Group behavior is controlled by `channels.telegram.groupPolicy` and `channels.telegram.requireMention`.
+- Safer defaults: `dmPolicy="pairing"`, `groupPolicy="allowlist"`, `requireMention=true`.
+
+Approve pairing requests:
+
+```bash
+zee pairing list telegram
+zee pairing approve telegram <code>
+```
+
+## Status and health
+
+Use:
+
+```bash
+zee channels status --channel telegram
+zee security audit
+zee doctor
+```
+
+These commands surface token/config issues, DM policy mistakes, and risky group policy combinations.

--- a/packages/zee/Swabble/docs/cli/channels.md
+++ b/packages/zee/Swabble/docs/cli/channels.md
@@ -25,6 +25,9 @@ zee channels logs --channel all
 
 ```bash
 zee channels add --channel whatsapp
+zee channels add --channel telegram --botToken <token> --audience <chat_id>
+zee channels add --channel slack --botToken <token> --audience <channel_id>
+zee channels add --channel discord --botToken <token> --audience <channel_id>
 zee channels remove --channel whatsapp --delete
 ```
 
@@ -35,6 +38,8 @@ zee channels remove --channel whatsapp --delete
 zee channels login --channel whatsapp
 zee channels logout --channel whatsapp
 ```
+
+Token-based channels (Telegram/Slack/Discord) are configured with `channels add` and usually do not require a separate login flow.
 
 ## Troubleshooting
 

--- a/packages/zee/Swabble/extensions/discord/clawdbot.plugin.json
+++ b/packages/zee/Swabble/extensions/discord/clawdbot.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "discord",
+  "channels": [
+    "discord"
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/packages/zee/Swabble/extensions/discord/index.ts
+++ b/packages/zee/Swabble/extensions/discord/index.ts
@@ -1,0 +1,16 @@
+import type { ZeePluginApi } from "zee/plugin-sdk";
+import { emptyPluginConfigSchema } from "zee/plugin-sdk";
+
+import { discordPlugin } from "./src/channel.js";
+
+const plugin = {
+  id: "discord",
+  name: "Discord",
+  description: "Discord channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: ZeePluginApi) {
+    api.registerChannel({ plugin: discordPlugin });
+  },
+};
+
+export default plugin;

--- a/packages/zee/Swabble/extensions/discord/package.json
+++ b/packages/zee/Swabble/extensions/discord/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@zee/discord",
+  "version": "2026.2.12-beta.1",
+  "type": "module",
+  "description": "Zee Discord channel plugin",
+  "zee": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "discord",
+      "label": "Discord",
+      "selectionLabel": "Discord Bot",
+      "detailLabel": "Discord REST",
+      "docsPath": "/channels/discord",
+      "docsLabel": "discord",
+      "blurb": "bot token + channel id routing; DM/group policy controls and mention gating.",
+      "order": 40,
+      "aliases": [
+        "dc"
+      ],
+      "systemImage": "bubble.left.and.bubble.right",
+      "quickstartAllowFrom": true,
+      "forceAccountBinding": true
+    }
+  }
+}

--- a/packages/zee/Swabble/extensions/discord/src/channel.test.ts
+++ b/packages/zee/Swabble/extensions/discord/src/channel.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { discordPlugin } from "./channel.js";
+
+describe("discord channel plugin", () => {
+  it("uses account-scoped DM policy paths for multi-account configs", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          accounts: {
+            guild: {
+              enabled: true,
+              botToken: "discord-token",
+              dmPolicy: "allowlist",
+              allowFrom: ["12345"],
+            },
+          },
+        },
+      },
+    } as any;
+
+    const account = discordPlugin.config.resolveAccount(cfg, "guild");
+    const dmPolicy = discordPlugin.security?.resolveDmPolicy?.({
+      cfg,
+      accountId: "guild",
+      account,
+    });
+
+    expect(dmPolicy?.policyPath).toBe("channels.discord.accounts.guild.dmPolicy");
+    expect(dmPolicy?.allowFromPath).toBe("channels.discord.accounts.guild.");
+  });
+
+  it("surfaces risky open-group configuration as a security warning", async () => {
+    const cfg = {
+      channels: {
+        discord: {
+          botToken: "discord-token",
+          dmPolicy: "allowlist",
+          allowFrom: ["12345"],
+          groupPolicy: "open",
+          requireMention: false,
+        },
+      },
+    } as any;
+
+    const account = discordPlugin.config.resolveAccount(cfg, "default");
+    const warnings = await discordPlugin.security?.collectWarnings?.({
+      cfg,
+      accountId: "default",
+      account,
+    });
+
+    expect(warnings?.some((entry) => entry.includes("requireMention=false"))).toBe(true);
+  });
+
+  it("reports missing token in status issues", async () => {
+    const cfg = {
+      channels: {
+        discord: {
+          dmPolicy: "pairing",
+        },
+      },
+    } as any;
+
+    const account = discordPlugin.config.resolveAccount(cfg, "default");
+    const snapshot = await discordPlugin.status?.buildAccountSnapshot?.({
+      cfg,
+      account,
+    });
+    const issues = discordPlugin.status?.collectStatusIssues?.([snapshot ?? { accountId: "default" }]);
+
+    expect(issues?.some((issue) => issue.message.includes("token is missing"))).toBe(true);
+  });
+});

--- a/packages/zee/Swabble/extensions/discord/src/channel.ts
+++ b/packages/zee/Swabble/extensions/discord/src/channel.ts
@@ -1,0 +1,708 @@
+import { z } from "zod";
+
+import {
+  DEFAULT_ACCOUNT_ID,
+  DmPolicySchema,
+  GroupPolicySchema,
+  addWildcardAllowFrom,
+  applyAccountNameToChannelSection,
+  buildChannelConfigSchema,
+  deleteAccountFromConfigSection,
+  formatDocsLink,
+  formatPairingApproveHint,
+  missingTargetError,
+  normalizeAccountId,
+  promptAccountId,
+  requireOpenAllowFrom,
+  setAccountEnabledInConfigSection,
+  type ChannelOnboardingAdapter,
+  type ChannelPlugin,
+  type ChannelStatusIssue,
+  type DmPolicy,
+  type ZeeConfig,
+} from "zee/plugin-sdk";
+
+const DISCORD_META = {
+  id: "discord",
+  label: "Discord",
+  selectionLabel: "Discord Bot",
+  detailLabel: "Discord REST",
+  docsPath: "/channels/discord",
+  docsLabel: "discord",
+  blurb: "bot token + channel id routing; DM/group policy controls and mention gating.",
+  order: 40,
+  aliases: ["dc"],
+  systemImage: "bubble.left.and.bubble.right",
+  quickstartAllowFrom: true,
+  forceAccountBinding: true,
+} as const;
+
+const DISCORD_BOT_TOKEN_ENV = "DISCORD_BOT_TOKEN";
+const DISCORD_API_BASE = "https://discord.com/api/v10";
+
+const DiscordAccountSchema = z
+  .object({
+    name: z.string().trim().min(1).optional(),
+    enabled: z.boolean().optional(),
+    botToken: z.string().trim().min(1).optional(),
+    guildId: z.string().trim().min(1).optional(),
+    defaultChannel: z.string().trim().min(1).optional(),
+    dmPolicy: DmPolicySchema.optional(),
+    allowFrom: z.array(z.string().trim().min(1)).optional(),
+    groupPolicy: GroupPolicySchema.optional(),
+    groupAllowFrom: z.array(z.string().trim().min(1)).optional(),
+    requireMention: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message: 'dmPolicy="open" requires allowFrom to include "*"',
+    });
+  });
+
+const DiscordConfigSchema = z
+  .object({
+    accounts: z.record(z.string(), DiscordAccountSchema).optional(),
+    name: z.string().trim().min(1).optional(),
+    enabled: z.boolean().optional(),
+    botToken: z.string().trim().min(1).optional(),
+    guildId: z.string().trim().min(1).optional(),
+    defaultChannel: z.string().trim().min(1).optional(),
+    dmPolicy: DmPolicySchema.optional(),
+    allowFrom: z.array(z.string().trim().min(1)).optional(),
+    groupPolicy: GroupPolicySchema.optional(),
+    groupAllowFrom: z.array(z.string().trim().min(1)).optional(),
+    requireMention: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message: 'channels.discord.dmPolicy="open" requires channels.discord.allowFrom to include "*"',
+    });
+  });
+
+type DiscordConfig = z.infer<typeof DiscordConfigSchema>;
+type DiscordAccountConfig = z.infer<typeof DiscordAccountSchema>;
+
+type ResolvedDiscordAccount = DiscordAccountConfig & {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  botToken?: string;
+  guildId?: string;
+  defaultChannel?: string;
+  dmPolicy: DmPolicy;
+  allowFrom: string[];
+  groupPolicy: "allowlist" | "open" | "disabled";
+  groupAllowFrom: string[];
+  requireMention: boolean;
+};
+
+function normalizeEntries(list?: Array<string | number> | null): string[] {
+  return (list ?? []).map((entry) => String(entry).trim()).filter(Boolean);
+}
+
+function readDiscordConfig(cfg: ZeeConfig): DiscordConfig {
+  const raw = (cfg.channels as Record<string, unknown> | undefined)?.discord;
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as DiscordConfig;
+  }
+  return {};
+}
+
+function listDiscordAccountIds(cfg: ZeeConfig): string[] {
+  const section = readDiscordConfig(cfg);
+  const ids = Object.keys(section.accounts ?? {}).filter(Boolean);
+  return ids.length > 0 ? ids : [DEFAULT_ACCOUNT_ID];
+}
+
+function resolveDefaultDiscordAccountId(cfg: ZeeConfig): string {
+  const ids = listDiscordAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) return DEFAULT_ACCOUNT_ID;
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function resolveDiscordAccount(cfg: ZeeConfig, accountId?: string | null): ResolvedDiscordAccount {
+  const section = readDiscordConfig(cfg);
+  const resolvedAccountId = normalizeAccountId(accountId ?? resolveDefaultDiscordAccountId(cfg));
+  const account = (section.accounts?.[resolvedAccountId] ?? {}) as DiscordAccountConfig;
+  const useTopLevel = resolvedAccountId === DEFAULT_ACCOUNT_ID;
+  return {
+    accountId: resolvedAccountId,
+    name: account.name ?? (useTopLevel ? section.name : undefined),
+    enabled: account.enabled ?? (useTopLevel ? section.enabled !== false : true),
+    botToken: account.botToken ?? (useTopLevel ? section.botToken : undefined),
+    guildId: account.guildId ?? (useTopLevel ? section.guildId : undefined),
+    defaultChannel: account.defaultChannel ?? (useTopLevel ? section.defaultChannel : undefined),
+    dmPolicy: account.dmPolicy ?? (useTopLevel ? section.dmPolicy : undefined) ?? "pairing",
+    allowFrom: normalizeEntries(account.allowFrom ?? (useTopLevel ? section.allowFrom : [])),
+    groupPolicy:
+      account.groupPolicy ?? (useTopLevel ? section.groupPolicy : undefined) ?? "allowlist",
+    groupAllowFrom: normalizeEntries(
+      account.groupAllowFrom ?? (useTopLevel ? section.groupAllowFrom : []),
+    ),
+    requireMention:
+      account.requireMention ?? (useTopLevel ? section.requireMention : undefined) ?? true,
+  };
+}
+
+function hasAccountOverride(cfg: ZeeConfig, accountId: string): boolean {
+  return Boolean(readDiscordConfig(cfg).accounts?.[accountId]);
+}
+
+function resolveConfigPathPrefix(cfg: ZeeConfig, accountId: string): string {
+  if (hasAccountOverride(cfg, accountId)) {
+    return `channels.discord.accounts.${accountId}.`;
+  }
+  return "channels.discord.";
+}
+
+function resolveDiscordBotToken(account: ResolvedDiscordAccount): {
+  token: string | null;
+  source: "config" | "env" | "none";
+} {
+  const configToken = account.botToken?.trim();
+  if (configToken) return { token: configToken, source: "config" };
+  const envToken = process.env[DISCORD_BOT_TOKEN_ENV]?.trim();
+  if (envToken) return { token: envToken, source: "env" };
+  return { token: null, source: "none" };
+}
+
+function applyAccountPatch(params: {
+  cfg: ZeeConfig;
+  accountId: string;
+  patch: Partial<DiscordAccountConfig>;
+  unsetKeys?: Array<keyof DiscordAccountConfig>;
+}): ZeeConfig {
+  const accountId = normalizeAccountId(params.accountId);
+  const section = readDiscordConfig(params.cfg);
+  const accounts = { ...(section.accounts ?? {}) };
+  const existing = { ...(accounts[accountId] ?? {}) } as DiscordAccountConfig;
+  const next = {
+    ...existing,
+    ...params.patch,
+  } as DiscordAccountConfig;
+  for (const key of params.unsetKeys ?? []) {
+    delete (next as Record<string, unknown>)[key as string];
+  }
+  accounts[accountId] = next;
+  return {
+    ...params.cfg,
+    channels: {
+      ...params.cfg.channels,
+      discord: {
+        ...section,
+        accounts,
+      },
+    },
+  } as ZeeConfig;
+}
+
+function setDiscordDmPolicy(cfg: ZeeConfig, accountId: string, dmPolicy: DmPolicy): ZeeConfig {
+  let next = applyAccountPatch({ cfg, accountId, patch: { dmPolicy } });
+  if (dmPolicy === "open") {
+    const resolved = resolveDiscordAccount(next, accountId);
+    next = applyAccountPatch({
+      cfg: next,
+      accountId,
+      patch: {
+        allowFrom: addWildcardAllowFrom(resolved.allowFrom),
+      },
+    });
+  }
+  return next;
+}
+
+function setDiscordAllowFrom(
+  cfg: ZeeConfig,
+  accountId: string,
+  allowFrom?: string[] | null,
+): ZeeConfig {
+  const normalized = allowFrom ? normalizeEntries(allowFrom) : undefined;
+  return applyAccountPatch({
+    cfg,
+    accountId,
+    patch: {
+      allowFrom: normalized,
+    },
+    unsetKeys: normalized ? undefined : ["allowFrom"],
+  });
+}
+
+function collectDiscordStatusIssues(accounts: Array<Record<string, unknown>>): ChannelStatusIssue[] {
+  const issues: ChannelStatusIssue[] = [];
+  for (const account of accounts) {
+    const accountId =
+      typeof account.accountId === "string" && account.accountId.trim()
+        ? account.accountId
+        : DEFAULT_ACCOUNT_ID;
+    if (account.enabled === false) continue;
+
+    if (account.configured !== true) {
+      issues.push({
+        channel: "discord",
+        accountId,
+        kind: "config",
+        message: "Discord bot token is missing.",
+        fix: `Set channels.discord.accounts.${accountId}.botToken or ${DISCORD_BOT_TOKEN_ENV}.`,
+      });
+      continue;
+    }
+
+    const dmPolicy = typeof account.dmPolicy === "string" ? account.dmPolicy : "pairing";
+    const allowFrom = Array.isArray(account.allowFrom)
+      ? account.allowFrom.map((value) => String(value))
+      : [];
+    if (dmPolicy === "open" && !allowFrom.includes("*")) {
+      issues.push({
+        channel: "discord",
+        accountId,
+        kind: "config",
+        message: 'dmPolicy="open" requires allowFrom to include "*".',
+      });
+    }
+
+    const groupPolicy = typeof account.mode === "string" ? account.mode : "allowlist";
+    const requireMention = account.allowUnmentionedGroups !== true;
+    if (groupPolicy === "open" && !requireMention) {
+      issues.push({
+        channel: "discord",
+        accountId,
+        kind: "permissions",
+        message: "Group policy is open and mentions are not required.",
+        fix: "Set channels.discord.requireMention=true or channels.discord.groupPolicy=allowlist.",
+      });
+    }
+  }
+  return issues;
+}
+
+async function sendDiscordText(params: {
+  account: ResolvedDiscordAccount;
+  to: string;
+  text: string;
+}): Promise<{
+  messageId: string;
+  channelId: string;
+  timestamp: number;
+}> {
+  const token = resolveDiscordBotToken(params.account).token;
+  if (!token) {
+    throw new Error(
+      `Discord bot token is missing. Set channels.discord.botToken or ${DISCORD_BOT_TOKEN_ENV}.`,
+    );
+  }
+
+  const endpoint = `${DISCORD_API_BASE}/channels/${encodeURIComponent(params.to)}/messages`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  if (typeof timeout.unref === "function") timeout.unref();
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        authorization: `Bot ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ content: params.text }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Discord send failed: ${message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const raw = await response.text();
+  let payload: Record<string, unknown> = {};
+  try {
+    payload = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+  } catch {
+    throw new Error(`Discord API returned invalid JSON (${response.status}).`);
+  }
+
+  if (!response.ok) {
+    const message =
+      typeof payload.message === "string" && payload.message.trim()
+        ? payload.message.trim()
+        : `HTTP ${response.status}`;
+    throw new Error(`Discord send failed: ${message}`);
+  }
+
+  const messageId = typeof payload.id === "string" ? payload.id : `${Date.now()}`;
+  const channelId = typeof payload.channel_id === "string" ? payload.channel_id : params.to;
+  const timestampRaw = typeof payload.timestamp === "string" ? Date.parse(payload.timestamp) : NaN;
+  const timestamp = Number.isFinite(timestampRaw) ? timestampRaw : Date.now();
+
+  return {
+    messageId,
+    channelId,
+    timestamp,
+  };
+}
+
+const discordOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel: "discord",
+  getStatus: async ({ cfg, accountOverrides }) => {
+    const overrideId = accountOverrides.discord?.trim();
+    const accountId = overrideId
+      ? normalizeAccountId(overrideId)
+      : resolveDefaultDiscordAccountId(cfg);
+    const account = resolveDiscordAccount(cfg, accountId);
+    const tokenSource = resolveDiscordBotToken(account).source;
+    const configured = tokenSource !== "none";
+    return {
+      channel: "discord",
+      configured,
+      statusLines: [
+        `Discord (${accountId === DEFAULT_ACCOUNT_ID ? "default" : accountId}): ${
+          configured ? `configured (${tokenSource})` : "token missing"
+        }`,
+      ],
+      selectionHint: configured ? "configured" : "token missing",
+      quickstartScore: configured ? 3 : 1,
+    };
+  },
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const overrideId = accountOverrides.discord?.trim();
+    let accountId = overrideId
+      ? normalizeAccountId(overrideId)
+      : resolveDefaultDiscordAccountId(cfg);
+
+    if (shouldPromptAccountIds && !overrideId) {
+      accountId = await promptAccountId({
+        cfg,
+        prompter,
+        label: "Discord",
+        currentId: accountId,
+        listAccountIds: listDiscordAccountIds,
+        defaultAccountId: resolveDefaultDiscordAccountId(cfg),
+      });
+    }
+
+    const current = resolveDiscordAccount(cfg, accountId);
+    const tokenInfo = resolveDiscordBotToken(current);
+
+    const botToken = await prompter.text({
+      message: `Discord bot token (${accountId})`,
+      initialValue: current.botToken,
+      placeholder: "Bot token",
+      validate: (value) => {
+        const trimmed = String(value ?? "").trim();
+        if (trimmed) return undefined;
+        if (tokenInfo.source !== "none") return undefined;
+        return `Required unless ${DISCORD_BOT_TOKEN_ENV} is set.`;
+      },
+    });
+
+    const defaultChannel = await prompter.text({
+      message: "Default Discord channel id (optional)",
+      initialValue: current.defaultChannel,
+      placeholder: "123456789012345678",
+    });
+
+    const requireMention = await prompter.confirm({
+      message: "Require mentions for Discord channel messages?",
+      initialValue: current.requireMention,
+    });
+
+    let next = applyAccountPatch({
+      cfg,
+      accountId,
+      patch: {
+        enabled: true,
+        requireMention,
+      },
+    });
+
+    const normalizedToken = String(botToken ?? "").trim();
+    if (normalizedToken) {
+      next = applyAccountPatch({
+        cfg: next,
+        accountId,
+        patch: {
+          botToken: normalizedToken,
+        },
+      });
+    }
+
+    const normalizedChannel = String(defaultChannel ?? "").trim();
+    if (normalizedChannel) {
+      next = applyAccountPatch({
+        cfg: next,
+        accountId,
+        patch: {
+          defaultChannel: normalizedChannel,
+        },
+      });
+    }
+
+    await prompter.note(
+      [
+        "Discord setup complete.",
+        "Use `zee channels status` to verify token + routing.",
+        `Docs: ${formatDocsLink("/channels/discord", "channels/discord")}`,
+      ].join("\n"),
+      "Discord",
+    );
+
+    return { cfg: next, accountId };
+  },
+  dmPolicy: {
+    label: "Discord",
+    channel: "discord",
+    policyKey: "channels.discord.dmPolicy",
+    allowFromKey: "channels.discord.allowFrom",
+    getCurrent: (cfg) => resolveDiscordAccount(cfg, resolveDefaultDiscordAccountId(cfg)).dmPolicy,
+    setPolicy: (cfg, policy) =>
+      setDiscordDmPolicy(cfg, resolveDefaultDiscordAccountId(cfg), policy),
+    promptAllowFrom: async ({ cfg, prompter, accountId }) => {
+      const resolvedAccountId = accountId
+        ? normalizeAccountId(accountId)
+        : resolveDefaultDiscordAccountId(cfg);
+      const account = resolveDiscordAccount(cfg, resolvedAccountId);
+      const raw = await prompter.text({
+        message: "Discord DM allowFrom (comma-separated user ids)",
+        initialValue: account.allowFrom.join(", "),
+        placeholder: "12345, 67890",
+      });
+      const entries = normalizeEntries(String(raw ?? "").split(/[\n,;]+/g));
+      return setDiscordAllowFrom(cfg, resolvedAccountId, entries);
+    },
+  },
+};
+
+function normalizeDiscordTarget(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  return trimmed.replace(/^discord:/i, "");
+}
+
+function looksLikeDiscordTargetId(raw: string, normalized?: string): boolean {
+  const value = (normalized ?? raw).trim();
+  return /^\d{15,20}$/.test(value);
+}
+
+export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
+  id: "discord",
+  meta: DISCORD_META,
+  onboarding: discordOnboardingAdapter,
+  pairing: {
+    idLabel: "discordSenderId",
+  },
+  capabilities: {
+    chatTypes: ["direct", "group", "thread"],
+    media: true,
+    reactions: true,
+    threads: true,
+    groupManagement: true,
+  },
+  configSchema: buildChannelConfigSchema(DiscordConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listDiscordAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveDiscordAccount(cfg, accountId),
+    defaultAccountId: (cfg) => resolveDefaultDiscordAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "discord",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "discord",
+        accountId,
+        clearBaseFields: [
+          "name",
+          "enabled",
+          "botToken",
+          "guildId",
+          "defaultChannel",
+          "dmPolicy",
+          "allowFrom",
+          "groupPolicy",
+          "groupAllowFrom",
+          "requireMention",
+        ],
+      }),
+    isEnabled: (account) => account.enabled !== false,
+    disabledReason: () => "disabled",
+    isConfigured: async (account) => resolveDiscordBotToken(account).source !== "none",
+    unconfiguredReason: () => "bot token missing",
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: resolveDiscordBotToken(account).source !== "none",
+      dmPolicy: account.dmPolicy,
+      allowFrom: account.allowFrom,
+      mode: account.groupPolicy,
+      allowUnmentionedGroups: account.requireMention === false,
+      botTokenSource: resolveDiscordBotToken(account).source,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) => resolveDiscordAccount(cfg, accountId).allowFrom,
+    formatAllowFrom: ({ allowFrom }) => normalizeEntries(allowFrom),
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const prefix = resolveConfigPathPrefix(cfg, resolvedAccountId);
+      return {
+        policy: account.dmPolicy,
+        allowFrom: account.allowFrom,
+        policyPath: `${prefix}dmPolicy`,
+        allowFromPath: prefix,
+        approveHint: formatPairingApproveHint("discord"),
+        normalizeEntry: (raw) => raw.trim(),
+      };
+    },
+    collectWarnings: ({ account }) => {
+      const warnings: string[] = [];
+      if (account.groupPolicy === "open") {
+        if (account.requireMention) {
+          warnings.push(
+            '- Discord channels: groupPolicy="open" allows any member in allowed channels to trigger when Zee is mentioned. Prefer groupPolicy="allowlist" for tighter control.',
+          );
+        } else {
+          warnings.push(
+            '- Discord channels: groupPolicy="open" with requireMention=false allows any member to trigger actions. Set requireMention=true or groupPolicy="allowlist".',
+          );
+        }
+      }
+      return warnings;
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "discord",
+        accountId,
+        name,
+        alwaysUseAccounts: true,
+      }),
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      let next = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "discord",
+        accountId,
+        name: input.name,
+        alwaysUseAccounts: true,
+      });
+
+      const botToken = input.botToken?.trim() || input.token?.trim() || undefined;
+      const defaultChannel = input.audience?.trim() || input.url?.trim() || undefined;
+      const guildId = input.ship?.trim() || undefined;
+      const dmAllowlist = normalizeEntries(input.dmAllowlist);
+      const groupAllowlist = normalizeEntries(input.groupChannels);
+
+      next = applyAccountPatch({
+        cfg: next,
+        accountId,
+        patch: {
+          enabled: true,
+          ...(botToken ? { botToken } : {}),
+          ...(defaultChannel ? { defaultChannel } : {}),
+          ...(guildId ? { guildId } : {}),
+          ...(dmAllowlist.length > 0 ? { allowFrom: dmAllowlist } : {}),
+          ...(groupAllowlist.length > 0 ? { groupAllowFrom: groupAllowlist } : {}),
+        },
+      });
+
+      return next;
+    },
+  },
+  groups: {
+    resolveRequireMention: ({ cfg, accountId }) =>
+      resolveDiscordAccount(cfg, accountId).requireMention,
+  },
+  commands: {
+    enforceOwnerForCommands: true,
+    skipWhenConfigEmpty: true,
+  },
+  messaging: {
+    normalizeTarget: normalizeDiscordTarget,
+    targetResolver: {
+      looksLikeId: looksLikeDiscordTargetId,
+      hint: "<channel-id>",
+    },
+  },
+  status: {
+    buildAccountSnapshot: ({ account }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: resolveDiscordBotToken(account).source !== "none",
+      dmPolicy: account.dmPolicy,
+      allowFrom: account.allowFrom,
+      mode: account.groupPolicy,
+      allowUnmentionedGroups: account.requireMention === false,
+      botTokenSource: resolveDiscordBotToken(account).source,
+    }),
+    collectStatusIssues: (accounts) =>
+      collectDiscordStatusIssues(accounts as Array<Record<string, unknown>>),
+  },
+  outbound: {
+    deliveryMode: "direct",
+    textChunkLimit: 2000,
+    resolveTarget: ({ cfg, accountId, to, allowFrom }) => {
+      const trimmed = to?.trim();
+      if (trimmed) return { ok: true, to: normalizeDiscordTarget(trimmed) ?? trimmed };
+
+      const account = cfg ? resolveDiscordAccount(cfg, accountId) : null;
+      const allowlist = normalizeEntries(allowFrom).filter((entry) => entry !== "*");
+      const fallback = account?.defaultChannel?.trim() || allowlist[0];
+      if (fallback) return { ok: true, to: fallback };
+
+      return {
+        ok: false,
+        error: missingTargetError("Discord", "<channel-id> or channels.discord.defaultChannel"),
+      };
+    },
+    sendText: async ({ cfg, to, text, accountId }) => {
+      const account = resolveDiscordAccount(cfg, accountId);
+      const result = await sendDiscordText({
+        account,
+        to,
+        text,
+      });
+      return {
+        channel: "discord",
+        messageId: result.messageId,
+        channelId: result.channelId,
+        timestamp: result.timestamp,
+      };
+    },
+    sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+      const account = resolveDiscordAccount(cfg, accountId);
+      const composed = mediaUrl ? `${text ? `${text}\n\n` : ""}${mediaUrl}` : text;
+      const result = await sendDiscordText({
+        account,
+        to,
+        text: composed,
+      });
+      return {
+        channel: "discord",
+        messageId: result.messageId,
+        channelId: result.channelId,
+        timestamp: result.timestamp,
+      };
+    },
+  },
+};

--- a/packages/zee/Swabble/extensions/discord/zee.plugin.json
+++ b/packages/zee/Swabble/extensions/discord/zee.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "discord",
+  "channels": [
+    "discord"
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/packages/zee/Swabble/extensions/slack/clawdbot.plugin.json
+++ b/packages/zee/Swabble/extensions/slack/clawdbot.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "slack",
+  "channels": [
+    "slack"
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/packages/zee/Swabble/extensions/slack/index.ts
+++ b/packages/zee/Swabble/extensions/slack/index.ts
@@ -1,0 +1,16 @@
+import type { ZeePluginApi } from "zee/plugin-sdk";
+import { emptyPluginConfigSchema } from "zee/plugin-sdk";
+
+import { slackPlugin } from "./src/channel.js";
+
+const plugin = {
+  id: "slack",
+  name: "Slack",
+  description: "Slack channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: ZeePluginApi) {
+    api.registerChannel({ plugin: slackPlugin });
+  },
+};
+
+export default plugin;

--- a/packages/zee/Swabble/extensions/slack/package.json
+++ b/packages/zee/Swabble/extensions/slack/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@zee/slack",
+  "version": "2026.2.12-beta.1",
+  "type": "module",
+  "description": "Zee Slack channel plugin",
+  "zee": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "slack",
+      "label": "Slack",
+      "selectionLabel": "Slack Bot",
+      "detailLabel": "Slack Web API",
+      "docsPath": "/channels/slack",
+      "docsLabel": "slack",
+      "blurb": "bot token + default channel id; per-channel DM/group policy and mention gating.",
+      "order": 30,
+      "aliases": [
+        "sl"
+      ],
+      "systemImage": "number",
+      "quickstartAllowFrom": true,
+      "forceAccountBinding": true
+    }
+  }
+}

--- a/packages/zee/Swabble/extensions/slack/src/channel.test.ts
+++ b/packages/zee/Swabble/extensions/slack/src/channel.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { slackPlugin } from "./channel.js";
+
+describe("slack channel plugin", () => {
+  it("uses account-scoped DM policy paths for multi-account configs", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          accounts: {
+            work: {
+              enabled: true,
+              botToken: "xoxb-token",
+              dmPolicy: "allowlist",
+              allowFrom: ["U123"],
+            },
+          },
+        },
+      },
+    } as any;
+
+    const account = slackPlugin.config.resolveAccount(cfg, "work");
+    const dmPolicy = slackPlugin.security?.resolveDmPolicy?.({
+      cfg,
+      accountId: "work",
+      account,
+    });
+
+    expect(dmPolicy?.policyPath).toBe("channels.slack.accounts.work.dmPolicy");
+    expect(dmPolicy?.allowFromPath).toBe("channels.slack.accounts.work.");
+  });
+
+  it("surfaces risky open-group configuration as a security warning", async () => {
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-token",
+          dmPolicy: "allowlist",
+          allowFrom: ["U123"],
+          groupPolicy: "open",
+          requireMention: false,
+        },
+      },
+    } as any;
+
+    const account = slackPlugin.config.resolveAccount(cfg, "default");
+    const warnings = await slackPlugin.security?.collectWarnings?.({
+      cfg,
+      accountId: "default",
+      account,
+    });
+
+    expect(warnings?.some((entry) => entry.includes("requireMention=false"))).toBe(true);
+  });
+
+  it("reports missing token in status issues", async () => {
+    const cfg = {
+      channels: {
+        slack: {
+          dmPolicy: "pairing",
+        },
+      },
+    } as any;
+
+    const account = slackPlugin.config.resolveAccount(cfg, "default");
+    const snapshot = await slackPlugin.status?.buildAccountSnapshot?.({
+      cfg,
+      account,
+    });
+    const issues = slackPlugin.status?.collectStatusIssues?.([snapshot ?? { accountId: "default" }]);
+
+    expect(issues?.some((issue) => issue.message.includes("token is missing"))).toBe(true);
+  });
+});

--- a/packages/zee/Swabble/extensions/slack/src/channel.ts
+++ b/packages/zee/Swabble/extensions/slack/src/channel.ts
@@ -1,0 +1,723 @@
+import { z } from "zod";
+
+import {
+  DEFAULT_ACCOUNT_ID,
+  DmPolicySchema,
+  GroupPolicySchema,
+  addWildcardAllowFrom,
+  applyAccountNameToChannelSection,
+  buildChannelConfigSchema,
+  deleteAccountFromConfigSection,
+  formatDocsLink,
+  formatPairingApproveHint,
+  missingTargetError,
+  normalizeAccountId,
+  promptAccountId,
+  requireOpenAllowFrom,
+  setAccountEnabledInConfigSection,
+  type ChannelOnboardingAdapter,
+  type ChannelPlugin,
+  type ChannelStatusIssue,
+  type DmPolicy,
+  type ZeeConfig,
+} from "zee/plugin-sdk";
+
+const SLACK_META = {
+  id: "slack",
+  label: "Slack",
+  selectionLabel: "Slack Bot",
+  detailLabel: "Slack Web API",
+  docsPath: "/channels/slack",
+  docsLabel: "slack",
+  blurb: "bot token + default channel id; per-channel DM/group policy and mention gating.",
+  order: 30,
+  aliases: ["sl"],
+  systemImage: "number",
+  quickstartAllowFrom: true,
+  forceAccountBinding: true,
+} as const;
+
+const SLACK_BOT_TOKEN_ENV = "SLACK_BOT_TOKEN";
+const SLACK_APP_TOKEN_ENV = "SLACK_APP_TOKEN";
+const SLACK_API_BASE = "https://slack.com/api";
+
+const SlackAccountSchema = z
+  .object({
+    name: z.string().trim().min(1).optional(),
+    enabled: z.boolean().optional(),
+    botToken: z.string().trim().min(1).optional(),
+    appToken: z.string().trim().min(1).optional(),
+    defaultChannel: z.string().trim().min(1).optional(),
+    dmPolicy: DmPolicySchema.optional(),
+    allowFrom: z.array(z.string().trim().min(1)).optional(),
+    groupPolicy: GroupPolicySchema.optional(),
+    groupAllowFrom: z.array(z.string().trim().min(1)).optional(),
+    requireMention: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message: 'dmPolicy="open" requires allowFrom to include "*"',
+    });
+  });
+
+const SlackConfigSchema = z
+  .object({
+    accounts: z.record(z.string(), SlackAccountSchema).optional(),
+    name: z.string().trim().min(1).optional(),
+    enabled: z.boolean().optional(),
+    botToken: z.string().trim().min(1).optional(),
+    appToken: z.string().trim().min(1).optional(),
+    defaultChannel: z.string().trim().min(1).optional(),
+    dmPolicy: DmPolicySchema.optional(),
+    allowFrom: z.array(z.string().trim().min(1)).optional(),
+    groupPolicy: GroupPolicySchema.optional(),
+    groupAllowFrom: z.array(z.string().trim().min(1)).optional(),
+    requireMention: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message: 'channels.slack.dmPolicy="open" requires channels.slack.allowFrom to include "*"',
+    });
+  });
+
+type SlackConfig = z.infer<typeof SlackConfigSchema>;
+type SlackAccountConfig = z.infer<typeof SlackAccountSchema>;
+
+type ResolvedSlackAccount = SlackAccountConfig & {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  botToken?: string;
+  appToken?: string;
+  defaultChannel?: string;
+  dmPolicy: DmPolicy;
+  allowFrom: string[];
+  groupPolicy: "allowlist" | "open" | "disabled";
+  groupAllowFrom: string[];
+  requireMention: boolean;
+};
+
+function normalizeEntries(list?: Array<string | number> | null): string[] {
+  return (list ?? []).map((entry) => String(entry).trim()).filter(Boolean);
+}
+
+function readSlackConfig(cfg: ZeeConfig): SlackConfig {
+  const raw = (cfg.channels as Record<string, unknown> | undefined)?.slack;
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as SlackConfig;
+  }
+  return {};
+}
+
+function listSlackAccountIds(cfg: ZeeConfig): string[] {
+  const section = readSlackConfig(cfg);
+  const ids = Object.keys(section.accounts ?? {}).filter(Boolean);
+  return ids.length > 0 ? ids : [DEFAULT_ACCOUNT_ID];
+}
+
+function resolveDefaultSlackAccountId(cfg: ZeeConfig): string {
+  const ids = listSlackAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) return DEFAULT_ACCOUNT_ID;
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function resolveSlackAccount(cfg: ZeeConfig, accountId?: string | null): ResolvedSlackAccount {
+  const section = readSlackConfig(cfg);
+  const resolvedAccountId = normalizeAccountId(accountId ?? resolveDefaultSlackAccountId(cfg));
+  const account = (section.accounts?.[resolvedAccountId] ?? {}) as SlackAccountConfig;
+  const useTopLevel = resolvedAccountId === DEFAULT_ACCOUNT_ID;
+
+  return {
+    accountId: resolvedAccountId,
+    name: account.name ?? (useTopLevel ? section.name : undefined),
+    enabled: account.enabled ?? (useTopLevel ? section.enabled !== false : true),
+    botToken: account.botToken ?? (useTopLevel ? section.botToken : undefined),
+    appToken: account.appToken ?? (useTopLevel ? section.appToken : undefined),
+    defaultChannel: account.defaultChannel ?? (useTopLevel ? section.defaultChannel : undefined),
+    dmPolicy: account.dmPolicy ?? (useTopLevel ? section.dmPolicy : undefined) ?? "pairing",
+    allowFrom: normalizeEntries(account.allowFrom ?? (useTopLevel ? section.allowFrom : [])),
+    groupPolicy: account.groupPolicy ?? (useTopLevel ? section.groupPolicy : undefined) ?? "allowlist",
+    groupAllowFrom: normalizeEntries(
+      account.groupAllowFrom ?? (useTopLevel ? section.groupAllowFrom : []),
+    ),
+    requireMention:
+      account.requireMention ?? (useTopLevel ? section.requireMention : undefined) ?? true,
+  };
+}
+
+function hasAccountOverride(cfg: ZeeConfig, accountId: string): boolean {
+  return Boolean(readSlackConfig(cfg).accounts?.[accountId]);
+}
+
+function resolveConfigPathPrefix(cfg: ZeeConfig, accountId: string): string {
+  if (hasAccountOverride(cfg, accountId)) {
+    return `channels.slack.accounts.${accountId}.`;
+  }
+  return "channels.slack.";
+}
+
+function resolveSlackTokens(account: ResolvedSlackAccount): {
+  botToken: string | null;
+  botSource: "config" | "env" | "none";
+  appToken: string | null;
+  appSource: "config" | "env" | "none";
+} {
+  const configBot = account.botToken?.trim();
+  const configApp = account.appToken?.trim();
+  const envBot = process.env[SLACK_BOT_TOKEN_ENV]?.trim();
+  const envApp = process.env[SLACK_APP_TOKEN_ENV]?.trim();
+  return {
+    botToken: configBot ?? envBot ?? null,
+    botSource: configBot ? "config" : envBot ? "env" : "none",
+    appToken: configApp ?? envApp ?? null,
+    appSource: configApp ? "config" : envApp ? "env" : "none",
+  };
+}
+
+function applyAccountPatch(params: {
+  cfg: ZeeConfig;
+  accountId: string;
+  patch: Partial<SlackAccountConfig>;
+  unsetKeys?: Array<keyof SlackAccountConfig>;
+}): ZeeConfig {
+  const accountId = normalizeAccountId(params.accountId);
+  const section = readSlackConfig(params.cfg);
+  const accounts = { ...(section.accounts ?? {}) };
+  const existing = { ...(accounts[accountId] ?? {}) } as SlackAccountConfig;
+  const next = {
+    ...existing,
+    ...params.patch,
+  } as SlackAccountConfig;
+  for (const key of params.unsetKeys ?? []) {
+    delete (next as Record<string, unknown>)[key as string];
+  }
+  accounts[accountId] = next;
+  return {
+    ...params.cfg,
+    channels: {
+      ...params.cfg.channels,
+      slack: {
+        ...section,
+        accounts,
+      },
+    },
+  } as ZeeConfig;
+}
+
+function setSlackDmPolicy(cfg: ZeeConfig, accountId: string, dmPolicy: DmPolicy): ZeeConfig {
+  let next = applyAccountPatch({ cfg, accountId, patch: { dmPolicy } });
+  if (dmPolicy === "open") {
+    const resolved = resolveSlackAccount(next, accountId);
+    next = applyAccountPatch({
+      cfg: next,
+      accountId,
+      patch: {
+        allowFrom: addWildcardAllowFrom(resolved.allowFrom),
+      },
+    });
+  }
+  return next;
+}
+
+function setSlackAllowFrom(cfg: ZeeConfig, accountId: string, allowFrom?: string[] | null): ZeeConfig {
+  const normalized = allowFrom ? normalizeEntries(allowFrom) : undefined;
+  return applyAccountPatch({
+    cfg,
+    accountId,
+    patch: {
+      allowFrom: normalized,
+    },
+    unsetKeys: normalized ? undefined : ["allowFrom"],
+  });
+}
+
+function collectSlackStatusIssues(accounts: Array<Record<string, unknown>>): ChannelStatusIssue[] {
+  const issues: ChannelStatusIssue[] = [];
+  for (const account of accounts) {
+    const accountId =
+      typeof account.accountId === "string" && account.accountId.trim()
+        ? account.accountId
+        : DEFAULT_ACCOUNT_ID;
+    if (account.enabled === false) continue;
+
+    if (account.configured !== true) {
+      issues.push({
+        channel: "slack",
+        accountId,
+        kind: "config",
+        message: "Slack bot token is missing.",
+        fix: `Set channels.slack.accounts.${accountId}.botToken or ${SLACK_BOT_TOKEN_ENV}.`,
+      });
+      continue;
+    }
+
+    const dmPolicy = typeof account.dmPolicy === "string" ? account.dmPolicy : "pairing";
+    const allowFrom = Array.isArray(account.allowFrom)
+      ? account.allowFrom.map((value) => String(value))
+      : [];
+    if (dmPolicy === "open" && !allowFrom.includes("*")) {
+      issues.push({
+        channel: "slack",
+        accountId,
+        kind: "config",
+        message: 'dmPolicy="open" requires allowFrom to include "*".',
+      });
+    }
+
+    const groupPolicy = typeof account.mode === "string" ? account.mode : "allowlist";
+    const requireMention = account.allowUnmentionedGroups !== true;
+    if (groupPolicy === "open" && !requireMention) {
+      issues.push({
+        channel: "slack",
+        accountId,
+        kind: "permissions",
+        message: "Group policy is open and mentions are not required.",
+        fix: "Set channels.slack.requireMention=true or channels.slack.groupPolicy=allowlist.",
+      });
+    }
+  }
+  return issues;
+}
+
+async function sendSlackText(params: {
+  account: ResolvedSlackAccount;
+  to: string;
+  text: string;
+  threadId?: string | number | null;
+}): Promise<{
+  messageId: string;
+  channelId: string;
+  meta?: Record<string, unknown>;
+}> {
+  const tokens = resolveSlackTokens(params.account);
+  if (!tokens.botToken) {
+    throw new Error(`Slack bot token is missing. Set channels.slack.botToken or ${SLACK_BOT_TOKEN_ENV}.`);
+  }
+
+  const body: Record<string, unknown> = {
+    channel: params.to,
+    text: params.text,
+  };
+  if (params.threadId !== undefined && params.threadId !== null) {
+    body.thread_ts = String(params.threadId);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  if (typeof timeout.unref === "function") timeout.unref();
+
+  let response: Response;
+  try {
+    response = await fetch(`${SLACK_API_BASE}/chat.postMessage`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${tokens.botToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Slack send failed: ${message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const raw = await response.text();
+  let payload: Record<string, unknown> = {};
+  try {
+    payload = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+  } catch {
+    throw new Error(`Slack API returned invalid JSON (${response.status}).`);
+  }
+
+  const ok = payload.ok === true;
+  if (!response.ok || !ok) {
+    const error =
+      typeof payload.error === "string" && payload.error.trim()
+        ? payload.error.trim()
+        : `HTTP ${response.status}`;
+    throw new Error(`Slack send failed: ${error}`);
+  }
+
+  const channelId = typeof payload.channel === "string" ? payload.channel : params.to;
+  const messageId = typeof payload.ts === "string" ? payload.ts : `${Date.now()}`;
+
+  return {
+    messageId,
+    channelId,
+    meta: {
+      threadTs: typeof payload.ts === "string" ? payload.ts : undefined,
+    },
+  };
+}
+
+const slackOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel: "slack",
+  getStatus: async ({ cfg, accountOverrides }) => {
+    const overrideId = accountOverrides.slack?.trim();
+    const accountId = overrideId ? normalizeAccountId(overrideId) : resolveDefaultSlackAccountId(cfg);
+    const account = resolveSlackAccount(cfg, accountId);
+    const tokens = resolveSlackTokens(account);
+    const configured = tokens.botSource !== "none";
+    return {
+      channel: "slack",
+      configured,
+      statusLines: [
+        `Slack (${accountId === DEFAULT_ACCOUNT_ID ? "default" : accountId}): ${
+          configured ? `configured (${tokens.botSource})` : "token missing"
+        }`,
+      ],
+      selectionHint: configured ? "configured" : "token missing",
+      quickstartScore: configured ? 3 : 1,
+    };
+  },
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const overrideId = accountOverrides.slack?.trim();
+    let accountId = overrideId ? normalizeAccountId(overrideId) : resolveDefaultSlackAccountId(cfg);
+
+    if (shouldPromptAccountIds && !overrideId) {
+      accountId = await promptAccountId({
+        cfg,
+        prompter,
+        label: "Slack",
+        currentId: accountId,
+        listAccountIds: listSlackAccountIds,
+        defaultAccountId: resolveDefaultSlackAccountId(cfg),
+      });
+    }
+
+    const current = resolveSlackAccount(cfg, accountId);
+    const tokenInfo = resolveSlackTokens(current);
+
+    const botToken = await prompter.text({
+      message: `Slack bot token (${accountId})`,
+      initialValue: current.botToken,
+      placeholder: "xoxb-...",
+      validate: (value) => {
+        const trimmed = String(value ?? "").trim();
+        if (trimmed) return undefined;
+        if (tokenInfo.botSource !== "none") return undefined;
+        return `Required unless ${SLACK_BOT_TOKEN_ENV} is set.`;
+      },
+    });
+
+    const defaultChannel = await prompter.text({
+      message: "Default Slack channel id (optional)",
+      initialValue: current.defaultChannel,
+      placeholder: "C0123456789",
+    });
+
+    const requireMention = await prompter.confirm({
+      message: "Require mentions for Slack channel messages?",
+      initialValue: current.requireMention,
+    });
+
+    let next = applyAccountPatch({
+      cfg,
+      accountId,
+      patch: {
+        enabled: true,
+        requireMention,
+      },
+    });
+
+    const normalizedToken = String(botToken ?? "").trim();
+    if (normalizedToken) {
+      next = applyAccountPatch({
+        cfg: next,
+        accountId,
+        patch: {
+          botToken: normalizedToken,
+        },
+      });
+    }
+
+    const normalizedChannel = String(defaultChannel ?? "").trim();
+    if (normalizedChannel) {
+      next = applyAccountPatch({
+        cfg: next,
+        accountId,
+        patch: {
+          defaultChannel: normalizedChannel,
+        },
+      });
+    }
+
+    await prompter.note(
+      [
+        "Slack setup complete.",
+        "Use `zee channels status` to verify token + routing.",
+        `Docs: ${formatDocsLink("/channels/slack", "channels/slack")}`,
+      ].join("\n"),
+      "Slack",
+    );
+
+    return { cfg: next, accountId };
+  },
+  dmPolicy: {
+    label: "Slack",
+    channel: "slack",
+    policyKey: "channels.slack.dmPolicy",
+    allowFromKey: "channels.slack.allowFrom",
+    getCurrent: (cfg) => resolveSlackAccount(cfg, resolveDefaultSlackAccountId(cfg)).dmPolicy,
+    setPolicy: (cfg, policy) => setSlackDmPolicy(cfg, resolveDefaultSlackAccountId(cfg), policy),
+    promptAllowFrom: async ({ cfg, prompter, accountId }) => {
+      const resolvedAccountId = accountId
+        ? normalizeAccountId(accountId)
+        : resolveDefaultSlackAccountId(cfg);
+      const account = resolveSlackAccount(cfg, resolvedAccountId);
+      const raw = await prompter.text({
+        message: "Slack DM allowFrom (comma-separated user ids)",
+        initialValue: account.allowFrom.join(", "),
+        placeholder: "U01234, U05678",
+      });
+      const entries = normalizeEntries(String(raw ?? "").split(/[\n,;]+/g));
+      return setSlackAllowFrom(cfg, resolvedAccountId, entries);
+    },
+  },
+};
+
+function normalizeSlackTarget(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  return trimmed.replace(/^slack:/i, "");
+}
+
+function looksLikeSlackTargetId(raw: string, normalized?: string): boolean {
+  const value = (normalized ?? raw).trim();
+  return /^[CDGU][A-Z0-9]{8,}$/i.test(value) || /^#[a-z0-9._-]+$/i.test(value);
+}
+
+export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
+  id: "slack",
+  meta: SLACK_META,
+  onboarding: slackOnboardingAdapter,
+  pairing: {
+    idLabel: "slackSenderId",
+  },
+  capabilities: {
+    chatTypes: ["direct", "group", "thread"],
+    media: true,
+    reactions: true,
+    threads: true,
+  },
+  configSchema: buildChannelConfigSchema(SlackConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listSlackAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveSlackAccount(cfg, accountId),
+    defaultAccountId: (cfg) => resolveDefaultSlackAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "slack",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "slack",
+        accountId,
+        clearBaseFields: [
+          "name",
+          "enabled",
+          "botToken",
+          "appToken",
+          "defaultChannel",
+          "dmPolicy",
+          "allowFrom",
+          "groupPolicy",
+          "groupAllowFrom",
+          "requireMention",
+        ],
+      }),
+    isEnabled: (account) => account.enabled !== false,
+    disabledReason: () => "disabled",
+    isConfigured: async (account) => resolveSlackTokens(account).botSource !== "none",
+    unconfiguredReason: () => "bot token missing",
+    describeAccount: (account) => {
+      const tokens = resolveSlackTokens(account);
+      return {
+        accountId: account.accountId,
+        name: account.name,
+        enabled: account.enabled,
+        configured: tokens.botSource !== "none",
+        dmPolicy: account.dmPolicy,
+        allowFrom: account.allowFrom,
+        mode: account.groupPolicy,
+        allowUnmentionedGroups: account.requireMention === false,
+        botTokenSource: tokens.botSource,
+        appTokenSource: tokens.appSource,
+      };
+    },
+    resolveAllowFrom: ({ cfg, accountId }) => resolveSlackAccount(cfg, accountId).allowFrom,
+    formatAllowFrom: ({ allowFrom }) => normalizeEntries(allowFrom),
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const prefix = resolveConfigPathPrefix(cfg, resolvedAccountId);
+      return {
+        policy: account.dmPolicy,
+        allowFrom: account.allowFrom,
+        policyPath: `${prefix}dmPolicy`,
+        allowFromPath: prefix,
+        approveHint: formatPairingApproveHint("slack"),
+        normalizeEntry: (raw) => raw.trim(),
+      };
+    },
+    collectWarnings: ({ account }) => {
+      const warnings: string[] = [];
+      if (account.groupPolicy === "open") {
+        if (account.requireMention) {
+          warnings.push(
+            '- Slack groups/channels: groupPolicy="open" allows any member in allowed channels to trigger when Zee is mentioned. Prefer groupPolicy="allowlist" for tighter control.',
+          );
+        } else {
+          warnings.push(
+            '- Slack groups/channels: groupPolicy="open" with requireMention=false allows any member to trigger actions. Set requireMention=true or groupPolicy="allowlist".',
+          );
+        }
+      }
+      return warnings;
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "slack",
+        accountId,
+        name,
+        alwaysUseAccounts: true,
+      }),
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      let next = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "slack",
+        accountId,
+        name: input.name,
+        alwaysUseAccounts: true,
+      });
+
+      const botToken = input.botToken?.trim() || input.token?.trim() || undefined;
+      const appToken = input.appToken?.trim() || undefined;
+      const defaultChannel = input.audience?.trim() || input.url?.trim() || undefined;
+      const dmAllowlist = normalizeEntries(input.dmAllowlist);
+      const groupAllowlist = normalizeEntries(input.groupChannels);
+
+      next = applyAccountPatch({
+        cfg: next,
+        accountId,
+        patch: {
+          enabled: true,
+          ...(botToken ? { botToken } : {}),
+          ...(appToken ? { appToken } : {}),
+          ...(defaultChannel ? { defaultChannel } : {}),
+          ...(dmAllowlist.length > 0 ? { allowFrom: dmAllowlist } : {}),
+          ...(groupAllowlist.length > 0 ? { groupAllowFrom: groupAllowlist } : {}),
+        },
+      });
+
+      return next;
+    },
+  },
+  groups: {
+    resolveRequireMention: ({ cfg, accountId }) => resolveSlackAccount(cfg, accountId).requireMention,
+  },
+  commands: {
+    enforceOwnerForCommands: true,
+    skipWhenConfigEmpty: true,
+  },
+  messaging: {
+    normalizeTarget: normalizeSlackTarget,
+    targetResolver: {
+      looksLikeId: looksLikeSlackTargetId,
+      hint: "<channel-id|#channel>",
+    },
+  },
+  status: {
+    buildAccountSnapshot: ({ account }) => {
+      const tokens = resolveSlackTokens(account);
+      return {
+        accountId: account.accountId,
+        name: account.name,
+        enabled: account.enabled,
+        configured: tokens.botSource !== "none",
+        dmPolicy: account.dmPolicy,
+        allowFrom: account.allowFrom,
+        mode: account.groupPolicy,
+        allowUnmentionedGroups: account.requireMention === false,
+        botTokenSource: tokens.botSource,
+        appTokenSource: tokens.appSource,
+      };
+    },
+    collectStatusIssues: (accounts) => collectSlackStatusIssues(accounts as Array<Record<string, unknown>>),
+  },
+  outbound: {
+    deliveryMode: "direct",
+    textChunkLimit: 4000,
+    resolveTarget: ({ cfg, accountId, to, allowFrom }) => {
+      const trimmed = to?.trim();
+      if (trimmed) return { ok: true, to: normalizeSlackTarget(trimmed) ?? trimmed };
+
+      const account = cfg ? resolveSlackAccount(cfg, accountId) : null;
+      const allowlist = normalizeEntries(allowFrom).filter((entry) => entry !== "*");
+      const fallback = account?.defaultChannel?.trim() || allowlist[0];
+      if (fallback) return { ok: true, to: fallback };
+
+      return {
+        ok: false,
+        error: missingTargetError(
+          "Slack",
+          "<channel-id|#channel> or channels.slack.defaultChannel",
+        ),
+      };
+    },
+    sendText: async ({ cfg, to, text, threadId, accountId }) => {
+      const account = resolveSlackAccount(cfg, accountId);
+      const result = await sendSlackText({
+        account,
+        to,
+        text,
+        threadId,
+      });
+      return {
+        channel: "slack",
+        messageId: result.messageId,
+        channelId: result.channelId,
+        meta: result.meta,
+      };
+    },
+    sendMedia: async ({ cfg, to, text, mediaUrl, threadId, accountId }) => {
+      const account = resolveSlackAccount(cfg, accountId);
+      const composed = mediaUrl ? `${text ? `${text}\n\n` : ""}${mediaUrl}` : text;
+      const result = await sendSlackText({
+        account,
+        to,
+        text: composed,
+        threadId,
+      });
+      return {
+        channel: "slack",
+        messageId: result.messageId,
+        channelId: result.channelId,
+        meta: result.meta,
+      };
+    },
+  },
+};

--- a/packages/zee/Swabble/extensions/slack/zee.plugin.json
+++ b/packages/zee/Swabble/extensions/slack/zee.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "slack",
+  "channels": [
+    "slack"
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/packages/zee/Swabble/extensions/telegram/clawdbot.plugin.json
+++ b/packages/zee/Swabble/extensions/telegram/clawdbot.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "telegram",
+  "channels": [
+    "telegram"
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/packages/zee/Swabble/extensions/telegram/index.ts
+++ b/packages/zee/Swabble/extensions/telegram/index.ts
@@ -1,0 +1,16 @@
+import type { ZeePluginApi } from "zee/plugin-sdk";
+import { emptyPluginConfigSchema } from "zee/plugin-sdk";
+
+import { telegramPlugin } from "./src/channel.js";
+
+const plugin = {
+  id: "telegram",
+  name: "Telegram",
+  description: "Telegram channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: ZeePluginApi) {
+    api.registerChannel({ plugin: telegramPlugin });
+  },
+};
+
+export default plugin;

--- a/packages/zee/Swabble/extensions/telegram/package.json
+++ b/packages/zee/Swabble/extensions/telegram/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@zee/telegram",
+  "version": "2026.2.12-beta.1",
+  "type": "module",
+  "description": "Zee Telegram channel plugin",
+  "zee": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "telegram",
+      "label": "Telegram",
+      "selectionLabel": "Telegram Bot",
+      "detailLabel": "Telegram Bot API",
+      "docsPath": "/channels/telegram",
+      "docsLabel": "telegram",
+      "blurb": "bot token + chat/group target ids; DM/group policy controls mirror WhatsApp semantics.",
+      "order": 20,
+      "aliases": [
+        "tg"
+      ],
+      "systemImage": "paperplane",
+      "quickstartAllowFrom": true,
+      "forceAccountBinding": true
+    }
+  }
+}

--- a/packages/zee/Swabble/extensions/telegram/src/channel.test.ts
+++ b/packages/zee/Swabble/extensions/telegram/src/channel.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { telegramPlugin } from "./channel.js";
+
+describe("telegram channel plugin", () => {
+  it("uses account-scoped DM policy paths for multi-account configs", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            personal: {
+              enabled: true,
+              botToken: "token-1",
+              dmPolicy: "allowlist",
+              allowFrom: ["12345"],
+            },
+          },
+        },
+      },
+    } as any;
+
+    const account = telegramPlugin.config.resolveAccount(cfg, "personal");
+    const dmPolicy = telegramPlugin.security?.resolveDmPolicy?.({
+      cfg,
+      accountId: "personal",
+      account,
+    });
+
+    expect(dmPolicy?.policyPath).toBe("channels.telegram.accounts.personal.dmPolicy");
+    expect(dmPolicy?.allowFromPath).toBe("channels.telegram.accounts.personal.");
+  });
+
+  it("surfaces risky open-group configuration as a security warning", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "token-1",
+          dmPolicy: "allowlist",
+          allowFrom: ["12345"],
+          groupPolicy: "open",
+          requireMention: false,
+        },
+      },
+    } as any;
+
+    const account = telegramPlugin.config.resolveAccount(cfg, "default");
+    const warnings = await telegramPlugin.security?.collectWarnings?.({
+      cfg,
+      accountId: "default",
+      account,
+    });
+
+    expect(warnings?.some((entry) => entry.includes("requireMention=false"))).toBe(true);
+  });
+
+  it("reports missing token in status issues", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          dmPolicy: "pairing",
+        },
+      },
+    } as any;
+
+    const account = telegramPlugin.config.resolveAccount(cfg, "default");
+    const snapshot = await telegramPlugin.status?.buildAccountSnapshot?.({
+      cfg,
+      account,
+    });
+    const issues = telegramPlugin.status?.collectStatusIssues?.([snapshot ?? { accountId: "default" }]);
+
+    expect(issues?.some((issue) => issue.message.includes("token is missing"))).toBe(true);
+  });
+});

--- a/packages/zee/Swabble/extensions/telegram/src/channel.ts
+++ b/packages/zee/Swabble/extensions/telegram/src/channel.ts
@@ -1,0 +1,782 @@
+import { z } from "zod";
+
+import {
+  DEFAULT_ACCOUNT_ID,
+  DmPolicySchema,
+  GroupPolicySchema,
+  addWildcardAllowFrom,
+  applyAccountNameToChannelSection,
+  buildChannelConfigSchema,
+  deleteAccountFromConfigSection,
+  formatDocsLink,
+  formatPairingApproveHint,
+  missingTargetError,
+  normalizeAccountId,
+  promptAccountId,
+  requireOpenAllowFrom,
+  setAccountEnabledInConfigSection,
+  type ChannelOnboardingAdapter,
+  type ChannelPlugin,
+  type ChannelStatusIssue,
+  type DmPolicy,
+  type ZeeConfig,
+} from "zee/plugin-sdk";
+
+const TELEGRAM_META = {
+  id: "telegram",
+  label: "Telegram",
+  selectionLabel: "Telegram Bot",
+  detailLabel: "Telegram Bot API",
+  docsPath: "/channels/telegram",
+  docsLabel: "telegram",
+  blurb: "bot token + chat/group target ids; DM/group policy controls mirror WhatsApp semantics.",
+  order: 20,
+  aliases: ["tg"],
+  systemImage: "paperplane",
+  quickstartAllowFrom: true,
+  forceAccountBinding: true,
+} as const;
+
+const TELEGRAM_BOT_TOKEN_ENV = "TELEGRAM_BOT_TOKEN";
+const TELEGRAM_DEFAULT_BASE_URL = "https://api.telegram.org";
+
+const TelegramAccountSchema = z
+  .object({
+    name: z.string().trim().min(1).optional(),
+    enabled: z.boolean().optional(),
+    botToken: z.string().trim().min(1).optional(),
+    defaultTarget: z.string().trim().min(1).optional(),
+    dmPolicy: DmPolicySchema.optional(),
+    allowFrom: z.array(z.string().trim().min(1)).optional(),
+    groupPolicy: GroupPolicySchema.optional(),
+    groupAllowFrom: z.array(z.string().trim().min(1)).optional(),
+    requireMention: z.boolean().optional(),
+    baseUrl: z.string().trim().url().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message: 'dmPolicy="open" requires allowFrom to include "*"',
+    });
+  });
+
+const TelegramConfigSchema = z
+  .object({
+    accounts: z.record(z.string(), TelegramAccountSchema).optional(),
+    name: z.string().trim().min(1).optional(),
+    enabled: z.boolean().optional(),
+    botToken: z.string().trim().min(1).optional(),
+    defaultTarget: z.string().trim().min(1).optional(),
+    dmPolicy: DmPolicySchema.optional(),
+    allowFrom: z.array(z.string().trim().min(1)).optional(),
+    groupPolicy: GroupPolicySchema.optional(),
+    groupAllowFrom: z.array(z.string().trim().min(1)).optional(),
+    requireMention: z.boolean().optional(),
+    baseUrl: z.string().trim().url().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    requireOpenAllowFrom({
+      policy: value.dmPolicy,
+      allowFrom: value.allowFrom,
+      ctx,
+      path: ["allowFrom"],
+      message: 'channels.telegram.dmPolicy="open" requires channels.telegram.allowFrom to include "*"',
+    });
+  });
+
+type TelegramConfig = z.infer<typeof TelegramConfigSchema>;
+type TelegramAccountConfig = z.infer<typeof TelegramAccountSchema>;
+
+type ResolvedTelegramAccount = TelegramAccountConfig & {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  botToken?: string;
+  dmPolicy: DmPolicy;
+  allowFrom: string[];
+  groupPolicy: "allowlist" | "open" | "disabled";
+  groupAllowFrom: string[];
+  requireMention: boolean;
+  defaultTarget?: string;
+  baseUrl: string;
+};
+
+function normalizeEntries(list?: Array<string | number> | null): string[] {
+  return (list ?? []).map((value) => String(value).trim()).filter(Boolean);
+}
+
+function readTelegramConfig(cfg: ZeeConfig): TelegramConfig {
+  const raw = (cfg.channels as Record<string, unknown> | undefined)?.telegram;
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as TelegramConfig;
+  }
+  return {};
+}
+
+function listTelegramAccountIds(cfg: ZeeConfig): string[] {
+  const section = readTelegramConfig(cfg);
+  const accountIds = Object.keys(section.accounts ?? {}).filter(Boolean);
+  return accountIds.length > 0 ? accountIds : [DEFAULT_ACCOUNT_ID];
+}
+
+function resolveDefaultTelegramAccountId(cfg: ZeeConfig): string {
+  const accountIds = listTelegramAccountIds(cfg);
+  if (accountIds.includes(DEFAULT_ACCOUNT_ID)) return DEFAULT_ACCOUNT_ID;
+  return accountIds[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function resolveTelegramAccount(cfg: ZeeConfig, accountId?: string | null): ResolvedTelegramAccount {
+  const section = readTelegramConfig(cfg);
+  const resolvedAccountId = normalizeAccountId(accountId ?? resolveDefaultTelegramAccountId(cfg));
+  const account = (section.accounts?.[resolvedAccountId] ?? {}) as TelegramAccountConfig;
+  const useTopLevel = resolvedAccountId === DEFAULT_ACCOUNT_ID;
+
+  const allowFrom = normalizeEntries(account.allowFrom ?? (useTopLevel ? section.allowFrom : []));
+  const groupAllowFrom = normalizeEntries(
+    account.groupAllowFrom ?? (useTopLevel ? section.groupAllowFrom : []),
+  );
+
+  return {
+    accountId: resolvedAccountId,
+    name: account.name ?? (useTopLevel ? section.name : undefined),
+    enabled: account.enabled ?? (useTopLevel ? section.enabled !== false : true),
+    botToken: account.botToken ?? (useTopLevel ? section.botToken : undefined),
+    defaultTarget: account.defaultTarget ?? (useTopLevel ? section.defaultTarget : undefined),
+    dmPolicy: account.dmPolicy ?? (useTopLevel ? section.dmPolicy : undefined) ?? "pairing",
+    allowFrom,
+    groupPolicy: account.groupPolicy ?? (useTopLevel ? section.groupPolicy : undefined) ?? "allowlist",
+    groupAllowFrom,
+    requireMention:
+      account.requireMention ?? (useTopLevel ? section.requireMention : undefined) ?? true,
+    baseUrl: account.baseUrl ?? (useTopLevel ? section.baseUrl : undefined) ?? TELEGRAM_DEFAULT_BASE_URL,
+  };
+}
+
+function hasAccountOverride(cfg: ZeeConfig, accountId: string): boolean {
+  return Boolean(readTelegramConfig(cfg).accounts?.[accountId]);
+}
+
+function resolveConfigPathPrefix(cfg: ZeeConfig, accountId: string): string {
+  if (hasAccountOverride(cfg, accountId)) {
+    return `channels.telegram.accounts.${accountId}.`;
+  }
+  return "channels.telegram.";
+}
+
+function resolveTelegramToken(account: ResolvedTelegramAccount): {
+  token: string | null;
+  source: "config" | "env" | "none";
+} {
+  const configToken = account.botToken?.trim();
+  if (configToken) return { token: configToken, source: "config" };
+  const envToken = process.env[TELEGRAM_BOT_TOKEN_ENV]?.trim();
+  if (envToken) return { token: envToken, source: "env" };
+  return { token: null, source: "none" };
+}
+
+function applyAccountPatch(params: {
+  cfg: ZeeConfig;
+  accountId: string;
+  patch: Partial<TelegramAccountConfig>;
+  unsetKeys?: Array<keyof TelegramAccountConfig>;
+}): ZeeConfig {
+  const accountId = normalizeAccountId(params.accountId);
+  const section = readTelegramConfig(params.cfg);
+  const accounts = { ...(section.accounts ?? {}) };
+  const existing = { ...(accounts[accountId] ?? {}) } as TelegramAccountConfig;
+  const next = {
+    ...existing,
+    ...params.patch,
+  } as TelegramAccountConfig;
+
+  for (const key of params.unsetKeys ?? []) {
+    delete (next as Record<string, unknown>)[key as string];
+  }
+
+  accounts[accountId] = next;
+
+  return {
+    ...params.cfg,
+    channels: {
+      ...params.cfg.channels,
+      telegram: {
+        ...section,
+        accounts,
+      },
+    },
+  } as ZeeConfig;
+}
+
+function setTelegramDmPolicy(cfg: ZeeConfig, accountId: string, dmPolicy: DmPolicy): ZeeConfig {
+  let next = applyAccountPatch({
+    cfg,
+    accountId,
+    patch: {
+      dmPolicy,
+    },
+  });
+  if (dmPolicy === "open") {
+    const resolved = resolveTelegramAccount(next, accountId);
+    next = applyAccountPatch({
+      cfg: next,
+      accountId,
+      patch: {
+        allowFrom: addWildcardAllowFrom(resolved.allowFrom),
+      },
+    });
+  }
+  return next;
+}
+
+function setTelegramAllowFrom(
+  cfg: ZeeConfig,
+  accountId: string,
+  allowFrom?: string[] | null,
+): ZeeConfig {
+  const normalized = allowFrom ? normalizeEntries(allowFrom) : undefined;
+  return applyAccountPatch({
+    cfg,
+    accountId,
+    patch: {
+      allowFrom: normalized,
+    },
+    unsetKeys: normalized ? undefined : ["allowFrom"],
+  });
+}
+
+async function parseTelegramResponse(res: Response): Promise<Record<string, unknown>> {
+  const raw = await res.text();
+  let parsed: unknown;
+  try {
+    parsed = raw ? (JSON.parse(raw) as unknown) : {};
+  } catch {
+    throw new Error(`Telegram API returned invalid JSON (${res.status}).`);
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`Telegram API returned an invalid payload (${res.status}).`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function toTelegramChatId(value: string): string | number {
+  return /^-?\d+$/.test(value) ? Number.parseInt(value, 10) : value;
+}
+
+async function sendTelegramText(params: {
+  account: ResolvedTelegramAccount;
+  to: string;
+  text: string;
+  threadId?: string | number | null;
+}): Promise<{
+  messageId: string;
+  chatId: string;
+  timestamp: number;
+  meta?: Record<string, unknown>;
+}> {
+  const token = resolveTelegramToken(params.account).token;
+  if (!token) {
+    throw new Error(
+      `Telegram token is missing. Set channels.telegram.botToken or ${TELEGRAM_BOT_TOKEN_ENV}.`,
+    );
+  }
+
+  const endpointBase = params.account.baseUrl.replace(/\/$/, "");
+  const endpoint = `${endpointBase}/bot${token}/sendMessage`;
+  const payload: Record<string, unknown> = {
+    chat_id: toTelegramChatId(params.to),
+    text: params.text,
+  };
+  if (params.threadId !== undefined && params.threadId !== null) {
+    payload.message_thread_id =
+      typeof params.threadId === "number"
+        ? params.threadId
+        : /^\d+$/.test(String(params.threadId))
+          ? Number.parseInt(String(params.threadId), 10)
+          : String(params.threadId);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  if (typeof timeout.unref === "function") timeout.unref();
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Telegram send failed: ${message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const parsed = await parseTelegramResponse(response);
+  const ok = parsed.ok === true;
+  if (!response.ok || !ok) {
+    const description =
+      typeof parsed.description === "string" && parsed.description.trim()
+        ? parsed.description.trim()
+        : `HTTP ${response.status}`;
+    throw new Error(`Telegram send failed: ${description}`);
+  }
+
+  const result =
+    parsed.result && typeof parsed.result === "object"
+      ? (parsed.result as Record<string, unknown>)
+      : {};
+  const resultChat =
+    result.chat && typeof result.chat === "object"
+      ? (result.chat as Record<string, unknown>)
+      : {};
+
+  const messageId =
+    typeof result.message_id === "number"
+      ? String(result.message_id)
+      : typeof result.message_id === "string"
+        ? result.message_id
+        : `${Date.now()}`;
+  const chatId =
+    typeof resultChat.id === "number"
+      ? String(resultChat.id)
+      : typeof resultChat.id === "string"
+        ? resultChat.id
+        : params.to;
+  const timestamp =
+    typeof result.date === "number" && Number.isFinite(result.date)
+      ? result.date * 1000
+      : Date.now();
+
+  return {
+    messageId,
+    chatId,
+    timestamp,
+    meta:
+      typeof resultChat.type === "string"
+        ? {
+            chatType: resultChat.type,
+          }
+        : undefined,
+  };
+}
+
+function collectTelegramStatusIssues(accounts: Array<Record<string, unknown>>): ChannelStatusIssue[] {
+  const issues: ChannelStatusIssue[] = [];
+  for (const account of accounts) {
+    const accountId =
+      typeof account.accountId === "string" && account.accountId.trim()
+        ? account.accountId
+        : DEFAULT_ACCOUNT_ID;
+    const enabled = account.enabled !== false;
+    if (!enabled) continue;
+
+    const configured = account.configured === true;
+    if (!configured) {
+      issues.push({
+        channel: "telegram",
+        accountId,
+        kind: "config",
+        message: "Telegram bot token is missing.",
+        fix: `Set channels.telegram.accounts.${accountId}.botToken or ${TELEGRAM_BOT_TOKEN_ENV}.`,
+      });
+      continue;
+    }
+
+    const dmPolicy = typeof account.dmPolicy === "string" ? account.dmPolicy : "pairing";
+    const allowFrom = Array.isArray(account.allowFrom)
+      ? account.allowFrom.map((entry) => String(entry))
+      : [];
+    if (dmPolicy === "open" && !allowFrom.includes("*")) {
+      issues.push({
+        channel: "telegram",
+        accountId,
+        kind: "config",
+        message: 'dmPolicy="open" requires allowFrom to include "*".',
+      });
+    }
+
+    const groupPolicy = typeof account.mode === "string" ? account.mode : "allowlist";
+    const requireMention = account.allowUnmentionedGroups !== true;
+    if (groupPolicy === "open" && !requireMention) {
+      issues.push({
+        channel: "telegram",
+        accountId,
+        kind: "permissions",
+        message: "Group policy is open and mentions are not required.",
+        fix: "Set channels.telegram.requireMention=true or channels.telegram.groupPolicy=allowlist.",
+      });
+    }
+  }
+  return issues;
+}
+
+const telegramOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel: "telegram",
+  getStatus: async ({ cfg, accountOverrides }) => {
+    const overrideId = accountOverrides.telegram?.trim();
+    const accountId = overrideId
+      ? normalizeAccountId(overrideId)
+      : resolveDefaultTelegramAccountId(cfg);
+    const account = resolveTelegramAccount(cfg, accountId);
+    const tokenSource = resolveTelegramToken(account).source;
+    const configured = tokenSource !== "none";
+    return {
+      channel: "telegram",
+      configured,
+      statusLines: [
+        `Telegram (${accountId === DEFAULT_ACCOUNT_ID ? "default" : accountId}): ${
+          configured ? `configured (${tokenSource})` : "token missing"
+        }`,
+      ],
+      selectionHint: configured ? "configured" : "token missing",
+      quickstartScore: configured ? 4 : 2,
+    };
+  },
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const overrideId = accountOverrides.telegram?.trim();
+    let accountId = overrideId
+      ? normalizeAccountId(overrideId)
+      : resolveDefaultTelegramAccountId(cfg);
+
+    if (shouldPromptAccountIds && !overrideId) {
+      accountId = await promptAccountId({
+        cfg,
+        prompter,
+        label: "Telegram",
+        currentId: accountId,
+        listAccountIds: listTelegramAccountIds,
+        defaultAccountId: resolveDefaultTelegramAccountId(cfg),
+      });
+    }
+
+    const current = resolveTelegramAccount(cfg, accountId);
+    const tokenHint = resolveTelegramToken(current).source;
+    const token = await prompter.text({
+      message: `Telegram bot token (${accountId})`,
+      initialValue: current.botToken,
+      placeholder: "123456789:AA...",
+      validate: (value) => {
+        const trimmed = String(value ?? "").trim();
+        if (trimmed) return undefined;
+        if (tokenHint !== "none") return undefined;
+        return `Required unless ${TELEGRAM_BOT_TOKEN_ENV} is set.`;
+      },
+    });
+
+    const defaultTarget = await prompter.text({
+      message: "Default Telegram target (optional chat id or @username)",
+      initialValue: current.defaultTarget,
+      placeholder: "-1001234567890",
+    });
+
+    const requireMention = await prompter.confirm({
+      message: "Require mentions for Telegram group messages?",
+      initialValue: current.requireMention,
+    });
+
+    let next = applyAccountPatch({
+      cfg,
+      accountId,
+      patch: {
+        enabled: true,
+        requireMention,
+      },
+    });
+
+    const normalizedToken = String(token ?? "").trim();
+    if (normalizedToken) {
+      next = applyAccountPatch({
+        cfg: next,
+        accountId,
+        patch: {
+          botToken: normalizedToken,
+        },
+      });
+    }
+
+    const normalizedTarget = String(defaultTarget ?? "").trim();
+    if (normalizedTarget) {
+      next = applyAccountPatch({
+        cfg: next,
+        accountId,
+        patch: {
+          defaultTarget: normalizedTarget,
+        },
+      });
+    }
+
+    await prompter.note(
+      [
+        "Telegram setup complete.",
+        "Use `zee channels status` to verify token + routing.",
+        `Docs: ${formatDocsLink("/channels/telegram", "channels/telegram")}`,
+      ].join("\n"),
+      "Telegram",
+    );
+
+    return { cfg: next, accountId };
+  },
+  dmPolicy: {
+    label: "Telegram",
+    channel: "telegram",
+    policyKey: "channels.telegram.dmPolicy",
+    allowFromKey: "channels.telegram.allowFrom",
+    getCurrent: (cfg) => {
+      const account = resolveTelegramAccount(cfg, resolveDefaultTelegramAccountId(cfg));
+      return account.dmPolicy;
+    },
+    setPolicy: (cfg, policy) =>
+      setTelegramDmPolicy(cfg, resolveDefaultTelegramAccountId(cfg), policy),
+    promptAllowFrom: async ({ cfg, prompter, accountId }) => {
+      const resolvedAccountId = accountId
+        ? normalizeAccountId(accountId)
+        : resolveDefaultTelegramAccountId(cfg);
+      const account = resolveTelegramAccount(cfg, resolvedAccountId);
+      const raw = await prompter.text({
+        message: "Telegram DM allowFrom (comma-separated user/chat ids)",
+        initialValue: account.allowFrom.join(", "),
+        placeholder: "12345678, 99887766",
+      });
+      const entries = normalizeEntries(String(raw ?? "").split(/[\n,;]+/g));
+      return setTelegramAllowFrom(cfg, resolvedAccountId, entries);
+    },
+  },
+};
+
+function normalizeTelegramTarget(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  return trimmed.replace(/^telegram:/i, "");
+}
+
+function looksLikeTelegramTargetId(raw: string, normalized?: string): boolean {
+  const value = (normalized ?? raw).trim();
+  return /^@?[a-zA-Z0-9_]{5,}$/.test(value) || /^-?\d{5,}$/.test(value);
+}
+
+export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount> = {
+  id: "telegram",
+  meta: TELEGRAM_META,
+  onboarding: telegramOnboardingAdapter,
+  pairing: {
+    idLabel: "telegramSenderId",
+  },
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    media: true,
+  },
+  configSchema: buildChannelConfigSchema(TelegramConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listTelegramAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveTelegramAccount(cfg, accountId),
+    defaultAccountId: (cfg) => resolveDefaultTelegramAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "telegram",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "telegram",
+        accountId,
+        clearBaseFields: [
+          "name",
+          "enabled",
+          "botToken",
+          "defaultTarget",
+          "dmPolicy",
+          "allowFrom",
+          "groupPolicy",
+          "groupAllowFrom",
+          "requireMention",
+          "baseUrl",
+        ],
+      }),
+    isEnabled: (account) => account.enabled !== false,
+    disabledReason: () => "disabled",
+    isConfigured: async (account) => resolveTelegramToken(account).source !== "none",
+    unconfiguredReason: () => "token missing",
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: resolveTelegramToken(account).source !== "none",
+      dmPolicy: account.dmPolicy,
+      allowFrom: account.allowFrom,
+      tokenSource: resolveTelegramToken(account).source,
+      mode: account.groupPolicy,
+      allowUnmentionedGroups: account.requireMention === false,
+      baseUrl: account.baseUrl,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) => resolveTelegramAccount(cfg, accountId).allowFrom,
+    formatAllowFrom: ({ allowFrom }) => normalizeEntries(allowFrom),
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      return {
+        policy: account.dmPolicy,
+        allowFrom: account.allowFrom,
+        policyPath: `${resolveConfigPathPrefix(cfg, resolvedAccountId)}dmPolicy`,
+        allowFromPath: resolveConfigPathPrefix(cfg, resolvedAccountId),
+        approveHint: formatPairingApproveHint("telegram"),
+        normalizeEntry: (raw) => raw.trim(),
+      };
+    },
+    collectWarnings: ({ account }) => {
+      const warnings: string[] = [];
+      if (account.groupPolicy === "open") {
+        if (account.requireMention) {
+          warnings.push(
+            '- Telegram groups: groupPolicy="open" allows any member in allowed groups to trigger when Zee is mentioned. Prefer groupPolicy="allowlist" for tighter control.',
+          );
+        } else {
+          warnings.push(
+            '- Telegram groups: groupPolicy="open" with requireMention=false allows any member to trigger actions. Set requireMention=true or groupPolicy="allowlist".',
+          );
+        }
+      }
+      return warnings;
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "telegram",
+        accountId,
+        name,
+        alwaysUseAccounts: true,
+      }),
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      let next = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "telegram",
+        accountId,
+        name: input.name,
+        alwaysUseAccounts: true,
+      });
+
+      const token = input.botToken?.trim() || input.token?.trim() || undefined;
+      const defaultTarget = input.audience?.trim() || input.url?.trim() || undefined;
+      const dmAllowlist = normalizeEntries(input.dmAllowlist);
+      const groupAllowlist = normalizeEntries(input.groupChannels);
+
+      next = applyAccountPatch({
+        cfg: next,
+        accountId,
+        patch: {
+          enabled: true,
+          ...(token ? { botToken: token } : {}),
+          ...(defaultTarget ? { defaultTarget } : {}),
+          ...(dmAllowlist.length > 0 ? { allowFrom: dmAllowlist } : {}),
+          ...(groupAllowlist.length > 0 ? { groupAllowFrom: groupAllowlist } : {}),
+        },
+      });
+      return next;
+    },
+  },
+  groups: {
+    resolveRequireMention: ({ cfg, accountId }) =>
+      resolveTelegramAccount(cfg, accountId).requireMention,
+  },
+  commands: {
+    enforceOwnerForCommands: true,
+    skipWhenConfigEmpty: true,
+  },
+  messaging: {
+    normalizeTarget: normalizeTelegramTarget,
+    targetResolver: {
+      looksLikeId: looksLikeTelegramTargetId,
+      hint: "<chat_id|@username>",
+    },
+  },
+  status: {
+    buildAccountSnapshot: ({ account }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: resolveTelegramToken(account).source !== "none",
+      dmPolicy: account.dmPolicy,
+      allowFrom: account.allowFrom,
+      tokenSource: resolveTelegramToken(account).source,
+      mode: account.groupPolicy,
+      allowUnmentionedGroups: account.requireMention === false,
+      baseUrl: account.baseUrl,
+    }),
+    collectStatusIssues: (accounts) => collectTelegramStatusIssues(accounts as Array<Record<string, unknown>>),
+  },
+  outbound: {
+    deliveryMode: "direct",
+    textChunkLimit: 4096,
+    resolveTarget: ({ cfg, accountId, to, allowFrom }) => {
+      const trimmed = to?.trim();
+      if (trimmed) {
+        return { ok: true, to: normalizeTelegramTarget(trimmed) ?? trimmed };
+      }
+
+      const account = cfg ? resolveTelegramAccount(cfg, accountId) : null;
+      const allowlist = normalizeEntries(allowFrom).filter((entry) => entry !== "*");
+      const fallback = account?.defaultTarget?.trim() || allowlist[0];
+      if (fallback) {
+        return { ok: true, to: fallback };
+      }
+
+      return {
+        ok: false,
+        error: missingTargetError(
+          "Telegram",
+          "<chat_id|@username> or channels.telegram.defaultTarget",
+        ),
+      };
+    },
+    sendText: async ({ cfg, to, text, threadId, accountId }) => {
+      const account = resolveTelegramAccount(cfg, accountId);
+      const result = await sendTelegramText({
+        account,
+        to,
+        text,
+        threadId,
+      });
+      return {
+        channel: "telegram",
+        messageId: result.messageId,
+        chatId: result.chatId,
+        timestamp: result.timestamp,
+        meta: result.meta,
+      };
+    },
+    sendMedia: async ({ cfg, to, text, mediaUrl, threadId, accountId }) => {
+      const composed = mediaUrl ? `${text ? `${text}\n\n` : ""}${mediaUrl}` : text;
+      const account = resolveTelegramAccount(cfg, accountId);
+      const result = await sendTelegramText({
+        account,
+        to,
+        text: composed,
+        threadId,
+      });
+      return {
+        channel: "telegram",
+        messageId: result.messageId,
+        chatId: result.chatId,
+        timestamp: result.timestamp,
+        meta: result.meta,
+      };
+    },
+  },
+};

--- a/packages/zee/Swabble/extensions/telegram/zee.plugin.json
+++ b/packages/zee/Swabble/extensions/telegram/zee.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "telegram",
+  "channels": [
+    "telegram"
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/packages/zee/Swabble/src/plugins/config-state.ts
+++ b/packages/zee/Swabble/src/plugins/config-state.ts
@@ -13,7 +13,7 @@ export type NormalizedPluginsConfig = {
   entries: Record<string, { enabled?: boolean; config?: unknown }>;
 };
 
-export const BUNDLED_ENABLED_BY_DEFAULT = new Set<string>();
+export const BUNDLED_ENABLED_BY_DEFAULT = new Set<string>(["telegram", "slack", "discord"]);
 
 const normalizeList = (value: unknown): string[] => {
   if (!Array.isArray(value)) return [];

--- a/packages/zee/Swabble/src/plugins/loader.test.ts
+++ b/packages/zee/Swabble/src/plugins/loader.test.ts
@@ -144,6 +144,29 @@ describe("loadZeePlugins", () => {
     expect(registry.channels.some((entry) => entry.plugin.id === "whatsapp")).toBe(true);
   });
 
+  it("loads bundled channel plugins enabled by default", () => {
+    const bundledDir = makeTempDir();
+    writePlugin({
+      id: "telegram",
+      body: `export default { id: "telegram", register() {} };`,
+      dir: bundledDir,
+      filename: "telegram.ts",
+    });
+    process.env.ZEE_BUNDLED_PLUGINS_DIR = bundledDir;
+
+    const registry = loadZeePlugins({
+      cache: false,
+      config: {
+        plugins: {
+          allow: ["telegram"],
+        },
+      },
+    });
+
+    const telegram = registry.plugins.find((entry) => entry.id === "telegram");
+    expect(telegram?.status).toBe("loaded");
+  });
+
   it("enables bundled memory plugin when selected by slot", () => {
     const bundledDir = makeTempDir();
     writePlugin({

--- a/packages/zee/src/compare/catalog.ts
+++ b/packages/zee/src/compare/catalog.ts
@@ -605,9 +605,9 @@ export const FEATURE_CATALOG: Feature[] = [
     description: "Multiple real-world channels (Telegram/Slack/Discord/Signal/etc).",
     support: {
       zee: {
-        level: "partial",
-        notes: "Zee embeds a reduced subset of OpenClaw’s channel stack (focuses on WhatsApp and a small set of surfaces).",
-        evidence: [{ kind: "doc", ref: "docs/architecture/upstream-differences.md" }],
+        level: "yes",
+        notes: "Bundled first-party channels include WhatsApp, Telegram, Slack, and Discord with shared policy/status/audit integration.",
+        evidence: [{ kind: "repo_path", ref: "packages/zee/Swabble/extensions" }],
       },
       opencode: { level: "no" },
       openclaw: { level: "yes", evidence: [{ kind: "note", ref: "openclaw/openclaw README (main)" }] },


### PR DESCRIPTION
## Summary
- add bundled first-party channel plugins for `telegram`, `slack`, and `discord`
- wire each channel with config schema, onboarding adapter, status snapshots/issues, security DM/group policy checks, and outbound text delivery
- enable these bundled channels by default so onboarding/status can surface them without manual plugin install
- add channel docs (`/channels/telegram`, `/channels/slack`, `/channels/discord`) and update channel/architecture comparison docs
- update feature catalog to mark Zee multi-channel inbox support as first-party

## Testing
- `cd packages/zee/Swabble && ./node_modules/.bin/vitest run extensions/telegram/src/channel.test.ts extensions/slack/src/channel.test.ts extensions/discord/src/channel.test.ts src/plugins/loader.test.ts`
- `cd packages/zee/Swabble && ./node_modules/.bin/vitest run src/security/audit.code-safety.test.ts src/commands/doctor-security.test.ts`

Closes #264
