### PR TITLE
feat(channels): add native action packs for slack and discord

### DIFF
--- a/docs/architecture/upstream-differences.md
+++ b/docs/architecture/upstream-differences.md
@@ -145,6 +145,7 @@ zee embeds a trimmed “OpenClaw-like” gateway inside the Zee persona package:
 
 Zee now ships bundled first-party channel plugins for Slack/Discord/Telegram under
 `packages/zee/Swabble/extensions/` (instead of mirroring OpenClaw's original top-level source layout).
+Slack and Discord extensions include policy-gated native action packs (reactions, pin/unpin, channel-info).
 
 Operationally, Zee’s gateway is launched by zee only when explicitly enabled (for example `zee daemon --gateway`).
 

--- a/packages/zee/Swabble/docs/channels/discord.md
+++ b/packages/zee/Swabble/docs/channels/discord.md
@@ -35,6 +35,7 @@ Minimal config:
 - DM access is controlled by `channels.discord.dmPolicy` + `channels.discord.allowFrom`.
 - `open` requires `allowFrom` to include `"*"`.
 - Channel/group behavior is controlled by `channels.discord.groupPolicy` and `channels.discord.requireMention`.
+- Native action permissions are controlled by `channels.discord.actions` (`reactions`, `pins`, `channelInfo`).
 - Safer defaults: `dmPolicy="pairing"`, `groupPolicy="allowlist"`, `requireMention=true`.
 
 Approve pairing requests:
@@ -42,6 +43,38 @@ Approve pairing requests:
 ```bash
 zee pairing list discord
 zee pairing approve discord <code>
+```
+
+## Native actions
+
+Supported action pack:
+- `react`
+- `pin` / `unpin`
+- `channel-info`
+
+Policy example:
+
+```json5
+{
+  channels: {
+    discord: {
+      actions: {
+        reactions: true,
+        pins: true,
+        channelInfo: true
+      }
+    }
+  }
+}
+```
+
+CLI examples:
+
+```bash
+zee message react --channel discord --target 123456789012345678 --message-id 998877665544332211 --emoji wave
+zee message pin --channel discord --target 123456789012345678 --message-id 998877665544332211
+zee message unpin --channel discord --target 123456789012345678 --message-id 998877665544332211
+zee message channel-info --channel discord --target 123456789012345678
 ```
 
 ## Status and health
@@ -54,4 +87,4 @@ zee security audit
 zee doctor
 ```
 
-These commands surface token/config issues, DM policy mistakes, and risky group policy combinations.
+These commands surface token/config issues, DM policy mistakes, risky group policy combinations, and over-broad action surfaces.

--- a/packages/zee/Swabble/docs/channels/index.md
+++ b/packages/zee/Swabble/docs/channels/index.md
@@ -20,6 +20,7 @@ Zee can run multiple channels at the same time via the Gateway.
 - DM access defaults to pairing-style controls.
 - `dmPolicy="open"` requires `allowFrom=["*"]`.
 - Group access should normally stay `groupPolicy="allowlist"` with mention gating enabled.
+- Keep channel action packs least-privilege (`channels.<channel>.actions.*`).
 - Review warnings with `zee security audit` and `zee doctor`.
 
 ## Operational commands

--- a/packages/zee/Swabble/docs/channels/slack.md
+++ b/packages/zee/Swabble/docs/channels/slack.md
@@ -35,6 +35,7 @@ Minimal config:
 - DM access is controlled by `channels.slack.dmPolicy` + `channels.slack.allowFrom`.
 - `open` requires `allowFrom` to include `"*"`.
 - Channel/group behavior is controlled by `channels.slack.groupPolicy` and `channels.slack.requireMention`.
+- Native action permissions are controlled by `channels.slack.actions` (`reactions`, `pins`, `channelInfo`).
 - Safer defaults: `dmPolicy="pairing"`, `groupPolicy="allowlist"`, `requireMention=true`.
 
 Approve pairing requests:
@@ -42,6 +43,38 @@ Approve pairing requests:
 ```bash
 zee pairing list slack
 zee pairing approve slack <code>
+```
+
+## Native actions
+
+Supported action pack:
+- `react`
+- `pin` / `unpin`
+- `channel-info`
+
+Policy example:
+
+```json5
+{
+  channels: {
+    slack: {
+      actions: {
+        reactions: true,
+        pins: true,
+        channelInfo: true
+      }
+    }
+  }
+}
+```
+
+CLI examples:
+
+```bash
+zee message react --channel slack --target C0123456789 --message-id 1739137646.001 --emoji thumbsup
+zee message pin --channel slack --target C0123456789 --message-id 1739137646.001
+zee message unpin --channel slack --target C0123456789 --message-id 1739137646.001
+zee message channel-info --channel slack --target C0123456789
 ```
 
 ## Status and health
@@ -54,4 +87,4 @@ zee security audit
 zee doctor
 ```
 
-These commands surface token/config issues, DM policy mistakes, and risky group policy combinations.
+These commands surface token/config issues, DM policy mistakes, risky group policy combinations, and over-broad action surfaces.

--- a/packages/zee/Swabble/docs/cli/channels.md
+++ b/packages/zee/Swabble/docs/cli/channels.md
@@ -41,6 +41,8 @@ zee channels logout --channel whatsapp
 
 Token-based channels (Telegram/Slack/Discord) are configured with `channels add` and usually do not require a separate login flow.
 
+For Slack/Discord native action packs, review and tune `channels.<provider>.actions.*` so message actions stay least-privilege.
+
 ## Troubleshooting
 
 - Run `zee status --deep` for a broad probe.

--- a/packages/zee/Swabble/extensions/discord/src/channel.test.ts
+++ b/packages/zee/Swabble/extensions/discord/src/channel.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { discordPlugin } from "./channel.js";
 
 describe("discord channel plugin", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
   it("uses account-scoped DM policy paths for multi-account configs", () => {
     const cfg = {
       channels: {
@@ -30,6 +37,89 @@ describe("discord channel plugin", () => {
     expect(dmPolicy?.allowFromPath).toBe("channels.discord.accounts.guild.");
   });
 
+  it("lists action pack entries with policy gating", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          botToken: "discord-token",
+          actions: {
+            pins: false,
+            channelInfo: false,
+          },
+        },
+      },
+    } as any;
+
+    const actions = discordPlugin.actions?.listActions?.({ cfg }) ?? [];
+    expect(actions).toContain("react");
+    expect(actions).not.toContain("pin");
+    expect(actions).not.toContain("unpin");
+    expect(actions).not.toContain("channel-info");
+  });
+
+  it("executes react action via discord api", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const cfg = {
+      channels: {
+        discord: {
+          botToken: "discord-token",
+        },
+      },
+    } as any;
+
+    const result = await discordPlugin.actions?.handleAction?.({
+      channel: "discord",
+      action: "react",
+      cfg,
+      params: {
+        channel: "123456789012345678",
+        messageId: "998877665544332211",
+        emoji: "<:wave:1234>",
+      },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://discord.com/api/v10/channels/123456789012345678/messages/998877665544332211/reactions/wave%3A1234/@me",
+    );
+    expect((fetchSpy.mock.calls[0]?.[1] as RequestInit).method).toBe("PUT");
+    expect((result as any)?.details).toMatchObject({
+      ok: true,
+      action: "react",
+      channel: "123456789012345678",
+      messageId: "998877665544332211",
+      emoji: "wave:1234",
+    });
+  });
+
+  it("blocks disabled actions by policy", async () => {
+    const cfg = {
+      channels: {
+        discord: {
+          botToken: "discord-token",
+          actions: {
+            reactions: false,
+          },
+        },
+      },
+    } as any;
+
+    await expect(
+      discordPlugin.actions?.handleAction?.({
+        channel: "discord",
+        action: "react",
+        cfg,
+        params: {
+          channel: "123456789012345678",
+          messageId: "998877665544332211",
+          emoji: "wave",
+        },
+      }),
+    ).rejects.toThrow("disabled by channels.discord.actions policy");
+  });
+
   it("surfaces risky open-group configuration as a security warning", async () => {
     const cfg = {
       channels: {
@@ -53,6 +143,29 @@ describe("discord channel plugin", () => {
     expect(warnings?.some((entry) => entry.includes("requireMention=false"))).toBe(true);
   });
 
+  it("surfaces DM open + wildcard + action surface warning", async () => {
+    const cfg = {
+      channels: {
+        discord: {
+          botToken: "discord-token",
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groupPolicy: "allowlist",
+          requireMention: true,
+        },
+      },
+    } as any;
+
+    const account = discordPlugin.config.resolveAccount(cfg, "default");
+    const warnings = await discordPlugin.security?.collectWarnings?.({
+      cfg,
+      accountId: "default",
+      account,
+    });
+
+    expect(warnings?.some((entry) => entry.includes("native actions are enabled"))).toBe(true);
+  });
+
   it("reports missing token in status issues", async () => {
     const cfg = {
       channels: {
@@ -70,5 +183,23 @@ describe("discord channel plugin", () => {
     const issues = discordPlugin.status?.collectStatusIssues?.([snapshot ?? { accountId: "default" }]);
 
     expect(issues?.some((issue) => issue.message.includes("token is missing"))).toBe(true);
+  });
+
+  it("reports action-surface status issue when dm open is wide", () => {
+    const issues = discordPlugin.status?.collectStatusIssues?.([
+      {
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        dmPolicy: "open",
+        allowFrom: ["*"],
+        mode: "allowlist",
+        allowUnmentionedGroups: false,
+        actions: {
+          reactions: true,
+        },
+      },
+    ]);
+    expect(issues?.some((issue) => issue.message.includes("Action surface is enabled"))).toBe(true);
   });
 });

--- a/packages/zee/Swabble/extensions/discord/src/channel.ts
+++ b/packages/zee/Swabble/extensions/discord/src/channel.ts
@@ -7,12 +7,15 @@ import {
   addWildcardAllowFrom,
   applyAccountNameToChannelSection,
   buildChannelConfigSchema,
+  createActionGate,
   deleteAccountFromConfigSection,
   formatDocsLink,
   formatPairingApproveHint,
+  jsonResult,
   missingTargetError,
   normalizeAccountId,
   promptAccountId,
+  readStringParam,
   requireOpenAllowFrom,
   setAccountEnabledInConfigSection,
   type ChannelOnboardingAdapter,
@@ -40,6 +43,15 @@ const DISCORD_META = {
 const DISCORD_BOT_TOKEN_ENV = "DISCORD_BOT_TOKEN";
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 
+const DiscordActionsSchema = z
+  .object({
+    reactions: z.boolean().optional(),
+    pins: z.boolean().optional(),
+    channelInfo: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 const DiscordAccountSchema = z
   .object({
     name: z.string().trim().min(1).optional(),
@@ -52,6 +64,7 @@ const DiscordAccountSchema = z
     groupPolicy: GroupPolicySchema.optional(),
     groupAllowFrom: z.array(z.string().trim().min(1)).optional(),
     requireMention: z.boolean().optional(),
+    actions: DiscordActionsSchema,
   })
   .strict()
   .superRefine((value, ctx) => {
@@ -77,6 +90,7 @@ const DiscordConfigSchema = z
     groupPolicy: GroupPolicySchema.optional(),
     groupAllowFrom: z.array(z.string().trim().min(1)).optional(),
     requireMention: z.boolean().optional(),
+    actions: DiscordActionsSchema,
   })
   .strict()
   .superRefine((value, ctx) => {
@@ -91,6 +105,7 @@ const DiscordConfigSchema = z
 
 type DiscordConfig = z.infer<typeof DiscordConfigSchema>;
 type DiscordAccountConfig = z.infer<typeof DiscordAccountSchema>;
+type DiscordActionConfig = NonNullable<z.infer<typeof DiscordActionsSchema>>;
 
 type ResolvedDiscordAccount = DiscordAccountConfig & {
   accountId: string;
@@ -104,6 +119,7 @@ type ResolvedDiscordAccount = DiscordAccountConfig & {
   groupPolicy: "allowlist" | "open" | "disabled";
   groupAllowFrom: string[];
   requireMention: boolean;
+  actions: DiscordActionConfig;
 };
 
 function normalizeEntries(list?: Array<string | number> | null): string[] {
@@ -151,6 +167,10 @@ function resolveDiscordAccount(cfg: ZeeConfig, accountId?: string | null): Resol
     ),
     requireMention:
       account.requireMention ?? (useTopLevel ? section.requireMention : undefined) ?? true,
+    actions: {
+      ...(useTopLevel ? (section.actions ?? {}) : {}),
+      ...(account.actions ?? {}),
+    },
   };
 }
 
@@ -281,19 +301,32 @@ function collectDiscordStatusIssues(accounts: Array<Record<string, unknown>>): C
         fix: "Set channels.discord.requireMention=true or channels.discord.groupPolicy=allowlist.",
       });
     }
+
+    const actions =
+      account.actions && typeof account.actions === "object"
+        ? (account.actions as Record<string, unknown>)
+        : {};
+    const hasActionSurface =
+      actions.reactions !== false || actions.pins !== false || actions.channelInfo !== false;
+    if (dmPolicy === "open" && allowFrom.includes("*") && hasActionSurface) {
+      issues.push({
+        channel: "discord",
+        accountId,
+        kind: "permissions",
+        message: "Action surface is enabled while DMs are open to everyone.",
+        fix: "Use dmPolicy=pairing/allowlist or disable channels.discord.actions.* controls.",
+      });
+    }
   }
   return issues;
 }
 
-async function sendDiscordText(params: {
+async function callDiscordApi(params: {
   account: ResolvedDiscordAccount;
-  to: string;
-  text: string;
-}): Promise<{
-  messageId: string;
-  channelId: string;
-  timestamp: number;
-}> {
+  method: string;
+  path: string;
+  body?: Record<string, unknown>;
+}): Promise<Record<string, unknown>> {
   const token = resolveDiscordBotToken(params.account).token;
   if (!token) {
     throw new Error(
@@ -301,8 +334,7 @@ async function sendDiscordText(params: {
     );
   }
 
-  const endpoint = `${DISCORD_API_BASE}/channels/${encodeURIComponent(params.to)}/messages`;
-
+  const endpoint = `${DISCORD_API_BASE}${params.path}`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 15_000);
   if (typeof timeout.unref === "function") timeout.unref();
@@ -310,19 +342,23 @@ async function sendDiscordText(params: {
   let response: Response;
   try {
     response = await fetch(endpoint, {
-      method: "POST",
+      method: params.method,
       headers: {
         authorization: `Bot ${token}`,
-        "content-type": "application/json",
+        ...(params.body ? { "content-type": "application/json" } : {}),
       },
-      body: JSON.stringify({ content: params.text }),
+      ...(params.body ? { body: JSON.stringify(params.body) } : {}),
       signal: controller.signal,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Discord send failed: ${message}`);
+    throw new Error(`Discord API request failed (${params.method} ${params.path}): ${message}`);
   } finally {
     clearTimeout(timeout);
+  }
+
+  if (response.status === 204) {
+    return { ok: true };
   }
 
   const raw = await response.text();
@@ -338,8 +374,27 @@ async function sendDiscordText(params: {
       typeof payload.message === "string" && payload.message.trim()
         ? payload.message.trim()
         : `HTTP ${response.status}`;
-    throw new Error(`Discord send failed: ${message}`);
+    throw new Error(`Discord API ${params.method} ${params.path} failed: ${message}`);
   }
+
+  return payload;
+}
+
+async function sendDiscordText(params: {
+  account: ResolvedDiscordAccount;
+  to: string;
+  text: string;
+}): Promise<{
+  messageId: string;
+  channelId: string;
+  timestamp: number;
+}> {
+  const payload = await callDiscordApi({
+    account: params.account,
+    method: "POST",
+    path: `/channels/${encodeURIComponent(params.to)}/messages`,
+    body: { content: params.text },
+  });
 
   const messageId = typeof payload.id === "string" ? payload.id : `${Date.now()}`;
   const channelId = typeof payload.channel_id === "string" ? payload.channel_id : params.to;
@@ -495,6 +550,45 @@ function looksLikeDiscordTargetId(raw: string, normalized?: string): boolean {
   return /^\d{15,20}$/.test(value);
 }
 
+function normalizeDiscordEmoji(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+  const custom = /^<a?:([a-zA-Z0-9_]+):(\d+)>$/.exec(trimmed);
+  if (custom) return `${custom[1]}:${custom[2]}`;
+  if (trimmed.startsWith(":") && trimmed.endsWith(":") && trimmed.length > 2) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function resolveDiscordActionTarget(params: Record<string, unknown>): string {
+  const primary = readStringParam(params, "channel");
+  const fallback = readStringParam(params, "channelId") ?? readStringParam(params, "to");
+  const target = primary ?? fallback;
+  if (!target) {
+    throw new Error("channel required");
+  }
+  return target;
+}
+
+function isDiscordActionEnabled(params: {
+  account: ResolvedDiscordAccount;
+  action: "react" | "pin" | "unpin" | "channel-info";
+}): boolean {
+  const gate = createActionGate(params.account.actions);
+  switch (params.action) {
+    case "react":
+      return gate("reactions");
+    case "pin":
+    case "unpin":
+      return gate("pins");
+    case "channel-info":
+      return gate("channelInfo");
+    default:
+      return false;
+  }
+}
+
 export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
   id: "discord",
   meta: DISCORD_META,
@@ -538,6 +632,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
           "groupPolicy",
           "groupAllowFrom",
           "requireMention",
+          "actions",
         ],
       }),
     isEnabled: (account) => account.enabled !== false,
@@ -553,6 +648,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       allowFrom: account.allowFrom,
       mode: account.groupPolicy,
       allowUnmentionedGroups: account.requireMention === false,
+      actions: account.actions,
       botTokenSource: resolveDiscordBotToken(account).source,
     }),
     resolveAllowFrom: ({ cfg, accountId }) => resolveDiscordAccount(cfg, accountId).allowFrom,
@@ -583,6 +679,13 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
             '- Discord channels: groupPolicy="open" with requireMention=false allows any member to trigger actions. Set requireMention=true or groupPolicy="allowlist".',
           );
         }
+      }
+      const gate = createActionGate(account.actions);
+      const hasActionSurface = gate("reactions") || gate("pins") || gate("channelInfo");
+      if (account.dmPolicy === "open" && account.allowFrom.includes("*") && hasActionSurface) {
+        warnings.push(
+          '- Discord actions: DM policy is open with wildcard allowFrom while native actions are enabled; this allows broad action triggering from any DM sender.',
+        );
       }
       return warnings;
     },
@@ -653,10 +756,90 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       allowFrom: account.allowFrom,
       mode: account.groupPolicy,
       allowUnmentionedGroups: account.requireMention === false,
+      actions: account.actions,
       botTokenSource: resolveDiscordBotToken(account).source,
     }),
     collectStatusIssues: (accounts) =>
       collectDiscordStatusIssues(accounts as Array<Record<string, unknown>>),
+  },
+  actions: {
+    listActions: ({ cfg }) => {
+      const account = resolveDiscordAccount(cfg, resolveDefaultDiscordAccountId(cfg));
+      const actions: Array<"react" | "pin" | "unpin" | "channel-info"> = [];
+      if (isDiscordActionEnabled({ account, action: "react" })) actions.push("react");
+      if (isDiscordActionEnabled({ account, action: "pin" })) actions.push("pin", "unpin");
+      if (isDiscordActionEnabled({ account, action: "channel-info" })) actions.push("channel-info");
+      return actions;
+    },
+    supportsAction: ({ action }) =>
+      action === "react" || action === "pin" || action === "unpin" || action === "channel-info",
+    handleAction: async ({ action, params, cfg, accountId }) => {
+      if (
+        action !== "react" &&
+        action !== "pin" &&
+        action !== "unpin" &&
+        action !== "channel-info"
+      ) {
+        throw new Error(`Action ${action} is not supported for provider discord.`);
+      }
+      const account = resolveDiscordAccount(cfg, accountId);
+      if (!isDiscordActionEnabled({ account, action })) {
+        throw new Error(`Action ${action} is disabled by channels.discord.actions policy.`);
+      }
+
+      if (action === "channel-info") {
+        const channel = resolveDiscordActionTarget(params);
+        const payload = await callDiscordApi({
+          account,
+          method: "GET",
+          path: `/channels/${encodeURIComponent(channel)}`,
+        });
+        return jsonResult({
+          ok: true,
+          action,
+          channel: payload,
+        });
+      }
+
+      const channel = resolveDiscordActionTarget(params);
+      const messageId = readStringParam(params, "messageId", {
+        required: true,
+        label: "messageId",
+      });
+
+      if (action === "react") {
+        const emojiRaw = readStringParam(params, "emoji", { required: true, label: "emoji" });
+        const emoji = normalizeDiscordEmoji(emojiRaw);
+        const remove = params.remove === true;
+        await callDiscordApi({
+          account,
+          method: remove ? "DELETE" : "PUT",
+          path: `/channels/${encodeURIComponent(channel)}/messages/${encodeURIComponent(
+            messageId,
+          )}/reactions/${encodeURIComponent(emoji)}/@me`,
+        });
+        return jsonResult({
+          ok: true,
+          action,
+          channel,
+          messageId,
+          emoji,
+          remove,
+        });
+      }
+
+      await callDiscordApi({
+        account,
+        method: action === "pin" ? "PUT" : "DELETE",
+        path: `/channels/${encodeURIComponent(channel)}/pins/${encodeURIComponent(messageId)}`,
+      });
+      return jsonResult({
+        ok: true,
+        action,
+        channel,
+        messageId,
+      });
+    },
   },
   outbound: {
     deliveryMode: "direct",

--- a/packages/zee/Swabble/extensions/slack/src/channel.test.ts
+++ b/packages/zee/Swabble/extensions/slack/src/channel.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { slackPlugin } from "./channel.js";
 
 describe("slack channel plugin", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
   it("uses account-scoped DM policy paths for multi-account configs", () => {
     const cfg = {
       channels: {
@@ -30,6 +37,93 @@ describe("slack channel plugin", () => {
     expect(dmPolicy?.allowFromPath).toBe("channels.slack.accounts.work.");
   });
 
+  it("lists action pack entries with policy gating", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-token",
+          actions: {
+            pins: false,
+            channelInfo: false,
+          },
+        },
+      },
+    } as any;
+
+    const actions = slackPlugin.actions?.listActions?.({ cfg }) ?? [];
+    expect(actions).toContain("react");
+    expect(actions).not.toContain("pin");
+    expect(actions).not.toContain("unpin");
+    expect(actions).not.toContain("channel-info");
+  });
+
+  it("executes react action via slack api", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-token",
+        },
+      },
+    } as any;
+
+    const result = await slackPlugin.actions?.handleAction?.({
+      channel: "slack",
+      action: "react",
+      cfg,
+      params: {
+        channel: "C12345678",
+        messageId: "1739137646.001",
+        emoji: ":thumbsup:",
+      },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://slack.com/api/reactions.add");
+    const request = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(request.body));
+    expect(body).toMatchObject({
+      channel: "C12345678",
+      timestamp: "1739137646.001",
+      name: "thumbsup",
+    });
+    expect((result as any)?.details).toMatchObject({
+      ok: true,
+      action: "react",
+      channel: "C12345678",
+    });
+  });
+
+  it("blocks disabled actions by policy", async () => {
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-token",
+          actions: {
+            reactions: false,
+          },
+        },
+      },
+    } as any;
+
+    await expect(
+      slackPlugin.actions?.handleAction?.({
+        channel: "slack",
+        action: "react",
+        cfg,
+        params: {
+          channel: "C12345678",
+          messageId: "1739137646.001",
+          emoji: "ok_hand",
+        },
+      }),
+    ).rejects.toThrow("disabled by channels.slack.actions policy");
+  });
+
   it("surfaces risky open-group configuration as a security warning", async () => {
     const cfg = {
       channels: {
@@ -53,6 +147,29 @@ describe("slack channel plugin", () => {
     expect(warnings?.some((entry) => entry.includes("requireMention=false"))).toBe(true);
   });
 
+  it("surfaces DM open + wildcard + action surface warning", async () => {
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-token",
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groupPolicy: "allowlist",
+          requireMention: true,
+        },
+      },
+    } as any;
+
+    const account = slackPlugin.config.resolveAccount(cfg, "default");
+    const warnings = await slackPlugin.security?.collectWarnings?.({
+      cfg,
+      accountId: "default",
+      account,
+    });
+
+    expect(warnings?.some((entry) => entry.includes("native actions are enabled"))).toBe(true);
+  });
+
   it("reports missing token in status issues", async () => {
     const cfg = {
       channels: {
@@ -70,5 +187,23 @@ describe("slack channel plugin", () => {
     const issues = slackPlugin.status?.collectStatusIssues?.([snapshot ?? { accountId: "default" }]);
 
     expect(issues?.some((issue) => issue.message.includes("token is missing"))).toBe(true);
+  });
+
+  it("reports action-surface status issue when dm open is wide", () => {
+    const issues = slackPlugin.status?.collectStatusIssues?.([
+      {
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        dmPolicy: "open",
+        allowFrom: ["*"],
+        mode: "allowlist",
+        allowUnmentionedGroups: false,
+        actions: {
+          reactions: true,
+        },
+      },
+    ]);
+    expect(issues?.some((issue) => issue.message.includes("Action surface is enabled"))).toBe(true);
   });
 });

--- a/packages/zee/Swabble/extensions/slack/src/channel.ts
+++ b/packages/zee/Swabble/extensions/slack/src/channel.ts
@@ -7,12 +7,15 @@ import {
   addWildcardAllowFrom,
   applyAccountNameToChannelSection,
   buildChannelConfigSchema,
+  createActionGate,
   deleteAccountFromConfigSection,
   formatDocsLink,
   formatPairingApproveHint,
+  jsonResult,
   missingTargetError,
   normalizeAccountId,
   promptAccountId,
+  readStringParam,
   requireOpenAllowFrom,
   setAccountEnabledInConfigSection,
   type ChannelOnboardingAdapter,
@@ -41,6 +44,15 @@ const SLACK_BOT_TOKEN_ENV = "SLACK_BOT_TOKEN";
 const SLACK_APP_TOKEN_ENV = "SLACK_APP_TOKEN";
 const SLACK_API_BASE = "https://slack.com/api";
 
+const SlackActionsSchema = z
+  .object({
+    reactions: z.boolean().optional(),
+    pins: z.boolean().optional(),
+    channelInfo: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 const SlackAccountSchema = z
   .object({
     name: z.string().trim().min(1).optional(),
@@ -53,6 +65,7 @@ const SlackAccountSchema = z
     groupPolicy: GroupPolicySchema.optional(),
     groupAllowFrom: z.array(z.string().trim().min(1)).optional(),
     requireMention: z.boolean().optional(),
+    actions: SlackActionsSchema,
   })
   .strict()
   .superRefine((value, ctx) => {
@@ -78,6 +91,7 @@ const SlackConfigSchema = z
     groupPolicy: GroupPolicySchema.optional(),
     groupAllowFrom: z.array(z.string().trim().min(1)).optional(),
     requireMention: z.boolean().optional(),
+    actions: SlackActionsSchema,
   })
   .strict()
   .superRefine((value, ctx) => {
@@ -92,6 +106,7 @@ const SlackConfigSchema = z
 
 type SlackConfig = z.infer<typeof SlackConfigSchema>;
 type SlackAccountConfig = z.infer<typeof SlackAccountSchema>;
+type SlackActionConfig = NonNullable<z.infer<typeof SlackActionsSchema>>;
 
 type ResolvedSlackAccount = SlackAccountConfig & {
   accountId: string;
@@ -105,6 +120,7 @@ type ResolvedSlackAccount = SlackAccountConfig & {
   groupPolicy: "allowlist" | "open" | "disabled";
   groupAllowFrom: string[];
   requireMention: boolean;
+  actions: SlackActionConfig;
 };
 
 function normalizeEntries(list?: Array<string | number> | null): string[] {
@@ -152,6 +168,10 @@ function resolveSlackAccount(cfg: ZeeConfig, accountId?: string | null): Resolve
     ),
     requireMention:
       account.requireMention ?? (useTopLevel ? section.requireMention : undefined) ?? true,
+    actions: {
+      ...(useTopLevel ? (section.actions ?? {}) : {}),
+      ...(account.actions ?? {}),
+    },
   };
 }
 
@@ -285,31 +305,36 @@ function collectSlackStatusIssues(accounts: Array<Record<string, unknown>>): Cha
         fix: "Set channels.slack.requireMention=true or channels.slack.groupPolicy=allowlist.",
       });
     }
+
+    const actions =
+      account.actions && typeof account.actions === "object"
+        ? (account.actions as Record<string, unknown>)
+        : {};
+    const hasActionSurface =
+      actions.reactions !== false || actions.pins !== false || actions.channelInfo !== false;
+    if (dmPolicy === "open" && allowFrom.includes("*") && hasActionSurface) {
+      issues.push({
+        channel: "slack",
+        accountId,
+        kind: "permissions",
+        message: "Action surface is enabled while DMs are open to everyone.",
+        fix: "Use dmPolicy=pairing/allowlist or disable channels.slack.actions.* controls.",
+      });
+    }
   }
   return issues;
 }
 
-async function sendSlackText(params: {
+async function callSlackApi(params: {
   account: ResolvedSlackAccount;
-  to: string;
-  text: string;
-  threadId?: string | number | null;
-}): Promise<{
-  messageId: string;
-  channelId: string;
-  meta?: Record<string, unknown>;
-}> {
+  method: string;
+  body: Record<string, unknown>;
+}): Promise<Record<string, unknown>> {
   const tokens = resolveSlackTokens(params.account);
   if (!tokens.botToken) {
-    throw new Error(`Slack bot token is missing. Set channels.slack.botToken or ${SLACK_BOT_TOKEN_ENV}.`);
-  }
-
-  const body: Record<string, unknown> = {
-    channel: params.to,
-    text: params.text,
-  };
-  if (params.threadId !== undefined && params.threadId !== null) {
-    body.thread_ts = String(params.threadId);
+    throw new Error(
+      `Slack bot token is missing. Set channels.slack.botToken or ${SLACK_BOT_TOKEN_ENV}.`,
+    );
   }
 
   const controller = new AbortController();
@@ -318,18 +343,18 @@ async function sendSlackText(params: {
 
   let response: Response;
   try {
-    response = await fetch(`${SLACK_API_BASE}/chat.postMessage`, {
+    response = await fetch(`${SLACK_API_BASE}/${params.method}`, {
       method: "POST",
       headers: {
         authorization: `Bearer ${tokens.botToken}`,
         "content-type": "application/json",
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify(params.body),
       signal: controller.signal,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Slack send failed: ${message}`);
+    throw new Error(`Slack API request failed (${params.method}): ${message}`);
   } finally {
     clearTimeout(timeout);
   }
@@ -348,8 +373,34 @@ async function sendSlackText(params: {
       typeof payload.error === "string" && payload.error.trim()
         ? payload.error.trim()
         : `HTTP ${response.status}`;
-    throw new Error(`Slack send failed: ${error}`);
+    throw new Error(`Slack API ${params.method} failed: ${error}`);
   }
+
+  return payload;
+}
+
+async function sendSlackText(params: {
+  account: ResolvedSlackAccount;
+  to: string;
+  text: string;
+  threadId?: string | number | null;
+}): Promise<{
+  messageId: string;
+  channelId: string;
+  meta?: Record<string, unknown>;
+}> {
+  const body: Record<string, unknown> = {
+    channel: params.to,
+    text: params.text,
+  };
+  if (params.threadId !== undefined && params.threadId !== null) {
+    body.thread_ts = String(params.threadId);
+  }
+  const payload = await callSlackApi({
+    account: params.account,
+    method: "chat.postMessage",
+    body,
+  });
 
   const channelId = typeof payload.channel === "string" ? payload.channel : params.to;
   const messageId = typeof payload.ts === "string" ? payload.ts : `${Date.now()}`;
@@ -361,6 +412,15 @@ async function sendSlackText(params: {
       threadTs: typeof payload.ts === "string" ? payload.ts : undefined,
     },
   };
+}
+
+function normalizeSlackEmoji(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+  if (trimmed.startsWith(":") && trimmed.endsWith(":") && trimmed.length > 2) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
 }
 
 const slackOnboardingAdapter: ChannelOnboardingAdapter = {
@@ -500,6 +560,34 @@ function looksLikeSlackTargetId(raw: string, normalized?: string): boolean {
   return /^[CDGU][A-Z0-9]{8,}$/i.test(value) || /^#[a-z0-9._-]+$/i.test(value);
 }
 
+function resolveSlackActionTarget(params: Record<string, unknown>): string {
+  const primary = readStringParam(params, "channel");
+  const fallback = readStringParam(params, "channelId") ?? readStringParam(params, "to");
+  const target = primary ?? fallback;
+  if (!target) {
+    throw new Error("channel required");
+  }
+  return target;
+}
+
+function isSlackActionEnabled(params: {
+  account: ResolvedSlackAccount;
+  action: "react" | "pin" | "unpin" | "channel-info";
+}): boolean {
+  const gate = createActionGate(params.account.actions);
+  switch (params.action) {
+    case "react":
+      return gate("reactions");
+    case "pin":
+    case "unpin":
+      return gate("pins");
+    case "channel-info":
+      return gate("channelInfo");
+    default:
+      return false;
+  }
+}
+
 export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   id: "slack",
   meta: SLACK_META,
@@ -542,6 +630,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
           "groupPolicy",
           "groupAllowFrom",
           "requireMention",
+          "actions",
         ],
       }),
     isEnabled: (account) => account.enabled !== false,
@@ -559,6 +648,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         allowFrom: account.allowFrom,
         mode: account.groupPolicy,
         allowUnmentionedGroups: account.requireMention === false,
+        actions: account.actions,
         botTokenSource: tokens.botSource,
         appTokenSource: tokens.appSource,
       };
@@ -591,6 +681,13 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             '- Slack groups/channels: groupPolicy="open" with requireMention=false allows any member to trigger actions. Set requireMention=true or groupPolicy="allowlist".',
           );
         }
+      }
+      const gate = createActionGate(account.actions);
+      const hasActionSurface = gate("reactions") || gate("pins") || gate("channelInfo");
+      if (account.dmPolicy === "open" && account.allowFrom.includes("*") && hasActionSurface) {
+        warnings.push(
+          '- Slack actions: DM policy is open with wildcard allowFrom while native actions are enabled; this allows broad action triggering from any DM sender.',
+        );
       }
       return warnings;
     },
@@ -662,11 +759,96 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         allowFrom: account.allowFrom,
         mode: account.groupPolicy,
         allowUnmentionedGroups: account.requireMention === false,
+        actions: account.actions,
         botTokenSource: tokens.botSource,
         appTokenSource: tokens.appSource,
       };
     },
     collectStatusIssues: (accounts) => collectSlackStatusIssues(accounts as Array<Record<string, unknown>>),
+  },
+  actions: {
+    listActions: ({ cfg }) => {
+      const account = resolveSlackAccount(cfg, resolveDefaultSlackAccountId(cfg));
+      const actions: Array<"react" | "pin" | "unpin" | "channel-info"> = [];
+      if (isSlackActionEnabled({ account, action: "react" })) actions.push("react");
+      if (isSlackActionEnabled({ account, action: "pin" })) actions.push("pin", "unpin");
+      if (isSlackActionEnabled({ account, action: "channel-info" })) actions.push("channel-info");
+      return actions;
+    },
+    supportsAction: ({ action }) =>
+      action === "react" || action === "pin" || action === "unpin" || action === "channel-info",
+    handleAction: async ({ action, params, cfg, accountId }) => {
+      if (
+        action !== "react" &&
+        action !== "pin" &&
+        action !== "unpin" &&
+        action !== "channel-info"
+      ) {
+        throw new Error(`Action ${action} is not supported for provider slack.`);
+      }
+      const account = resolveSlackAccount(cfg, accountId);
+      if (!isSlackActionEnabled({ account, action })) {
+        throw new Error(`Action ${action} is disabled by channels.slack.actions policy.`);
+      }
+
+      if (action === "channel-info") {
+        const channel = resolveSlackActionTarget(params);
+        const payload = await callSlackApi({
+          account,
+          method: "conversations.info",
+          body: { channel },
+        });
+        return jsonResult({
+          ok: true,
+          action,
+          channel: payload.channel ?? channel,
+        });
+      }
+
+      const channel = resolveSlackActionTarget(params);
+      const messageId = readStringParam(params, "messageId", {
+        required: true,
+        label: "messageId",
+      });
+
+      if (action === "react") {
+        const emojiRaw = readStringParam(params, "emoji", { required: true, label: "emoji" });
+        const emoji = normalizeSlackEmoji(emojiRaw);
+        const remove = params.remove === true;
+        await callSlackApi({
+          account,
+          method: remove ? "reactions.remove" : "reactions.add",
+          body: {
+            channel,
+            timestamp: messageId,
+            name: emoji,
+          },
+        });
+        return jsonResult({
+          ok: true,
+          action,
+          channel,
+          messageId,
+          emoji,
+          remove,
+        });
+      }
+
+      await callSlackApi({
+        account,
+        method: action === "pin" ? "pins.add" : "pins.remove",
+        body: {
+          channel,
+          timestamp: messageId,
+        },
+      });
+      return jsonResult({
+        ok: true,
+        action,
+        channel,
+        messageId,
+      });
+    },
   },
   outbound: {
     deliveryMode: "direct",


### PR DESCRIPTION
Supersedes #285 (which auto-closed when base branch `gap-264-slice` was deleted after #284 merge).

## Summary
- add Slack and Discord native action packs for non-WhatsApp channels
- implement policy-gated actions for both providers: `react`, `pin`, `unpin`, `channel-info`
- surface action-surface risk signals in channel security warnings and status issues when DMs are fully open
- update channel docs and CLI guidance for action policies

## Validation
- `cd packages/zee/Swabble && ./node_modules/.bin/vitest run extensions/slack/src/channel.test.ts extensions/discord/src/channel.test.ts`
- `cd packages/zee/Swabble && ./node_modules/.bin/vitest run src/security/audit.code-safety.test.ts src/commands/doctor-security.test.ts`
