### PR TITLE
feat: add @zee/tui wrapper package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "workspaces": {
     "packages": [
+      "packages/tui",
       "packages/zee",
       "packages/zee-adapter",
       "packages/app",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "workspaces": {
     "packages": [
-      "packages/tui",
       "packages/zee",
       "packages/zee-adapter",
       "packages/app",

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -1,0 +1,20 @@
+# @zee/tui
+
+Reusable terminal UI framework package for Zee.
+
+## Install
+
+```bash
+npm install @zee/tui
+```
+
+## Usage
+
+```ts
+import { TUI, Text, ProcessTerminal } from "@zee/tui"
+
+const terminal = new ProcessTerminal()
+const tui = new TUI(terminal)
+tui.addChild(new Text("Hello from @zee/tui"))
+tui.start()
+```

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -10,7 +10,10 @@
     "build": "tsgo"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
   "files": [
     "dist"
@@ -24,9 +27,6 @@
     "typescript": "catalog:",
     "@typescript/native-preview": "catalog:"
   },
-  "publishConfig": {
-    "directory": "dist"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/adolago/zee.git",
@@ -38,5 +38,7 @@
     "terminal",
     "ui",
     "components"
-  ]
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts"
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@zee/tui",
+  "version": "1.0.0",
+  "description": "Reusable terminal UI framework package for Zee",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "typecheck": "tsgo --noEmit",
+    "build": "tsgo"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@mariozechner/pi-tui": "0.52.9"
+  },
+  "devDependencies": {
+    "@tsconfig/node22": "catalog:",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "@typescript/native-preview": "catalog:"
+  },
+  "publishConfig": {
+    "directory": "dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adolago/zee.git",
+    "directory": "packages/tui"
+  },
+  "keywords": [
+    "zee",
+    "tui",
+    "terminal",
+    "ui",
+    "components"
+  ]
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Zee TUI package
+ *
+ * Re-exporting the terminal UI framework Zee currently builds on.
+ */
+export * from "@mariozechner/pi-tui"

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add new workspace package `@zee/tui`
- re-export `@mariozechner/pi-tui` from `packages/tui/src/index.ts`
- include package metadata/README and add `packages/tui` to workspace packages

Closes #300

## Validation
- package structure and exports verified locally
