### PR TITLE
docs: define OpenCode sync policy and snapshot playbook

### DIFF
--- a/docs/architecture/opencode-snapshot-playbook.md
+++ b/docs/architecture/opencode-snapshot-playbook.md
@@ -1,0 +1,72 @@
+# OpenCode Snapshot Playbook
+
+This playbook provides a reproducible command sequence for OpenCode lane refreshes.
+
+Policy reference: `docs/architecture/opencode-sync-policy.md`
+
+## Preconditions
+
+- Repo remote target is `adolago/zee`.
+- `opencode` remote is configured (`https://github.com/sst/opencode.git`).
+- Maintainer runs from repo root.
+
+## Guardrail
+
+Run before any GitHub issue/PR operation:
+
+```bash
+./scripts/verify-pr-target.sh
+```
+
+## Snapshot Command Sequence
+
+1. Fetch and check OpenCode upstream drift:
+
+```bash
+./scripts/check-upstream.sh --remote opencode --fetch
+```
+
+2. Produce multi-upstream dashboard (includes OpenCode pin summary):
+
+```bash
+./scripts/check-upstream-all.sh
+```
+
+3. Preview OpenCode sync impact without mutating history:
+
+```bash
+./scripts/sync-upstream.sh --remote opencode --preview
+```
+
+4. Capture direct divergence counts (optional but recommended):
+
+```bash
+git rev-list --left-right --count opencode/dev...HEAD
+git -c diff.renameLimit=20000 diff --name-status opencode/dev...HEAD > /tmp/opencode.diff.txt
+```
+
+## Evidence Capture Template
+
+For each refresh cycle, record:
+
+- Refresh date (UTC)
+- Current `opencode/dev` full SHA
+- Ahead/behind counts from `check-upstream.sh`
+- Notable file-delta signals (from `/tmp/opencode.diff.txt` summary)
+- Lane decisions changed this cycle
+
+## Documentation Update Steps
+
+1. Update pin values in:
+   - `docs/architecture/upstream-differences.md`
+   - `docs/architecture/zee-opencode-gap-map-top10.md`
+2. Update affected lane artifacts in `docs/architecture/opencode-lanes/`.
+3. Re-rank top-10 backlog if priority changed.
+4. Open or update lane issues for any new high-priority deltas.
+
+## Lane Refresh Exit Criteria
+
+- Pins and evidence updated
+- Lane decisions reviewed and documented
+- Rank table reflects current upstream reality
+- Follow-up issue links are present for new/changed lanes

--- a/docs/architecture/opencode-sync-policy.md
+++ b/docs/architecture/opencode-sync-policy.md
@@ -1,0 +1,69 @@
+# OpenCode Upstream Sync Policy (Lane 06)
+
+Tracking issue: `adolago/zee#291`
+
+## Purpose
+
+Define a repeatable, auditable policy for syncing Zee against `sst/opencode` (`opencode/dev`) and updating OpenCode delta lanes without manual drift.
+
+## Scope
+
+- OpenCode upstream tracking only (`opencode/dev`).
+- Lane triage updates in `docs/architecture/zee-opencode-gap-map-top10.md` and lane docs.
+- Evidence capture requirements for maintainers.
+
+## Cadence
+
+- Weekly quick-check:
+  - detect upstream movement and high-risk delta signals
+- Monthly refresh:
+  - refresh pin, re-score ranked lane backlog, update lane decisions
+- Event-triggered refresh:
+  - run immediately when upstream introduces breaking or parity-critical workflow changes
+
+## Pin Policy
+
+- All OpenCode comparisons must declare a pinned upstream commit from `opencode/dev`.
+- Pin location:
+  - `docs/architecture/upstream-differences.md` (current upstream pins section)
+  - `docs/architecture/zee-opencode-gap-map-top10.md` (snapshot pins section)
+- Pin updates must be accompanied by:
+  - command evidence from the snapshot playbook
+  - lane decision delta summary
+
+## Decision Policy
+
+- `port`:
+  - default for clear security/reliability parity deltas with low architecture conflict
+- `adapt`:
+  - default for user-facing workflow parity where Zee architecture differs
+- `defer`:
+  - useful but non-critical items not needed for parity-safe operation
+- `non-goal`:
+  - OpenCode product surfaces Zee intentionally does not plan to mirror
+
+## Evidence Requirements
+
+Each monthly or event-triggered refresh must include:
+
+1. Current `opencode/dev` commit hash.
+2. `check-upstream` output proving ahead/behind state.
+3. `sync-upstream --preview` output for proposed merge impact.
+4. Updated lane map with any rank/decision changes.
+5. Explicit notes for any reclassified items (`port` <-> `adapt` <-> `defer` <-> `non-goal`).
+
+## Lane Update Checklist
+
+- [ ] Refresh upstream metadata via playbook commands.
+- [ ] Update pinned commit hashes in comparison docs.
+- [ ] Re-evaluate top-10 rank ordering in `zee-opencode-gap-map-top10.md`.
+- [ ] Update lane artifacts for changed deltas.
+- [ ] Open/follow-up lane issues when new items enter top-10.
+- [ ] Record why each changed item is `port`/`adapt`/`defer`/`non-goal`.
+
+## Ownership
+
+- Responsible maintainer: `@adolago`
+- Backup reviewer: repository maintainers with upstream-sync context
+
+Policy changes should be proposed via PR and reference this lane.

