### PR TITLE
fix(opencode-sync): config and flags parity for #314

### DIFF
--- a/packages/zee/Swabble/src/commands/configure.gateway.test.ts
+++ b/packages/zee/Swabble/src/commands/configure.gateway.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  text: vi.fn(),
+  select: vi.fn(),
+  confirm: vi.fn(),
+  note: vi.fn(),
+  findTailscaleBinary: vi.fn(),
+}));
+
+vi.mock("./configure.shared.js", () => ({
+  text: mocks.text,
+  select: mocks.select,
+  confirm: mocks.confirm,
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: mocks.note,
+}));
+
+vi.mock("../infra/tailscale.js", () => ({
+  findTailscaleBinary: mocks.findTailscaleBinary,
+}));
+
+vi.mock("./onboard-helpers.js", async () => {
+  const actual = await vi.importActual<typeof import("./onboard-helpers.js")>("./onboard-helpers.js");
+  return {
+    ...actual,
+    guardCancel: (value: unknown) => value,
+    randomToken: () => "generated-token",
+  };
+});
+
+import { promptGatewayConfig } from "./configure.gateway.js";
+
+describe("promptGatewayConfig credential normalization", () => {
+  beforeEach(() => {
+    mocks.text.mockReset();
+    mocks.select.mockReset();
+    mocks.confirm.mockReset();
+    mocks.note.mockReset();
+    mocks.findTailscaleBinary.mockReset();
+  });
+
+  it("does not coerce missing token input into literal 'undefined'", async () => {
+    mocks.text
+      .mockResolvedValueOnce("3210")
+      .mockResolvedValueOnce(undefined as unknown as string);
+    mocks.select
+      .mockResolvedValueOnce("loopback")
+      .mockResolvedValueOnce("token")
+      .mockResolvedValueOnce("off");
+
+    const runtime = {
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as unknown as Parameters<typeof promptGatewayConfig>[1];
+
+    const result = await promptGatewayConfig({} as never, runtime);
+    expect(result.token).toBe("generated-token");
+    expect(result.config.gateway?.auth).toMatchObject({
+      mode: "token",
+      token: "generated-token",
+    });
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing password input instead of storing 'undefined'", async () => {
+    mocks.text
+      .mockResolvedValueOnce("3210")
+      .mockResolvedValueOnce(undefined as unknown as string);
+    mocks.select
+      .mockResolvedValueOnce("loopback")
+      .mockResolvedValueOnce("password")
+      .mockResolvedValueOnce("off");
+
+    const runtime = {
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as unknown as Parameters<typeof promptGatewayConfig>[1];
+
+    await expect(promptGatewayConfig({} as never, runtime)).rejects.toThrow(
+      "Gateway password is required.",
+    );
+    expect(runtime.error).toHaveBeenCalledWith("Gateway password is required.");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/zee/Swabble/src/commands/configure.gateway.ts
+++ b/packages/zee/Swabble/src/commands/configure.gateway.ts
@@ -4,6 +4,7 @@ import { findTailscaleBinary } from "../infra/tailscale.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { buildGatewayAuthConfig } from "./configure.gateway-auth.js";
+import { normalizeCredentialInput } from "./credential-input.js";
 import { confirm, select, text } from "./configure.shared.js";
 import { guardCancel, randomToken } from "./onboard-helpers.js";
 
@@ -175,7 +176,7 @@ export async function promptGatewayConfig(
       }),
       runtime,
     );
-    gatewayToken = String(tokenInput).trim() || randomToken();
+    gatewayToken = normalizeCredentialInput(tokenInput) ?? randomToken();
   }
 
   if (authMode === "password") {
@@ -186,7 +187,12 @@ export async function promptGatewayConfig(
       }),
       runtime,
     );
-    gatewayPassword = String(password).trim();
+    gatewayPassword = normalizeCredentialInput(password);
+    if (!gatewayPassword) {
+      runtime.error("Gateway password is required.");
+      runtime.exit(1);
+      throw new Error("Gateway password is required.");
+    }
   }
 
   const authConfig = buildGatewayAuthConfig({

--- a/packages/zee/Swabble/src/commands/credential-input.test.ts
+++ b/packages/zee/Swabble/src/commands/credential-input.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeCredentialInput } from "./credential-input.js";
+
+describe("normalizeCredentialInput", () => {
+  it("returns undefined for non-string values", () => {
+    expect(normalizeCredentialInput(undefined)).toBeUndefined();
+    expect(normalizeCredentialInput(null)).toBeUndefined();
+    expect(normalizeCredentialInput(123)).toBeUndefined();
+    expect(normalizeCredentialInput({ key: "value" })).toBeUndefined();
+  });
+
+  it("returns undefined for blank values", () => {
+    expect(normalizeCredentialInput("")).toBeUndefined();
+    expect(normalizeCredentialInput("   ")).toBeUndefined();
+  });
+
+  it("returns undefined for literal undefined/null strings", () => {
+    expect(normalizeCredentialInput("undefined")).toBeUndefined();
+    expect(normalizeCredentialInput("  undefined  ")).toBeUndefined();
+    expect(normalizeCredentialInput("null")).toBeUndefined();
+    expect(normalizeCredentialInput(" NULL ")).toBeUndefined();
+  });
+
+  it("returns normalized value for valid input", () => {
+    expect(normalizeCredentialInput(" token ")).toBe("token");
+    expect(normalizeCredentialInput("sk-test")).toBe("sk-test");
+  });
+});

--- a/packages/zee/Swabble/src/commands/credential-input.ts
+++ b/packages/zee/Swabble/src/commands/credential-input.ts
@@ -1,0 +1,8 @@
+export function normalizeCredentialInput(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const lowered = trimmed.toLowerCase();
+  if (lowered === "undefined" || lowered === "null") return undefined;
+  return trimmed;
+}

--- a/packages/zee/Swabble/src/config/redact-snapshot.test.ts
+++ b/packages/zee/Swabble/src/config/redact-snapshot.test.ts
@@ -44,6 +44,45 @@ describe("redactConfigObject", () => {
     expect(out.whatsapp.tokenSource).toBe("none");
     expect(out.apiKey).toBe(REDACTED_SENTINEL);
   });
+
+  it("supports custom nested key matchers", () => {
+    const input = {
+      plugins: {
+        entries: {
+          alpha: {
+            config: {
+              privateCredential: "s3cr3t",
+              safeValue: "ok",
+            },
+          },
+        },
+      },
+    };
+
+    const out = redactConfigObject(input, {
+      nestedKeyMatchers: ["privatecredential"],
+    }) as typeof input;
+    expect(out.plugins.entries.alpha.config.privateCredential).toBe(REDACTED_SENTINEL);
+    expect(out.plugins.entries.alpha.config.safeValue).toBe("ok");
+  });
+
+  it("supports default-deny under high-risk paths with allowlist overrides", () => {
+    const input = {
+      auth: {
+        mode: "token",
+        username: "ops-user",
+        token: "abc123",
+      },
+    };
+
+    const out = redactConfigObject(input, {
+      defaultDeny: true,
+      allowlist: ["auth.mode"],
+    }) as typeof input;
+    expect(out.auth.mode).toBe("token");
+    expect(out.auth.username).toBe(REDACTED_SENTINEL);
+    expect(out.auth.token).toBe(REDACTED_SENTINEL);
+  });
 });
 
 describe("redactConfigSnapshot", () => {

--- a/packages/zee/Swabble/src/config/redact-snapshot.ts
+++ b/packages/zee/Swabble/src/config/redact-snapshot.ts
@@ -1,6 +1,7 @@
 import JSON5 from "json5";
 
 import type { ConfigFileSnapshot } from "./types.js";
+import type { SecurityRedactionConfig } from "./types.security.js";
 
 /**
  * Sentinel value used to replace sensitive config fields in gateway responses.
@@ -11,6 +12,18 @@ import type { ConfigFileSnapshot } from "./types.js";
 export const REDACTED_SENTINEL = "<redacted>";
 
 const ENV_REF_RE = /^\$\{[A-Z0-9_]+\}$/;
+const HIGH_RISK_PATH_PARTS = new Set([
+  "auth",
+  "oauth",
+  "credentials",
+  "credential",
+  "secrets",
+  "secret",
+  "tokens",
+  "token",
+  "apikeys",
+  "api_keys",
+]);
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
@@ -31,31 +44,119 @@ function isSensitiveKey(key: string): boolean {
   return false;
 }
 
-function redactValue(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map((entry) => redactValue(entry));
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function compilePathPattern(raw: string): RegExp {
+  const trimmed = raw.trim();
+  const source = trimmed
+    .split("*")
+    .map((part) => escapeRegExp(part))
+    .join(".*");
+  return new RegExp(`^${source}$`, "i");
+}
+
+type RedactionPolicyResolved = {
+  defaultDeny: boolean;
+  allowlist: RegExp[];
+  matchers: RegExp[];
+};
+
+function resolvePolicy(policy?: SecurityRedactionConfig): RedactionPolicyResolved {
+  return {
+    defaultDeny: policy?.defaultDeny === true,
+    allowlist: (policy?.allowlist ?? [])
+      .map((entry) => String(entry).trim())
+      .filter(Boolean)
+      .map((entry) => compilePathPattern(entry)),
+    matchers: (policy?.nestedKeyMatchers ?? [])
+      .map((entry) => String(entry).trim())
+      .filter(Boolean)
+      .map((entry) => {
+        try {
+          return new RegExp(entry, "i");
+        } catch {
+          return compilePathPattern(entry);
+        }
+      }),
+  };
+}
+
+function isAllowlisted(pathSegments: string[], policy: RedactionPolicyResolved): boolean {
+  if (policy.allowlist.length === 0) return false;
+  const path = pathSegments.join(".");
+  return policy.allowlist.some((pattern) => pattern.test(path));
+}
+
+function shouldRedactString(params: {
+  key: string;
+  value: string;
+  pathSegments: string[];
+  policy: RedactionPolicyResolved;
+}): boolean {
+  const { key, value, pathSegments, policy } = params;
+  if (!value.trim()) return false;
+  if (isEnvReference(value)) return false;
+  if (isAllowlisted(pathSegments, policy)) return false;
+
+  const path = pathSegments.join(".");
+  if (isSensitiveKey(key)) return true;
+  if (policy.matchers.some((pattern) => pattern.test(key) || pattern.test(path))) return true;
+
+  if (!policy.defaultDeny) return false;
+  const parentSegments = pathSegments.slice(0, -1).map((segment) => segment.toLowerCase());
+  return parentSegments.some(
+    (segment) =>
+      HIGH_RISK_PATH_PARTS.has(segment) ||
+      isSensitiveKey(segment),
+  );
+}
+
+function redactValue(
+  value: unknown,
+  policy: RedactionPolicyResolved,
+  path: string[] = [],
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => redactValue(entry, policy, [...path, String(index)]));
+  }
   if (!isPlainObject(value)) return value;
 
   const out: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value)) {
-    if (isSensitiveKey(key) && typeof child === "string" && child.trim() && !isEnvReference(child)) {
+    const childPath = [...path, key];
+    if (
+      typeof child === "string" &&
+      shouldRedactString({
+        key,
+        value: child,
+        pathSegments: childPath,
+        policy,
+      })
+    ) {
       out[key] = REDACTED_SENTINEL;
       continue;
     }
-    out[key] = redactValue(child);
+    out[key] = redactValue(child, policy, childPath);
   }
   return out;
 }
 
-export function redactConfigObject<T = unknown>(value: T): T {
-  return redactValue(value) as T;
+export function redactConfigObject<T = unknown>(value: T, policy?: SecurityRedactionConfig): T {
+  return redactValue(value, resolvePolicy(policy)) as T;
 }
 
-export function redactConfigSnapshot(snapshot: ConfigFileSnapshot): ConfigFileSnapshot {
+export function redactConfigSnapshot(
+  snapshot: ConfigFileSnapshot,
+  policy?: SecurityRedactionConfig,
+): ConfigFileSnapshot {
+  const effectivePolicy = policy ?? snapshot.config?.security?.redaction;
   let redactedRaw: string | null = snapshot.raw;
   if (typeof snapshot.raw === "string") {
     try {
       const parsed = JSON5.parse(snapshot.raw) as unknown;
-      const redacted = redactConfigObject(parsed);
+      const redacted = redactConfigObject(parsed, effectivePolicy);
       redactedRaw = JSON.stringify(redacted, null, 2).trimEnd().concat("\n");
     } catch {
       // Avoid leaking secrets when raw can't be parsed.
@@ -66,15 +167,22 @@ export function redactConfigSnapshot(snapshot: ConfigFileSnapshot): ConfigFileSn
   return {
     ...snapshot,
     raw: redactedRaw,
-    parsed: redactConfigObject(snapshot.parsed),
-    config: redactConfigObject(snapshot.config),
+    parsed: redactConfigObject(snapshot.parsed, effectivePolicy),
+    config: redactConfigObject(snapshot.config, effectivePolicy),
   };
 }
 
-function restoreValue(next: unknown, base: unknown, path: string[]): unknown {
+function restoreValue(
+  next: unknown,
+  base: unknown,
+  path: string[],
+  policy: RedactionPolicyResolved,
+): unknown {
   if (Array.isArray(next)) {
     const baseArr = Array.isArray(base) ? base : [];
-    return next.map((value, index) => restoreValue(value, baseArr[index], [...path, String(index)]));
+    return next.map((value, index) =>
+      restoreValue(value, baseArr[index], [...path, String(index)], policy),
+    );
   }
   if (!isPlainObject(next)) return next;
 
@@ -82,7 +190,15 @@ function restoreValue(next: unknown, base: unknown, path: string[]): unknown {
   const out: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(next)) {
     const baseChild = baseObj[key];
-    if (isSensitiveKey(key) && child === REDACTED_SENTINEL) {
+    if (
+      child === REDACTED_SENTINEL &&
+      shouldRedactString({
+        key,
+        value: REDACTED_SENTINEL,
+        pathSegments: [...path, key],
+        policy,
+      })
+    ) {
       const hasBaseValue = key in baseObj;
       if (!hasBaseValue) {
         const label = path.length > 0 ? `${path.join(".")}.${key}` : key;
@@ -93,11 +209,15 @@ function restoreValue(next: unknown, base: unknown, path: string[]): unknown {
       out[key] = baseChild;
       continue;
     }
-    out[key] = restoreValue(child, baseChild, [...path, key]);
+    out[key] = restoreValue(child, baseChild, [...path, key], policy);
   }
   return out;
 }
 
-export function restoreRedactedValues<T = unknown>(next: T, base: unknown): T {
-  return restoreValue(next, base, []) as T;
+export function restoreRedactedValues<T = unknown>(
+  next: T,
+  base: unknown,
+  policy?: SecurityRedactionConfig,
+): T {
+  return restoreValue(next, base, [], resolvePolicy(policy)) as T;
 }

--- a/packages/zee/Swabble/src/config/schema.ts
+++ b/packages/zee/Swabble/src/config/schema.ts
@@ -53,6 +53,7 @@ const GROUP_LABELS: Record<string, string> = {
   wizard: "Wizard",
   update: "Update",
   diagnostics: "Diagnostics",
+  security: "Security",
   logging: "Logging",
   gateway: "Gateway",
   canvasHost: "Canvas Host",
@@ -84,6 +85,7 @@ const GROUP_ORDER: Record<string, number> = {
   wizard: 20,
   update: 25,
   diagnostics: 27,
+  security: 28,
   gateway: 30,
   canvasHost: 32,
   nodeHost: 35,
@@ -159,6 +161,17 @@ const FIELD_LABELS: Record<string, string> = {
   "gateway.daemonBridge.createSession": "Daemon Bridge Auto-Create Sessions",
   "gateway.auth.token": "Gateway Token",
   "gateway.auth.password": "Gateway Password",
+  "gateway.auth.rateLimit.enabled": "Gateway Auth Rate Limiting",
+  "gateway.auth.rateLimit.windowMs": "Gateway Auth Rate-Limit Window (ms)",
+  "gateway.auth.rateLimit.maxAttemptsPerIp": "Gateway Auth Max Attempts per IP",
+  "gateway.auth.rateLimit.maxAttemptsPerToken": "Gateway Auth Max Attempts per Token",
+  "gateway.auth.rateLimit.lockoutMs": "Gateway Auth Lockout Duration (ms)",
+  "security.redaction.defaultDeny": "Config Redaction Default Deny",
+  "security.redaction.allowlist": "Config Redaction Allowlist",
+  "security.redaction.nestedKeyMatchers": "Config Redaction Key Matchers",
+  "security.unicodeSanitization.enabled": "Unicode Sanitization Enabled",
+  "security.unicodeSanitization.mode": "Unicode Sanitization Mode",
+  "security.unicodeSanitization.homoglyphClasses": "Unicode Sanitization Classes",
   "gateway.allowedOrigins": "Gateway Allowed Origins",
   "gateway.controlUi.enabled": "Control UI Enabled",
   "gateway.controlUi.allowInsecureAuth": "Control UI Insecure Auth",
@@ -235,6 +248,7 @@ const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.cacheTtlMinutes": "Web Fetch Cache TTL (min)",
   "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
+  "tools.web.fetch.includeImages": "Web Fetch Attach Images",
   "gateway.http.endpoints.chatCompletions.enabled": "OpenAI Chat Completions Endpoint",
   "gateway.reload.mode": "Config Reload Mode",
   "gateway.reload.debounceMs": "Config Reload Debounce (ms)",
@@ -393,6 +407,28 @@ const FIELD_HELP: Record<string, string> = {
   "gateway.auth.token":
     "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",
   "gateway.auth.password": "Required for Tailscale funnel.",
+  "gateway.auth.rateLimit.enabled":
+    "Enable auth failure throttling and temporary lockouts for gateway HTTP/WS auth.",
+  "gateway.auth.rateLimit.windowMs":
+    "Sliding window size for counting failed auth attempts (milliseconds).",
+  "gateway.auth.rateLimit.maxAttemptsPerIp":
+    "Max failed auth attempts per client IP within the rate-limit window.",
+  "gateway.auth.rateLimit.maxAttemptsPerToken":
+    "Max failed auth attempts per token/password fingerprint within the rate-limit window.",
+  "gateway.auth.rateLimit.lockoutMs":
+    "Lockout duration after exceeding auth attempt limits (milliseconds).",
+  "security.redaction.defaultDeny":
+    "When enabled, redact string values under high-risk auth/credential paths unless explicitly allowlisted.",
+  "security.redaction.allowlist":
+    "Dot-path allowlist that bypasses config redaction checks (supports '*' wildcards).",
+  "security.redaction.nestedKeyMatchers":
+    "Additional case-insensitive snippets used to classify nested keys/paths as sensitive.",
+  "security.unicodeSanitization.enabled":
+    "Enable additional homoglyph sanitization for untrusted external content wrappers.",
+  "security.unicodeSanitization.mode":
+    "Action for dangerous homoglyphs: normalize to ASCII markers or reject.",
+  "security.unicodeSanitization.homoglyphClasses":
+    "Optional class labels to tune homoglyph sanitization behavior.",
   "gateway.controlUi.enabled":
     "Enable the Control UI surface for gateway operators (default: false).",
   "gateway.controlUi.allowInsecureAuth":
@@ -463,6 +499,8 @@ const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.cacheTtlMinutes": "Cache TTL in minutes for web_fetch results.",
   "tools.web.fetch.maxRedirects": "Maximum redirects allowed for web_fetch (default: 3).",
   "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
+  "tools.web.fetch.includeImages":
+    "Attach image responses as image blocks in tool output when possible (default: true).",
   "tools.web.fetch.readability":
     "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
   "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl fallback for web_fetch (if configured).",

--- a/packages/zee/Swabble/src/config/types.gateway.ts
+++ b/packages/zee/Swabble/src/config/types.gateway.ts
@@ -51,6 +51,19 @@ export type TalkConfig = {
 
 export type GatewayAuthMode = "token" | "password";
 
+export type GatewayAuthRateLimitConfig = {
+  /** Enable auth rate limiting and lockouts (default: true). */
+  enabled?: boolean;
+  /** Sliding window for failed auth attempts in milliseconds (default: 60000). */
+  windowMs?: number;
+  /** Max failed attempts per client IP within the window (default: 20). */
+  maxAttemptsPerIp?: number;
+  /** Max failed attempts per token/password within the window (default: 10). */
+  maxAttemptsPerToken?: number;
+  /** Lockout duration in milliseconds after limit is exceeded (default: 300000). */
+  lockoutMs?: number;
+};
+
 export type GatewayAuthConfig = {
   /** Authentication mode for Gateway connections. Defaults to token when set. */
   mode?: GatewayAuthMode;
@@ -60,6 +73,8 @@ export type GatewayAuthConfig = {
   password?: string;
   /** Allow Tailscale identity headers when serve mode is enabled. */
   allowTailscale?: boolean;
+  /** Optional auth rate limiting controls. */
+  rateLimit?: GatewayAuthRateLimitConfig;
 };
 
 export type GatewayTailscaleMode = "off" | "serve" | "funnel";

--- a/packages/zee/Swabble/src/config/types.security.ts
+++ b/packages/zee/Swabble/src/config/types.security.ts
@@ -1,0 +1,34 @@
+export type SecurityRedactionConfig = {
+  /**
+   * When true, redact string values under high-risk paths (auth/credentials/tokens)
+   * even if the leaf key does not look sensitive.
+   */
+  defaultDeny?: boolean;
+  /**
+   * Dot-path allowlist that bypasses redaction checks.
+   * Supports exact entries and "*" wildcards.
+   */
+  allowlist?: string[];
+  /**
+   * Additional case-insensitive key/path patterns treated as sensitive.
+   * Plain text snippets are supported.
+   */
+  nestedKeyMatchers?: string[];
+};
+
+export type UnicodeSanitizationMode = "reject" | "normalize";
+
+export type SecurityUnicodeSanitizationConfig = {
+  /** Enable extra Unicode homoglyph sanitization for untrusted content. */
+  enabled?: boolean;
+  /** Action to take when dangerous homoglyphs are detected. */
+  mode?: UnicodeSanitizationMode;
+  /** Optional class labels to control category rollout. */
+  homoglyphClasses?: string[];
+};
+
+export type SecurityConfig = {
+  redaction?: SecurityRedactionConfig;
+  unicodeSanitization?: SecurityUnicodeSanitizationConfig;
+};
+

--- a/packages/zee/Swabble/src/config/types.ts
+++ b/packages/zee/Swabble/src/config/types.ts
@@ -18,6 +18,7 @@ export * from "./types.node-host.js";
 export * from "./types.plugins.js";
 export * from "./types.queue.js";
 export * from "./types.sandbox.js";
+export * from "./types.security.js";
 export * from "./types.skills.js";
 export * from "./types.tts.js";
 export * from "./types.tools.js";

--- a/packages/zee/Swabble/src/config/types.zee.ts
+++ b/packages/zee/Swabble/src/config/types.zee.ts
@@ -21,6 +21,7 @@ import type {
 import type { ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
 import type { PluginsConfig } from "./types.plugins.js";
+import type { SecurityConfig } from "./types.security.js";
 import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
@@ -132,6 +133,7 @@ export type ZeeConfig = {
   talk?: TalkConfig;
   canvasHost?: CanvasHostConfig;
   gateway?: GatewayConfig;
+  security?: SecurityConfig;
 };
 
 export type ConfigValidationIssue = {

--- a/packages/zee/Swabble/src/config/zod-schema.ts
+++ b/packages/zee/Swabble/src/config/zod-schema.ts
@@ -150,6 +150,27 @@ export const ZeeSchema = z
       })
       .strict()
       .optional(),
+    security: z
+      .object({
+        redaction: z
+          .object({
+            defaultDeny: z.boolean().optional(),
+            allowlist: z.array(z.string()).optional(),
+            nestedKeyMatchers: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
+        unicodeSanitization: z
+          .object({
+            enabled: z.boolean().optional(),
+            mode: z.union([z.literal("reject"), z.literal("normalize")]).optional(),
+            homoglyphClasses: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
     update: z
       .object({
         channel: z.union([z.literal("stable"), z.literal("beta"), z.literal("dev")]).optional(),
@@ -350,6 +371,16 @@ export const ZeeSchema = z
             token: z.string().optional(),
             password: z.string().optional(),
             allowTailscale: z.boolean().optional(),
+            rateLimit: z
+              .object({
+                enabled: z.boolean().optional(),
+                windowMs: z.number().int().positive().optional(),
+                maxAttemptsPerIp: z.number().int().positive().optional(),
+                maxAttemptsPerToken: z.number().int().positive().optional(),
+                lockoutMs: z.number().int().positive().optional(),
+              })
+              .strict()
+              .optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
Closes #314

## What this PR does
- hardens gateway credential prompts so missing values are not coerced into literal `"undefined"`/`"null"`
- adds focused tests for credential normalization and gateway prompt behavior
- introduces `security` config types and schema validation (`redaction` + `unicodeSanitization`)
- extends config metadata labels/help for new security and gateway auth-rate-limit settings
- upgrades config redaction policy support with:
  - wildcard allowlist paths
  - nested key/path matchers
  - optional default-deny behavior under high-risk auth/credential paths

## Parity mapping for #314
Implemented (theme-aligned):
- config schema/type evolution for runtime config safety and autocompletion surface
- config redaction behavior + tests for sensitive nested values and allowlist/default-deny controls
- gateway credential input hardening to avoid invalid sentinel string persistence

N/A with rationale:
- OPENCODE-specific env flags (`OPENCODE_*`) and TUI experimental flags do not map directly to Zee runtime flags
- OPENCODE package-manager/plugin-install specifics are architecture-specific to `packages/opencode`
- docs-only and repo-tooling-only commits in the source theme are out of scope for this Swabble config slice

## Verification
- `pnpm exec vitest run src/commands/credential-input.test.ts src/commands/configure.gateway.test.ts src/config/redact-snapshot.test.ts`
- `pnpm build` (in `packages/zee/Swabble`)
