### PR TITLE
feat: add zee package manifest workflow

### DIFF
--- a/packages/zee/src/cli/cmd/package.ts
+++ b/packages/zee/src/cli/cmd/package.ts
@@ -21,6 +21,9 @@ async function withScope<T>(args: ScopeInput, fn: (scope: PackageScope, projectR
   return bootstrap(process.cwd(), async () => {
     const scope: PackageScope = args.local ? "local" : "global"
     const projectRoot = scope === "local" ? Instance.worktree : undefined
+    if (scope === "local" && projectRoot === "/") {
+      throw new Error("Local package scope requires running inside a git worktree")
+    }
     return fn(scope, projectRoot)
   })
 }
@@ -189,4 +192,3 @@ export const PackageConfigCommand = cmd({
     })
   },
 })
-

--- a/packages/zee/src/cli/cmd/package.ts
+++ b/packages/zee/src/cli/cmd/package.ts
@@ -1,0 +1,192 @@
+import type { Argv } from "yargs"
+import { cmd } from "./cmd"
+import { bootstrap } from "../bootstrap"
+import { UI } from "../ui"
+import { Instance } from "@/project/instance"
+import {
+  formatManifestKinds,
+  inspectPackageConfig,
+  installSource,
+  listInstalled,
+  removePackage,
+  type PackageScope,
+  updatePackages,
+} from "@/package/manager"
+
+type ScopeInput = {
+  local?: boolean
+}
+
+async function withScope<T>(args: ScopeInput, fn: (scope: PackageScope, projectRoot?: string) => Promise<T>) {
+  return bootstrap(process.cwd(), async () => {
+    const scope: PackageScope = args.local ? "local" : "global"
+    const projectRoot = scope === "local" ? Instance.worktree : undefined
+    return fn(scope, projectRoot)
+  })
+}
+
+function scopeOption(yargs: Argv) {
+  return yargs.option("local", {
+    alias: "l",
+    type: "boolean",
+    default: false,
+    describe: "install in project-local .zee scope instead of global scope",
+  })
+}
+
+export const PackageCommand = cmd({
+  command: "package",
+  describe: "manage unified packages (plugins, skills, prompts, themes, extensions)",
+  builder: (yargs: Argv) =>
+    yargs
+      .command(PackageInstallCommand)
+      .command(PackageRemoveCommand)
+      .command(PackageUpdateCommand)
+      .command(PackageListCommand)
+      .command(PackageConfigCommand)
+      .demandCommand(),
+  async handler() {},
+})
+
+export const PackageInstallCommand = cmd({
+  command: "install <source>",
+  aliases: ["add", "i"],
+  describe: "install a package from npm/git and apply zee manifest resources",
+  builder: (yargs: Argv) =>
+    scopeOption(yargs).positional("source", {
+      describe: "package source (npm, git url, or other Bun-supported spec)",
+      type: "string",
+      demandOption: true,
+    }),
+  handler: async (args) => {
+    await withScope(args, async (scope, projectRoot) => {
+      const source = String(args.source)
+      UI.println(UI.Style.TEXT_DIM + `Installing ${source} (${scope})...` + UI.Style.TEXT_NORMAL)
+      const installed = await installSource({ source, scope, projectRoot })
+      if (!installed.length) {
+        UI.warn("No dependency changes detected")
+        return
+      }
+      for (const entry of installed) {
+        UI.success(`Installed ${entry.packageName}@${entry.version ?? "unknown"}`)
+        const summary = formatManifestKinds(entry.manifest)
+        if (Object.keys(summary).length) {
+          UI.println(UI.Style.TEXT_DIM + `  resources: ${JSON.stringify(summary)}` + UI.Style.TEXT_NORMAL)
+        } else {
+          UI.println(UI.Style.TEXT_DIM + "  resources: none declared in manifest" + UI.Style.TEXT_NORMAL)
+        }
+      }
+    })
+  },
+})
+
+export const PackageRemoveCommand = cmd({
+  command: "remove <identifier>",
+  aliases: ["rm", "uninstall"],
+  describe: "remove an installed package by source or package name",
+  builder: (yargs: Argv) =>
+    scopeOption(yargs).positional("identifier", {
+      describe: "package source or package name",
+      type: "string",
+      demandOption: true,
+    }),
+  handler: async (args) => {
+    await withScope(args, async (scope, projectRoot) => {
+      const identifier = String(args.identifier)
+      const removed = await removePackage({ identifier, scope, projectRoot })
+      if (!removed.length) {
+        UI.warn(`No package matched "${identifier}"`)
+        return
+      }
+      for (const entry of removed) {
+        UI.success(`Removed ${entry.packageName}`)
+      }
+    })
+  },
+})
+
+export const PackageUpdateCommand = cmd({
+  command: "update [identifier]",
+  aliases: ["upgrade"],
+  describe: "update installed packages (all or selected)",
+  builder: (yargs: Argv) =>
+    scopeOption(yargs).positional("identifier", {
+      describe: "optional package source or package name",
+      type: "string",
+      demandOption: false,
+    }),
+  handler: async (args) => {
+    await withScope(args, async (scope, projectRoot) => {
+      const identifier = args.identifier ? String(args.identifier) : undefined
+      const updated = await updatePackages({ identifier, scope, projectRoot })
+      if (!updated.length) {
+        UI.warn("No packages updated")
+        return
+      }
+      for (const entry of updated) {
+        UI.success(`Updated ${entry.packageName}@${entry.version ?? "unknown"}`)
+      }
+    })
+  },
+})
+
+export const PackageListCommand = cmd({
+  command: "list",
+  aliases: ["ls"],
+  describe: "list installed packages",
+  builder: (yargs: Argv) =>
+    scopeOption(
+      yargs.option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output JSON",
+      }),
+    ),
+  handler: async (args) => {
+    await withScope(args, async (scope, projectRoot) => {
+      const installed = await listInstalled({ scope, projectRoot })
+      if (args.json) {
+        console.log(JSON.stringify(installed, null, 2))
+        return
+      }
+      if (!installed.length) {
+        UI.println("No packages installed")
+        return
+      }
+      for (const entry of installed) {
+        const when = new Date(entry.installedAt).toISOString()
+        UI.println(`${entry.packageName} ${UI.Style.TEXT_DIM}(${entry.scope}, ${when})${UI.Style.TEXT_NORMAL}`)
+        UI.println(UI.Style.TEXT_DIM + `  source: ${entry.source}` + UI.Style.TEXT_NORMAL)
+      }
+    })
+  },
+})
+
+export const PackageConfigCommand = cmd({
+  command: "config",
+  describe: "show package runtime/configuration details",
+  builder: (yargs: Argv) =>
+    scopeOption(
+      yargs.option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output JSON",
+      }),
+    ),
+  handler: async (args) => {
+    await withScope(args, async (scope, projectRoot) => {
+      const details = await inspectPackageConfig({ scope, projectRoot })
+      if (args.json) {
+        console.log(JSON.stringify(details, null, 2))
+        return
+      }
+
+      UI.println(`Scope: ${details.scope}`)
+      UI.println(`Runtime root: ${details.runtimeRoot}`)
+      UI.println(`Resources root: ${details.resourcesRoot}`)
+      UI.println(`State file: ${details.stateFile}`)
+      UI.println(`Installed: ${details.installs.length}`)
+    })
+  },
+})
+