--- a/docs/architecture/zee-opencode-gap-map-top10.md
+++ b/docs/architecture/zee-opencode-gap-map-top10.md
@@ -29,7 +29,7 @@ Baseline reference: `docs/architecture/upstream-differences.md`.
 | 3 | 03 | [#288](https://github.com/adolago/zee/issues/288) | Auth/provider plugin parity and migration ergonomics | adapt | triage-done | `docs/architecture/opencode-lanes/lane-03-auth-provider.md` |
 | 4 | 04 | [#289](https://github.com/adolago/zee/issues/289) | Web/desktop/package topology parity strategy | adapt | triage-done | `docs/architecture/opencode-lanes/lane-04-package-topology.md` |
 | 5 | 05 | [#290](https://github.com/adolago/zee/issues/290) | API/LSP/server workflow parity deltas | adapt | triage-done | `docs/architecture/opencode-lanes/lane-05-api-lsp-workflows.md` |
-| 6 | 06 | [#291](https://github.com/adolago/zee/issues/291) | Upstream sync automation and policy | port | open | `docs/architecture/opencode-sync-policy.md` |
+| 6 | 06 | [#291](https://github.com/adolago/zee/issues/291) | Upstream sync automation and policy | port | triage-done | `docs/architecture/opencode-sync-policy.md` |
 | 7 | 07 | `TBD` | Provider breadth parity (extra `@ai-sdk/*` footprint vs Zee policy) | defer | backlog | `docs/architecture/feature-comparison.md` |
 | 8 | 08 | `TBD` | Project-local `.opencode/` migration ergonomics into `.zee/` | adapt | backlog | `docs/architecture/upstream-differences.md` |
 | 9 | 09 | `TBD` | Client/server mode behavior parity (serve flows, remote clients) | adapt | backlog | `docs/architecture/feature-comparison.md` |
@@ -71,6 +71,9 @@ Baseline reference: `docs/architecture/upstream-differences.md`.
 
 - Scope: repeatable triage automation and evidence standards.
 - Current decision: `port` (process and tooling parity).
+- Artifacts:
+  - `docs/architecture/opencode-sync-policy.md`
+  - `docs/architecture/opencode-snapshot-playbook.md`
 
 ## Refresh Process (Pinned to `opencode/dev`)
 


### PR DESCRIPTION
## Summary
- add `docs/architecture/opencode-sync-policy.md` with refresh cadence, pin policy, decision policy, and lane update checklist
- add `docs/architecture/opencode-snapshot-playbook.md` with reproducible upstream snapshot command sequence
- update lane 06 status in the canonical OpenCode gap map to `triage-done`

## Acceptance
- documented sync policy and cadence
- script/command playbook for reproducible delta snapshots
- lane update checklist for future refresh cycles

Closes #291
