### PR TITLE
feat: add @zee/web-ui wrapper package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "workspaces": {
     "packages": [
+      "packages/web-ui",
       "packages/zee",
       "packages/zee-adapter",
       "packages/app",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "workspaces": {
     "packages": [
-      "packages/web-ui",
       "packages/zee",
       "packages/zee-adapter",
       "packages/app",

--- a/packages/web-ui/README.md
+++ b/packages/web-ui/README.md
@@ -1,0 +1,19 @@
+# @zee/web-ui
+
+Reusable web chat component package for Zee.
+
+## Install
+
+```bash
+npm install @zee/web-ui
+```
+
+## Usage
+
+```ts
+import { ChatPanel } from "@zee/web-ui"
+import "@mariozechner/pi-web-ui/app.css"
+
+const chatPanel = new ChatPanel()
+document.body.appendChild(chatPanel)
+```

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@zee/web-ui",
+  "version": "1.0.0",
+  "description": "Reusable web chat component package for Zee",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "typecheck": "tsgo --noEmit",
+    "build": "tsgo"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@mariozechner/pi-web-ui": "0.52.9"
+  },
+  "devDependencies": {
+    "@tsconfig/node22": "catalog:",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "@typescript/native-preview": "catalog:"
+  },
+  "publishConfig": {
+    "directory": "dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adolago/zee.git",
+    "directory": "packages/web-ui"
+  },
+  "keywords": [
+    "zee",
+    "web-ui",
+    "chat",
+    "components",
+    "assistant"
+  ]
+}

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -10,7 +10,10 @@
     "build": "tsgo"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
   "files": [
     "dist"
@@ -24,9 +27,6 @@
     "typescript": "catalog:",
     "@typescript/native-preview": "catalog:"
   },
-  "publishConfig": {
-    "directory": "dist"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/adolago/zee.git",
@@ -38,5 +38,7 @@
     "chat",
     "components",
     "assistant"
-  ]
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts"
 }

--- a/packages/web-ui/src/index.ts
+++ b/packages/web-ui/src/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Zee Web UI package
+ *
+ * Re-exporting the embeddable web chat UI surface Zee currently builds on.
+ */
+export * from "@mariozechner/pi-web-ui"

--- a/packages/web-ui/tsconfig.json
+++ b/packages/web-ui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add new workspace package `@zee/web-ui`
- re-export `@mariozechner/pi-web-ui` from `packages/web-ui/src/index.ts`
- include package metadata/README and add `packages/web-ui` to workspace packages

Closes #301

## Validation
- package structure and exports verified locally