--- a/packages/zee/src/index.ts
+++ b/packages/zee/src/index.ts
@@ -32,6 +32,7 @@ import { DaemonOrchCommand } from "./cli/cmd/daemon-orch"
 import { DaemonInstallCommand, DaemonUninstallCommand, DaemonServiceStatusCommand } from "./cli/cmd/daemon-install"
 import { PluginCommand } from "./cli/cmd/plugin"
 import { SetupCommand } from "./cli/cmd/setup"
+import { PackageCommand } from "./cli/cmd/package"
 import { BugReportCommand } from "./cli/cmd/bug-report"
 import { CheckCommand } from "./cli/cmd/check"
 import { ProviderCommand } from "./cli/cmd/provider"
@@ -180,6 +181,7 @@ const cli = yargs(hideBin(process.argv))
   .command(PluginCommand)
   .command(ProviderCommand)
   .command(SetupCommand)
+  .command(PackageCommand)
   .command(BugReportCommand)
   .command(ClawHubCommand)
   .command(CompareCommand)

--- a/packages/zee/src/package/manager.ts
+++ b/packages/zee/src/package/manager.ts
@@ -1,0 +1,322 @@
+import path from "node:path"
+import fs from "node:fs/promises"
+import { BunProc } from "@/bun"
+import { Global } from "@/global"
+import { Log } from "@/util/log"
+import { Filesystem } from "@/util/filesystem"
+import { loadPackageMetadata, type ResourceKind, ResourceKindSchema, validateManifestPaths, type ZeeManifest } from "./manifest"
+
+const log = Log.create({ service: "package-manager" })
+
+export type PackageScope = "global" | "local"
+
+export type InstalledPackage = {
+  source: string
+  packageName: string
+  version?: string
+  scope: PackageScope
+  runtimeRoot: string
+  projectRoot?: string
+  installedAt: number
+  manifest: ZeeManifest
+  linkedPaths: string[]
+}
+
+type PackageState = {
+  installs: InstalledPackage[]
+}
+
+function stateFilepath() {
+  return path.join(Global.Path.state, "packages.json")
+}
+
+function runtimeRootForScope(scope: PackageScope, projectRoot?: string): string {
+  if (scope === "local") {
+    if (!projectRoot) throw new Error("local scope requires projectRoot")
+    return path.join(projectRoot, ".zee", "packages")
+  }
+  return path.join(Global.Path.data, "packages")
+}
+
+function resourcesRootForScope(scope: PackageScope, projectRoot?: string): string {
+  if (scope === "local") {
+    if (!projectRoot) throw new Error("local scope requires projectRoot")
+    return path.join(projectRoot, ".zee")
+  }
+  return Global.Path.config
+}
+
+function safeSegment(input: string): string {
+  return input.replace(/[^a-zA-Z0-9._-]/g, "_")
+}
+
+async function readState(): Promise<PackageState> {
+  const txt = await fs.readFile(stateFilepath(), "utf-8").catch(() => "")
+  if (!txt) return { installs: [] }
+  try {
+    const parsed = JSON.parse(txt) as PackageState
+    if (!Array.isArray(parsed.installs)) return { installs: [] }
+    return parsed
+  } catch {
+    return { installs: [] }
+  }
+}
+
+async function writeState(state: PackageState) {
+  const filepath = stateFilepath()
+  await fs.mkdir(path.dirname(filepath), { recursive: true })
+  await Bun.write(filepath, JSON.stringify(state, null, 2))
+}
+
+async function ensureRuntimeRoot(runtimeRoot: string) {
+  await fs.mkdir(runtimeRoot, { recursive: true })
+  const pkgJson = path.join(runtimeRoot, "package.json")
+  const exists = await Filesystem.exists(pkgJson)
+  if (!exists) {
+    await Bun.write(
+      pkgJson,
+      JSON.stringify(
+        {
+          name: "zee-package-runtime",
+          private: true,
+          type: "module",
+          dependencies: {},
+        },
+        null,
+        2,
+      ),
+    )
+  }
+}
+
+async function readDependencies(runtimeRoot: string): Promise<Record<string, string>> {
+  const pkgJson = path.join(runtimeRoot, "package.json")
+  const txt = await fs.readFile(pkgJson, "utf-8")
+  const parsed = JSON.parse(txt) as { dependencies?: Record<string, string> }
+  return parsed.dependencies ?? {}
+}
+
+function changedPackages(before: Record<string, string>, after: Record<string, string>): string[] {
+  const out = new Set<string>()
+  for (const [name, version] of Object.entries(after)) {
+    if (before[name] !== version) out.add(name)
+  }
+  return [...out]
+}
+
+async function linkResourcePaths(input: {
+  packageName: string
+  packageDir: string
+  manifest: ZeeManifest
+  scope: PackageScope
+  projectRoot?: string
+}) {
+  const resourcesRoot = resourcesRootForScope(input.scope, input.projectRoot)
+  const pkgSegment = safeSegment(input.packageName)
+  const linkedPaths: string[] = []
+
+  const ensureCleanDir = async (dir: string) => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    await fs.mkdir(dir, { recursive: true })
+  }
+
+  for (const kind of ResourceKindSchema.options) {
+    const entries = input.manifest[kind]
+    if (!entries.length) continue
+
+    const targetRoot = path.join(resourcesRoot, kind, pkgSegment)
+    await ensureCleanDir(targetRoot)
+
+    for (const rel of entries) {
+      const sourcePath = path.resolve(input.packageDir, rel)
+      const sourceExists = await Filesystem.exists(sourcePath)
+      if (!sourceExists) {
+        throw new Error(`Missing ${kind} path "${rel}" in package ${input.packageName}`)
+      }
+
+      const basename = path.basename(rel)
+      const targetPath = path.join(targetRoot, basename)
+      await fs.rm(targetPath, { recursive: true, force: true }).catch(() => {})
+      await fs.symlink(sourcePath, targetPath)
+      linkedPaths.push(targetPath)
+    }
+  }
+
+  return linkedPaths
+}
+
+function dedupeInstalls(installs: InstalledPackage[]): InstalledPackage[] {
+  const byKey = new Map<string, InstalledPackage>()
+  for (const item of installs) {
+    const key = `${item.scope}:${item.projectRoot ?? "-"}:${item.packageName}`
+    byKey.set(key, item)
+  }
+  return [...byKey.values()]
+}
+
+export async function installSource(input: {
+  source: string
+  scope: PackageScope
+  projectRoot?: string
+}): Promise<InstalledPackage[]> {
+  const runtimeRoot = runtimeRootForScope(input.scope, input.projectRoot)
+  await ensureRuntimeRoot(runtimeRoot)
+  const depsBefore = await readDependencies(runtimeRoot)
+
+  await BunProc.run(["add", "--force", "--exact", "--cwd", runtimeRoot, input.source], {
+    cwd: runtimeRoot,
+  })
+
+  const depsAfter = await readDependencies(runtimeRoot)
+  const changed = changedPackages(depsBefore, depsAfter)
+  if (!changed.length) {
+    return []
+  }
+
+  const state = await readState()
+  const now = Date.now()
+  const installed: InstalledPackage[] = []
+
+  for (const packageName of changed) {
+    const packageDir = path.join(runtimeRoot, "node_modules", packageName)
+    const meta = await loadPackageMetadata(packageDir)
+    const manifestErrors = validateManifestPaths(meta)
+    if (manifestErrors.length) {
+      throw new Error(`Invalid zee manifest in ${packageName}: ${manifestErrors.join("; ")}`)
+    }
+
+    const linkedPaths = await linkResourcePaths({
+      packageName,
+      packageDir,
+      manifest: meta.manifest,
+      scope: input.scope,
+      projectRoot: input.projectRoot,
+    })
+
+    installed.push({
+      source: input.source,
+      packageName,
+      version: depsAfter[packageName],
+      scope: input.scope,
+      runtimeRoot,
+      projectRoot: input.projectRoot,
+      installedAt: now,
+      manifest: meta.manifest,
+      linkedPaths,
+    })
+  }
+
+  const filtered = state.installs.filter((entry) => {
+    return !installed.some((next) => {
+      return (
+        next.scope === entry.scope &&
+        next.packageName === entry.packageName &&
+        (next.projectRoot ?? "") === (entry.projectRoot ?? "")
+      )
+    })
+  })
+
+  state.installs = dedupeInstalls([...filtered, ...installed])
+  await writeState(state)
+  return installed
+}
+
+export async function removePackage(input: {
+  identifier: string
+  scope?: PackageScope
+  projectRoot?: string
+}): Promise<InstalledPackage[]> {
+  const state = await readState()
+  const matches = state.installs.filter((entry) => {
+    if (input.scope && entry.scope !== input.scope) return false
+    if (entry.packageName !== input.identifier && entry.source !== input.identifier) return false
+    if (entry.scope === "local") {
+      return (entry.projectRoot ?? "") === (input.projectRoot ?? "")
+    }
+    return true
+  })
+
+  for (const entry of matches) {
+    await BunProc.run(["remove", "--cwd", entry.runtimeRoot, entry.packageName], {
+      cwd: entry.runtimeRoot,
+    }).catch(() => {})
+    for (const linkedPath of entry.linkedPaths) {
+      await fs.rm(linkedPath, { recursive: true, force: true }).catch(() => {})
+    }
+    const resourcesRoot = resourcesRootForScope(entry.scope, entry.projectRoot)
+    for (const kind of ResourceKindSchema.options) {
+      const dir = path.join(resourcesRoot, kind, safeSegment(entry.packageName))
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
+  }
+
+  state.installs = state.installs.filter((entry) => !matches.includes(entry))
+  await writeState(state)
+  return matches
+}
+
+export async function listInstalled(input?: { scope?: PackageScope; projectRoot?: string }): Promise<InstalledPackage[]> {
+  const state = await readState()
+  return state.installs
+    .filter((entry) => {
+      if (input?.scope && entry.scope !== input.scope) return false
+      if (entry.scope === "local" && input?.projectRoot) {
+        return (entry.projectRoot ?? "") === input.projectRoot
+      }
+      return true
+    })
+    .sort((a, b) => b.installedAt - a.installedAt)
+}
+
+export async function updatePackages(input?: {
+  identifier?: string
+  scope?: PackageScope
+  projectRoot?: string
+}) {
+  const installs = await listInstalled({
+    scope: input?.scope,
+    projectRoot: input?.projectRoot,
+  })
+  const targets = input?.identifier
+    ? installs.filter((entry) => entry.packageName === input.identifier || entry.source === input.identifier)
+    : installs
+
+  const updated: InstalledPackage[] = []
+  const seen = new Set<string>()
+  for (const item of targets) {
+    const key = `${item.scope}:${item.projectRoot ?? "-"}:${item.source}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    const result = await installSource({
+      source: item.source,
+      scope: item.scope,
+      projectRoot: item.projectRoot,
+    })
+    updated.push(...result)
+  }
+  return updated
+}
+
+export async function inspectPackageConfig(input?: { scope?: PackageScope; projectRoot?: string }) {
+  const scope = input?.scope ?? "global"
+  const runtimeRoot = runtimeRootForScope(scope, input?.projectRoot)
+  const resourcesRoot = resourcesRootForScope(scope, input?.projectRoot)
+  const installs = await listInstalled({ scope, projectRoot: input?.projectRoot })
+  return {
+    scope,
+    runtimeRoot,
+    resourcesRoot,
+    stateFile: stateFilepath(),
+    installs,
+  }
+}
+
+export function formatManifestKinds(manifest: ZeeManifest) {
+  const out: Partial<Record<ResourceKind, number>> = {}
+  for (const kind of ResourceKindSchema.options) {
+    if (manifest[kind].length) out[kind] = manifest[kind].length
+  }
+  return out
+}
+
+log.info("package manager loaded")

--- a/packages/zee/src/package/manager.ts
+++ b/packages/zee/src/package/manager.ts
@@ -115,17 +115,13 @@ async function linkResourcePaths(input: {
   const pkgSegment = safeSegment(input.packageName)
   const linkedPaths: string[] = []
 
-  const ensureCleanDir = async (dir: string) => {
-    await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
-    await fs.mkdir(dir, { recursive: true })
-  }
-
   for (const kind of ResourceKindSchema.options) {
     const entries = input.manifest[kind]
-    if (!entries.length) continue
 
     const targetRoot = path.join(resourcesRoot, kind, pkgSegment)
-    await ensureCleanDir(targetRoot)
+    await fs.rm(targetRoot, { recursive: true, force: true }).catch(() => {})
+    if (!entries.length) continue
+    await fs.mkdir(targetRoot, { recursive: true })
 
     for (const rel of entries) {
       const sourcePath = path.resolve(input.packageDir, rel)

--- a/packages/zee/src/package/manifest.ts
+++ b/packages/zee/src/package/manifest.ts
@@ -1,0 +1,65 @@
+import path from "node:path"
+import fs from "node:fs/promises"
+import z from "zod"
+
+export const ResourceKindSchema = z.enum(["plugins", "skills", "prompts", "themes", "extensions"])
+export type ResourceKind = z.infer<typeof ResourceKindSchema>
+
+export const ZeeManifestSchema = z
+  .object({
+    plugins: z.array(z.string()).default([]),
+    skills: z.array(z.string()).default([]),
+    prompts: z.array(z.string()).default([]),
+    themes: z.array(z.string()).default([]),
+    extensions: z.array(z.string()).default([]),
+  })
+  .default({
+    plugins: [],
+    skills: [],
+    prompts: [],
+    themes: [],
+    extensions: [],
+  })
+
+export type ZeeManifest = z.infer<typeof ZeeManifestSchema>
+
+export const PackageJsonSchema = z.object({
+  name: z.string(),
+  version: z.string().optional(),
+  zee: ZeeManifestSchema.optional(),
+})
+
+export type PackageMetadata = {
+  name: string
+  version?: string
+  manifest: ZeeManifest
+  packageDir: string
+}
+
+export async function loadPackageMetadata(packageDir: string): Promise<PackageMetadata> {
+  const pkgPath = path.join(packageDir, "package.json")
+  const pkgText = await fs.readFile(pkgPath, "utf-8")
+  const raw = JSON.parse(pkgText)
+  const parsed = PackageJsonSchema.parse(raw)
+  return {
+    name: parsed.name,
+    version: parsed.version,
+    manifest: parsed.zee ?? ZeeManifestSchema.parse({}),
+    packageDir,
+  }
+}
+
+export function validateManifestPaths(meta: PackageMetadata): string[] {
+  const errors: string[] = []
+  for (const kind of ResourceKindSchema.options) {
+    for (const rel of meta.manifest[kind]) {
+      const resolved = path.resolve(meta.packageDir, rel)
+      const normalized = path.normalize(resolved)
+      if (!normalized.startsWith(path.normalize(meta.packageDir + path.sep))) {
+        errors.push(`${kind}: path escapes package root: ${rel}`)
+      }
+    }
+  }
+  return errors
+}
+

--- a/packages/zee/test/package/manager.test.ts
+++ b/packages/zee/test/package/manager.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import { formatManifestKinds, inspectPackageConfig, listInstalled } from "../../src/package/manager"
+
+describe("package manager", () => {
+  test("formatManifestKinds only includes non-empty resources", () => {
+    const summary = formatManifestKinds({
+      plugins: [],
+      skills: ["skills"],
+      prompts: [],
+      themes: ["themes/a", "themes/b"],
+      extensions: [],
+    })
+    expect(summary).toEqual({
+      skills: 1,
+      themes: 2,
+    })
+  })
+
+  test("inspectPackageConfig returns empty installs initially", async () => {
+    await using tmp = await tmpdir()
+    const prev = process.env.ZEE_TEST_HOME
+    process.env.ZEE_TEST_HOME = tmp.path
+    try {
+      const cfg = await inspectPackageConfig({ scope: "global" })
+      const installs = await listInstalled({ scope: "global" })
+      expect(cfg.scope).toBe("global")
+      expect(Array.isArray(cfg.installs)).toBe(true)
+      expect(installs).toEqual([])
+    } finally {
+      process.env.ZEE_TEST_HOME = prev
+    }
+  })
+})
+

--- a/packages/zee/test/package/manifest.test.ts
+++ b/packages/zee/test/package/manifest.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import fs from "node:fs/promises"
+import { tmpdir } from "../fixture/fixture"
+import { loadPackageMetadata, validateManifestPaths } from "../../src/package/manifest"
+
+describe("package manifest", () => {
+  test("loads manifest from package.json", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "package.json"), JSON.stringify({ name: "@acme/pkg", zee: { skills: ["skills"] } }))
+        await fs.mkdir(path.join(dir, "skills"), { recursive: true })
+        await Bun.write(path.join(dir, "skills", "SKILL.md"), "# test")
+      },
+    })
+
+    const meta = await loadPackageMetadata(tmp.path)
+    expect(meta.name).toBe("@acme/pkg")
+    expect(meta.manifest.skills).toEqual(["skills"])
+    expect(meta.manifest.plugins).toEqual([])
+  })
+
+  test("rejects resource paths escaping package root", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "package.json"), JSON.stringify({ name: "@acme/pkg", zee: { skills: ["../oops"] } }))
+      },
+    })
+
+    const meta = await loadPackageMetadata(tmp.path)
+    const errors = validateManifestPaths(meta)
+    expect(errors.length).toBe(1)
+    expect(errors[0]).toContain("escapes package root")
+  })
+})


### PR DESCRIPTION
## Summary
- add `zee package` command group (`install/remove/update/list/config`)
- add package manifest schema + validation for `plugins/skills/prompts/themes/extensions`
- add runtime package manager that installs package sources, links manifest resources, and persists install state
- wire the command into the CLI entrypoint
- add package manifest/manager tests

Closes #302

## Validation
- `cd packages/zee && bun test test/package/manifest.test.ts test/package/manager.test.ts`
