### PR TITLE
docs: triage OpenCode lane 03 auth/provider parity

### DIFF
--- a/docs/architecture/opencode-lanes/lane-03-auth-provider.md
+++ b/docs/architecture/opencode-lanes/lane-03-auth-provider.md
@@ -1,0 +1,51 @@
+# OpenCode Lane 03: Auth/Provider Plugin Parity
+
+Tracking issue: `adolago/zee#288`
+
+## Scope
+
+- Compare auth and provider plugin surfaces between Zee and OpenCode.
+- Make explicit `port` / `adapt` / `defer` / `non-goal` decisions per delta.
+- Define migration guidance targets for users moving from OpenCode to Zee.
+
+## Delta Table
+
+| Delta item | Zee status | OpenCode status | Decision | Rationale | Upstream reference |
+| --- | --- | --- | --- | --- | --- |
+| Provider package breadth (`@ai-sdk/*` diversity) | Curated/smaller provider set in `packages/zee` | Broad provider package set in OpenCode monorepo | adapt | Preserve Zee reliability and support burden constraints while reducing migration friction for common providers. | `docs/architecture/upstream-differences.md` (Providers/model backends) |
+| OAuth subscription-first login flow ergonomics | Partial support (less prescriptive UX) | Stronger subscription/OAuth-first messaging in ecosystem docs | adapt | Keep Zee auth model but improve user-facing profile rotation and onboarding guidance. | `docs/architecture/feature-comparison.md` (`model.oauth-subscriptions`) |
+| Extension/plugin auth bootstrap conventions | Zee plugin/skills model differs from OpenCode extension model | OpenCode extension conventions are product-specific | non-goal | Avoid coupling Zee to OpenCode extension internals; maintain Zee-native skill/plugin lifecycle. | `docs/architecture/feature-comparison.md` (`platform.extensions`) |
+| Config naming and migration from `.opencode/` provider defaults | Zee uses `.zee/` + Zee config shapes | OpenCode uses `.opencode/` config defaults | port | Straightforward migration-documentation and mapping improvements reduce setup friction without architecture risk. | `docs/architecture/upstream-differences.md` (Config and state model) |
+| Auth secret handling defaults and operator guidance | Mixed env/config references and auth commands | OpenCode workflows vary by provider, often key-based | adapt | Strengthen Zee docs and command flow so secret handling defaults are explicit and recoverable. | `docs/architecture/feature-comparison.md` (`model.auth-profiles`) |
+
+## Migration Guidance Targets
+
+1. Publish an OpenCode-to-Zee auth/provider migration page with:
+   - provider ID mapping table
+   - `.opencode/` to `.zee/` key mapping
+   - recommended Zee auth profile order and fallback behavior
+2. Add command-level examples for:
+   - subscription/OAuth-first onboarding
+   - API key fallback onboarding
+   - safe profile rotation and revocation handling
+
+## Concrete Implementation Candidate
+
+### Candidate A: `zee auth import-opencode` (proposed)
+
+- Owner: `@adolago`
+- Decision type: `adapt` (Zee-native interface with OpenCode-aware migration)
+- Candidate behavior:
+  - read `.opencode/opencode.jsonc` in a project
+  - map recognized provider/auth defaults into `.zee/` project config
+  - emit a migration report showing mapped, skipped, and non-goal keys
+- Minimum test scope:
+  - unit tests for mapping rules and unknown-key handling
+  - integration test with fixture `.opencode/opencode.jsonc` -> generated `.zee/*`
+  - CLI acceptance test: import command exits non-zero on invalid config and shows actionable diagnostics
+
+## Acceptance Checklist
+
+- [x] Delta table with explicit decisions and upstream refs
+- [x] Zee decision recorded for each tracked item
+- [x] Concrete implementation candidate defined with owner and test scope

--- a/docs/architecture/zee-opencode-gap-map-top10.md
+++ b/docs/architecture/zee-opencode-gap-map-top10.md
@@ -26,7 +26,7 @@ Baseline reference: `docs/architecture/upstream-differences.md`.
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | 01 | [#219](https://github.com/adolago/zee/issues/219) | TUI parity baseline (thinking keybind, remote auth, custom models path) | adapt | open | `docs/architecture/upstream-differences.md` |
 | 2 | 02 | [#221](https://github.com/adolago/zee/issues/221) | Config parity baseline (models.dev URL, mDNS domain, managed settings) | adapt | open | `docs/architecture/upstream-differences.md` |
-| 3 | 03 | [#288](https://github.com/adolago/zee/issues/288) | Auth/provider plugin parity and migration ergonomics | adapt | open | `docs/architecture/opencode-lanes/lane-03-auth-provider.md` |
+| 3 | 03 | [#288](https://github.com/adolago/zee/issues/288) | Auth/provider plugin parity and migration ergonomics | adapt | triage-done | `docs/architecture/opencode-lanes/lane-03-auth-provider.md` |
 | 4 | 04 | [#289](https://github.com/adolago/zee/issues/289) | Web/desktop/package topology parity strategy | adapt | open | `docs/architecture/opencode-lanes/lane-04-package-topology.md` |
 | 5 | 05 | [#290](https://github.com/adolago/zee/issues/290) | API/LSP/server workflow parity deltas | adapt | open | `docs/architecture/opencode-lanes/lane-05-api-lsp-workflows.md` |
 | 6 | 06 | [#291](https://github.com/adolago/zee/issues/291) | Upstream sync automation and policy | port | open | `docs/architecture/opencode-sync-policy.md` |
@@ -53,6 +53,7 @@ Baseline reference: `docs/architecture/upstream-differences.md`.
 
 - Scope: provider/auth plugin surface and migration guidance.
 - Current decision: `adapt`.
+- Artifact: `docs/architecture/opencode-lanes/lane-03-auth-provider.md`.
 
 ### Lane 04 (`#289`): Web/desktop/package topology
 


### PR DESCRIPTION
## Summary
- add `docs/architecture/opencode-lanes/lane-03-auth-provider.md` with an explicit auth/provider delta table
- record explicit `port`/`adapt`/`non-goal` decisions with upstream references for each tracked item
- define a concrete implementation candidate (`zee auth import-opencode`) with owner and test scope
- update lane 03 status in the canonical OpenCode gap map to `triage-done`

## Acceptance
- documented delta table with upstream refs
- explicit Zee decision per delta item
- concrete implementation candidate with owner and test scope

Closes #288
