### PR TITLE
Fix #332: default standalone server bind to loopback

### DIFF
--- a/packages/zee/Swabble/src/canvas-host/server.test.ts
+++ b/packages/zee/Swabble/src/canvas-host/server.test.ts
@@ -49,6 +49,34 @@ describe("canvas host", () => {
     }
   });
 
+  it("defaults standalone bind host to loopback", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-canvas-"));
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((_code: number) => {
+        throw new Error("unexpected exit");
+      }),
+    };
+
+    const server = await startCanvasHost({
+      runtime: runtime as never,
+      auth: TEST_AUTH,
+      rootDir: dir,
+      port: 0,
+      allowInTests: true,
+    });
+
+    try {
+      const res = await fetch(withAuth(`http://127.0.0.1:${server.port}${CANVAS_HOST_PATH}/`));
+      expect(res.status).toBe(200);
+      expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("http://127.0.0.1:"));
+    } finally {
+      await server.close();
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("creates a default index.html when missing", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-canvas-"));
 

--- a/packages/zee/Swabble/src/canvas-host/server.ts
+++ b/packages/zee/Swabble/src/canvas-host/server.ts
@@ -473,7 +473,7 @@ export async function startCanvasHost(opts: CanvasHostServerOpts): Promise<Canva
     }));
 
   const ownsHandler = opts.ownsHandler ?? opts.handler === undefined;
-  const bindHost = opts.listenHost?.trim() || "0.0.0.0";
+  const bindHost = opts.listenHost?.trim() || "127.0.0.1";
 
   const server = http.createServer((req, res) => {
     if (String(req.headers.upgrade ?? "").toLowerCase() === "websocket") return;


### PR DESCRIPTION
Closes #332

Upstream parity: openclaw/openclaw#13184

## What changed
- Changed canvas host standalone default bind host from `0.0.0.0` to `127.0.0.1`.
- Added regression test asserting loopback default behavior and runtime log URL.

## Validation
- ✅ `vitest run src/canvas-host/server.test.ts` (10/10 passing)
- ⚠️ `bun run build` in `packages/zee` fails in this environment due unresolved local dependency `@clawhub/registry@file:../../../claw-registry`.

## Scope
In scope:
- Standalone host bind default safety hardening.

Out of scope:
- External/messaging channel behavior changes.
