### PR TITLE
fix(opencode-sync): provider integration parity for #312

### DIFF
--- a/packages/zee/src/provider/provider.ts
+++ b/packages/zee/src/provider/provider.ts
@@ -1101,6 +1101,25 @@ export namespace Provider {
     return state().then((s) => s.providers[providerID])
   }
 
+  /**
+   * Normalize model IDs for provider-side aliases/renames.
+   * Keep this narrow and conservative to avoid changing behavior for other providers.
+   */
+  function normalizeRequestedModelID(providerID: string, modelID: string): string {
+    if (providerID !== "google") return modelID
+
+    let normalized = modelID.trim().replace(/^google\//, "").replace(/-+/g, "-")
+
+    // Some clients send Gemini 3 IDs using "3.0" while catalog keys use "3".
+    normalized = normalized.replace(/^gemini-3\.0(?=-)/, "gemini-3")
+
+    // Gemini 3 shorthand aliases should resolve to canonical preview IDs.
+    if (normalized === "gemini-3-pro") return "gemini-3-pro-preview"
+    if (normalized === "gemini-3-flash") return "gemini-3-flash-preview"
+
+    return normalized
+  }
+
   export async function getModel(providerID: string, modelID: string) {
     const s = await state()
     const provider = s.providers[providerID]
@@ -1111,11 +1130,19 @@ export namespace Provider {
       throw new ModelNotFoundError({ providerID, modelID, suggestions })
     }
 
-    const info = provider.models[modelID]
+    const normalizedModelID = normalizeRequestedModelID(providerID, modelID)
+    const requestedModelIDs = normalizedModelID === modelID ? [modelID] : [normalizedModelID, modelID]
+    const info = requestedModelIDs.map((id) => provider.models[id]).find(Boolean)
     if (!info) {
       const availableModels = Object.keys(provider.models)
-      const matches = fuzzysort.go(modelID, availableModels, { limit: 3, threshold: -10000 })
-      const suggestions = matches.map((m) => m.target)
+      const matchedSuggestions = Array.from(
+        new Set(
+          requestedModelIDs.flatMap((id) =>
+            fuzzysort.go(id, availableModels, { limit: 3, threshold: -10000 }).map((match) => match.target),
+          ),
+        ),
+      )
+      const suggestions = matchedSuggestions.length > 0 ? matchedSuggestions : availableModels.slice(0, 3)
       throw new ModelNotFoundError({ providerID, modelID, suggestions })
     }
     return info

--- a/packages/zee/test/provider/provider.test.ts
+++ b/packages/zee/test/provider/provider.test.ts
@@ -346,6 +346,123 @@ test("getModel throws ModelNotFoundError for invalid provider", async () => {
   })
 })
 
+test("getModel normalizes google gemini aliases to canonical preview IDs", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "zee.json"),
+        JSON.stringify({
+          $schema: "zee",
+          provider: {
+            google: {
+              options: {
+                apiKey: "test-google-key",
+              },
+              models: {
+                "gemini-3-pro-preview": {
+                  name: "Gemini 3 Pro Preview",
+                },
+                "gemini-3-flash-preview": {
+                  name: "Gemini 3 Flash Preview",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const flashFrom30 = await Provider.getModel("google", "gemini-3.0-flash-preview")
+      expect(flashFrom30.id).toBe("gemini-3-flash-preview")
+
+      const flashFromBase = await Provider.getModel("google", "gemini-3-flash")
+      expect(flashFromBase.id).toBe("gemini-3-flash-preview")
+
+      const proFrom30 = await Provider.getModel("google", "gemini-3.0-pro-preview")
+      expect(proFrom30.id).toBe("gemini-3-pro-preview")
+    },
+  })
+})
+
+test("getModel prefers normalized google alias when both legacy and canonical IDs exist", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "zee.json"),
+        JSON.stringify({
+          $schema: "zee",
+          provider: {
+            google: {
+              options: {
+                apiKey: "test-google-key",
+              },
+              models: {
+                "gemini-3.0-flash-preview": {
+                  name: "Legacy Gemini 3.0 Flash Preview",
+                },
+                "gemini-3-flash-preview": {
+                  name: "Canonical Gemini 3 Flash Preview",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = await Provider.getModel("google", "gemini-3.0-flash-preview")
+      expect(model.id).toBe("gemini-3-flash-preview")
+    },
+  })
+})
+
+test("getModel keeps helpful suggestions when google normalized model is missing", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "zee.json"),
+        JSON.stringify({
+          $schema: "zee",
+          provider: {
+            google: {
+              options: {
+                apiKey: "test-google-key",
+              },
+              models: {
+                "gemini-3-pro-preview": {
+                  name: "Gemini 3 Pro Preview",
+                },
+                "gemini-3-flash-preview": {
+                  name: "Gemini 3 Flash Preview",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      try {
+        await Provider.getModel("google", "gemini-3.0-does-not-exist")
+        expect(true).toBe(false) // Should not reach here
+      } catch (e: any) {
+        expect(e.data.modelID).toBe("gemini-3.0-does-not-exist")
+        expect(e.data.suggestions).toBeDefined()
+        expect(e.data.suggestions.length).toBeGreaterThan(0)
+      }
+    },
+  })
+})
+
 test("parseModel correctly parses provider/model string", () => {
   const result = Provider.parseModel("anthropic/claude-sonnet-4")
   expect(result.providerID).toBe("anthropic")


### PR DESCRIPTION
Closes #312

## What this PR does
- normalizes Google model IDs before lookup to support common Gemini alias formats
- maps `google/gemini-*` and `gemini-3.0-*` forms to canonical catalog keys
- prefers canonical `gemini-3-*-preview` IDs when both legacy and canonical forms exist
- preserves useful model suggestions in `ModelNotFoundError` after normalization
- adds provider tests for alias normalization, canonical precedence, and suggestion fallback

## Verification
- `bun test test/provider/provider.test.ts` (in `packages/zee`)
