### PR TITLE
feat: add zee pods command suite

### DIFF
--- a/packages/zee/src/cli/cmd/pods.ts
+++ b/packages/zee/src/cli/cmd/pods.ts
@@ -143,7 +143,8 @@ export const PodsShellCommand = cmd({
       demandOption: false,
     }),
   handler: async (args) => {
-    await openPodShell(args.name ? String(args.name) : undefined)
+    const code = await openPodShell(args.name ? String(args.name) : undefined)
+    if (code !== 0) process.exit(code)
   },
 })
 
@@ -269,11 +270,12 @@ export const PodsLogsCommand = cmd({
         default: 200,
       }),
   handler: async (args) => {
-    await streamModelLogs({
+    const code = await streamModelLogs({
       name: String(args.name),
       follow: !!args.follow,
       lines: Number(args.lines),
     })
+    if (code !== 0) process.exit(code)
   },
 })
 
@@ -297,4 +299,3 @@ export const PodsConfigCommand = cmd({
     UI.println(`Tracked models: ${cfg.models.length}`)
   },
 })
-

--- a/packages/zee/src/cli/cmd/pods.ts
+++ b/packages/zee/src/cli/cmd/pods.ts
@@ -1,0 +1,300 @@
+import type { Argv } from "yargs"
+import { cmd } from "./cmd"
+import { UI } from "../ui"
+import {
+  inspectPodsConfig,
+  listModels,
+  listPods,
+  openPodShell,
+  removePod,
+  runPodSsh,
+  setActivePod,
+  setupPod,
+  startModel,
+  stopModel,
+  streamModelLogs,
+  type VllmProfile,
+} from "@/pods/manager"
+
+export const PodsCommand = cmd({
+  command: "pods",
+  describe: "manage remote GPU pods and vLLM model processes",
+  builder: (yargs: Argv) =>
+    yargs
+      .command(PodsSetupCommand)
+      .command(PodsListCommand)
+      .command(PodsActiveCommand)
+      .command(PodsRemoveCommand)
+      .command(PodsShellCommand)
+      .command(PodsSshCommand)
+      .command(PodsStartModelCommand)
+      .command(PodsStopModelCommand)
+      .command(PodsModelsCommand)
+      .command(PodsLogsCommand)
+      .command(PodsConfigCommand)
+      .demandCommand(),
+  async handler() {},
+})
+
+const profileChoices: VllmProfile[] = ["release", "nightly", "gpt-oss", "custom"]
+
+export const PodsSetupCommand = cmd({
+  command: "setup <name> <ssh>",
+  describe: "register or update a pod definition",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("name", { type: "string", demandOption: true })
+      .positional("ssh", { type: "string", demandOption: true, describe: "ssh command, e.g. 'ssh root@1.2.3.4'" })
+      .option("mount", { type: "string", describe: "optional remote mount command metadata" })
+      .option("models-path", { type: "string", describe: "optional remote models path metadata" })
+      .option("profile", {
+        type: "string",
+        choices: profileChoices,
+        default: "release",
+        describe: "vLLM profile metadata",
+      })
+      .option("no-active", {
+        type: "boolean",
+        default: false,
+        describe: "do not make this pod active",
+      }),
+  handler: async (args) => {
+    const pod = await setupPod({
+      name: String(args.name),
+      ssh: String(args.ssh),
+      mount: args.mount ? String(args.mount) : undefined,
+      modelsPath: args.modelsPath ? String(args.modelsPath) : undefined,
+      profile: args.profile as VllmProfile,
+      setActive: !args.noActive,
+    })
+    UI.success(`Pod saved: ${pod.name}`)
+  },
+})
+
+export const PodsListCommand = cmd({
+  command: "list",
+  aliases: ["ls"],
+  describe: "list configured pods",
+  builder: (yargs: Argv) =>
+    yargs.option("json", {
+      type: "boolean",
+      default: false,
+    }),
+  handler: async (args) => {
+    const pods = await listPods()
+    if (args.json) {
+      console.log(JSON.stringify(pods, null, 2))
+      return
+    }
+
+    if (!pods.pods.length) {
+      UI.println("No pods configured")
+      return
+    }
+
+    for (const pod of pods.pods) {
+      const active = pod.name === pods.activePod ? `${UI.Style.TEXT_SUCCESS}*${UI.Style.TEXT_NORMAL} ` : "  "
+      UI.println(`${active}${pod.name} (${pod.profile})`)
+      UI.println(UI.Style.TEXT_DIM + `    ${pod.ssh}` + UI.Style.TEXT_NORMAL)
+      if (pod.modelsPath) UI.println(UI.Style.TEXT_DIM + `    models: ${pod.modelsPath}` + UI.Style.TEXT_NORMAL)
+    }
+  },
+})
+
+export const PodsActiveCommand = cmd({
+  command: "active <name>",
+  describe: "set active pod",
+  builder: (yargs: Argv) =>
+    yargs.positional("name", {
+      type: "string",
+      demandOption: true,
+    }),
+  handler: async (args) => {
+    const pod = await setActivePod(String(args.name))
+    UI.success(`Active pod: ${pod.name}`)
+  },
+})
+
+export const PodsRemoveCommand = cmd({
+  command: "remove <name>",
+  aliases: ["rm"],
+  describe: "remove pod definition",
+  builder: (yargs: Argv) =>
+    yargs.positional("name", {
+      type: "string",
+      demandOption: true,
+    }),
+  handler: async (args) => {
+    const removed = await removePod(String(args.name))
+    if (!removed) {
+      UI.warn(`Pod not found: ${String(args.name)}`)
+      return
+    }
+    UI.success(`Removed pod: ${removed.name}`)
+  },
+})
+
+export const PodsShellCommand = cmd({
+  command: "shell [name]",
+  describe: "open interactive shell on pod",
+  builder: (yargs: Argv) =>
+    yargs.positional("name", {
+      type: "string",
+      demandOption: false,
+    }),
+  handler: async (args) => {
+    await openPodShell(args.name ? String(args.name) : undefined)
+  },
+})
+
+export const PodsSshCommand = cmd({
+  command: "ssh [name] [command..]",
+  describe: "run a remote command on a pod",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("name", {
+        type: "string",
+        demandOption: false,
+      })
+      .positional("command", {
+        type: "string",
+        array: true,
+        demandOption: true,
+      }),
+  handler: async (args) => {
+    const command = [...(Array.isArray(args.command) ? args.command : []), ...(args["--"] || [])].join(" ").trim()
+    if (!command) {
+      UI.error("command is required")
+      process.exit(2)
+    }
+    const result = await runPodSsh({
+      name: args.name ? String(args.name) : undefined,
+      command,
+    })
+    if (result.stdout) process.stdout.write(result.stdout + "\n")
+    if (result.stderr) process.stderr.write(result.stderr + "\n")
+    if (result.code !== 0) process.exit(result.code)
+  },
+})
+
+export const PodsStartModelCommand = cmd({
+  command: "start <model>",
+  describe: "start a vLLM model process on a pod",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("model", { type: "string", demandOption: true })
+      .option("name", { type: "string", demandOption: true, describe: "logical process name" })
+      .option("pod", { type: "string", describe: "target pod name (defaults to active pod)" })
+      .option("port", { type: "number", default: 8000, describe: "vLLM port" })
+      .option("log-file", { type: "string", describe: "remote log file path" })
+      .option("vllm-arg", {
+        type: "string",
+        array: true,
+        default: [],
+        describe: "extra argument passed to vllm serve (repeatable)",
+      }),
+  handler: async (args) => {
+    const started = await startModel({
+      model: String(args.model),
+      name: String(args.name),
+      pod: args.pod ? String(args.pod) : undefined,
+      port: Number(args.port),
+      logFile: args.logFile ? String(args.logFile) : undefined,
+      extraArgs: (args.vllmArg as string[] | undefined) ?? [],
+    })
+    UI.success(`Started ${started.name} on ${started.pod}:${started.port}`)
+    if (started.pid) UI.println(UI.Style.TEXT_DIM + `pid: ${started.pid}` + UI.Style.TEXT_NORMAL)
+    UI.println(UI.Style.TEXT_DIM + `log: ${started.logFile}` + UI.Style.TEXT_NORMAL)
+  },
+})
+
+export const PodsStopModelCommand = cmd({
+  command: "stop <name>",
+  describe: "stop a tracked model process",
+  builder: (yargs: Argv) =>
+    yargs.positional("name", {
+      type: "string",
+      demandOption: true,
+    }),
+  handler: async (args) => {
+    const stopped = await stopModel(String(args.name))
+    if (!stopped) {
+      UI.warn(`Model process not found: ${String(args.name)}`)
+      return
+    }
+    UI.success(`Stopped model process: ${stopped.name}`)
+  },
+})
+
+export const PodsModelsCommand = cmd({
+  command: "models",
+  describe: "list tracked model processes",
+  builder: (yargs: Argv) =>
+    yargs.option("json", {
+      type: "boolean",
+      default: false,
+    }),
+  handler: async (args) => {
+    const models = await listModels()
+    if (args.json) {
+      console.log(JSON.stringify(models, null, 2))
+      return
+    }
+    if (!models.length) {
+      UI.println("No model processes tracked")
+      return
+    }
+    for (const model of models) {
+      UI.println(`${model.name} (${model.status})`)
+      UI.println(UI.Style.TEXT_DIM + `  pod=${model.pod} port=${model.port} model=${model.model}` + UI.Style.TEXT_NORMAL)
+    }
+  },
+})
+
+export const PodsLogsCommand = cmd({
+  command: "logs <name>",
+  describe: "stream logs for a tracked model process",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("name", {
+        type: "string",
+        demandOption: true,
+      })
+      .option("follow", {
+        type: "boolean",
+        default: true,
+      })
+      .option("lines", {
+        type: "number",
+        default: 200,
+      }),
+  handler: async (args) => {
+    await streamModelLogs({
+      name: String(args.name),
+      follow: !!args.follow,
+      lines: Number(args.lines),
+    })
+  },
+})
+
+export const PodsConfigCommand = cmd({
+  command: "config",
+  describe: "inspect pods state/config paths",
+  builder: (yargs: Argv) =>
+    yargs.option("json", {
+      type: "boolean",
+      default: false,
+    }),
+  handler: async (args) => {
+    const cfg = await inspectPodsConfig()
+    if (args.json) {
+      console.log(JSON.stringify(cfg, null, 2))
+      return
+    }
+    UI.println(`State file: ${cfg.stateFile}`)
+    UI.println(`Active pod: ${cfg.activePod ?? "(none)"}`)
+    UI.println(`Pods: ${cfg.pods.length}`)
+    UI.println(`Tracked models: ${cfg.models.length}`)
+  },
+})
+

--- a/packages/zee/src/index.ts
+++ b/packages/zee/src/index.ts
@@ -32,6 +32,7 @@ import { DaemonOrchCommand } from "./cli/cmd/daemon-orch"
 import { DaemonInstallCommand, DaemonUninstallCommand, DaemonServiceStatusCommand } from "./cli/cmd/daemon-install"
 import { PluginCommand } from "./cli/cmd/plugin"
 import { SetupCommand } from "./cli/cmd/setup"
+import { PodsCommand } from "./cli/cmd/pods"
 import { BugReportCommand } from "./cli/cmd/bug-report"
 import { CheckCommand } from "./cli/cmd/check"
 import { ProviderCommand } from "./cli/cmd/provider"
@@ -180,6 +181,7 @@ const cli = yargs(hideBin(process.argv))
   .command(PluginCommand)
   .command(ProviderCommand)
   .command(SetupCommand)
+  .command(PodsCommand)
   .command(BugReportCommand)
   .command(ClawHubCommand)
   .command(CompareCommand)

--- a/packages/zee/src/pods/manager.ts
+++ b/packages/zee/src/pods/manager.ts
@@ -1,0 +1,310 @@
+import path from "node:path"
+import fs from "node:fs/promises"
+import { Global } from "@/global"
+import { Filesystem } from "@/util/filesystem"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "pods-manager" })
+
+export type VllmProfile = "release" | "nightly" | "gpt-oss" | "custom"
+
+export type PodDefinition = {
+  name: string
+  ssh: string
+  mount?: string
+  modelsPath?: string
+  profile: VllmProfile
+  createdAt: number
+  updatedAt: number
+}
+
+export type ModelProcess = {
+  name: string
+  pod: string
+  model: string
+  port: number
+  pid?: number
+  logFile: string
+  extraArgs: string[]
+  startedAt: number
+}
+
+type PodsState = {
+  activePod?: string
+  pods: Record<string, PodDefinition>
+  models: Record<string, ModelProcess>
+}
+
+function stateFilepath() {
+  return path.join(Global.Path.state, "pods.json")
+}
+
+async function readState(): Promise<PodsState> {
+  const txt = await fs.readFile(stateFilepath(), "utf-8").catch(() => "")
+  if (!txt) {
+    return { pods: {}, models: {} }
+  }
+  try {
+    const parsed = JSON.parse(txt) as PodsState
+    return {
+      activePod: parsed.activePod,
+      pods: parsed.pods ?? {},
+      models: parsed.models ?? {},
+    }
+  } catch {
+    return { pods: {}, models: {} }
+  }
+}
+
+async function writeState(state: PodsState) {
+  const filepath = stateFilepath()
+  await fs.mkdir(path.dirname(filepath), { recursive: true })
+  await Bun.write(filepath, JSON.stringify(state, null, 2))
+}
+
+function singleQuote(input: string): string {
+  return `'${input.replace(/'/g, `'\"'\"'`)}'`
+}
+
+function commandForPod(pod: PodDefinition, remoteCommand?: string): string {
+  if (!remoteCommand) return pod.ssh
+  return `${pod.ssh} ${singleQuote(remoteCommand)}`
+}
+
+async function runCommand(cmd: string): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bash", "-lc", cmd], {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  })
+  const [stdoutText, stderrText, code] = await Promise.all([
+    proc.stdout ? new Response(proc.stdout).text() : Promise.resolve(""),
+    proc.stderr ? new Response(proc.stderr).text() : Promise.resolve(""),
+    proc.exited,
+  ])
+  return {
+    code,
+    stdout: stdoutText.trim(),
+    stderr: stderrText.trim(),
+  }
+}
+
+async function runInteractive(cmd: string): Promise<number> {
+  const proc = Bun.spawn(["bash", "-lc", cmd], {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  })
+  return proc.exited
+}
+
+function requirePod(state: PodsState, name?: string): PodDefinition {
+  const resolvedName = name ?? state.activePod
+  if (!resolvedName) {
+    throw new Error("No pod selected. Set an active pod with `zee pods active <name>`.")
+  }
+  const pod = state.pods[resolvedName]
+  if (!pod) {
+    throw new Error(`Pod not found: ${resolvedName}`)
+  }
+  return pod
+}
+
+export async function setupPod(input: {
+  name: string
+  ssh: string
+  mount?: string
+  modelsPath?: string
+  profile?: VllmProfile
+  setActive?: boolean
+}) {
+  const state = await readState()
+  const now = Date.now()
+  const existing = state.pods[input.name]
+  state.pods[input.name] = {
+    name: input.name,
+    ssh: input.ssh,
+    mount: input.mount,
+    modelsPath: input.modelsPath,
+    profile: input.profile ?? "release",
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  }
+  if (input.setActive !== false || !state.activePod) {
+    state.activePod = input.name
+  }
+  await writeState(state)
+  return state.pods[input.name]
+}
+
+export async function listPods() {
+  const state = await readState()
+  return {
+    activePod: state.activePod,
+    pods: Object.values(state.pods).sort((a, b) => a.name.localeCompare(b.name)),
+  }
+}
+
+export async function setActivePod(name: string) {
+  const state = await readState()
+  if (!state.pods[name]) throw new Error(`Pod not found: ${name}`)
+  state.activePod = name
+  await writeState(state)
+  return state.pods[name]
+}
+
+export async function removePod(name: string) {
+  const state = await readState()
+  const existing = state.pods[name]
+  if (!existing) return undefined
+  delete state.pods[name]
+  if (state.activePod === name) {
+    state.activePod = Object.keys(state.pods)[0]
+  }
+
+  // Remove model entries bound to the pod as they are stale after removal.
+  for (const [modelName, model] of Object.entries(state.models)) {
+    if (model.pod === name) delete state.models[modelName]
+  }
+
+  await writeState(state)
+  return existing
+}
+
+export async function openPodShell(name?: string) {
+  const state = await readState()
+  const pod = requirePod(state, name)
+  return runInteractive(commandForPod(pod))
+}
+
+export async function runPodSsh(input: { name?: string; command: string }) {
+  const state = await readState()
+  const pod = requirePod(state, input.name)
+  return runCommand(commandForPod(pod, input.command))
+}
+
+export async function startModel(input: {
+  model: string
+  name: string
+  pod?: string
+  port?: number
+  logFile?: string
+  extraArgs?: string[]
+}) {
+  const state = await readState()
+  const pod = requirePod(state, input.pod)
+  const port = input.port ?? 8000
+  const logFile = input.logFile ?? `~/zee-vllm-${input.name}.log`
+  const extraArgs = input.extraArgs ?? []
+  const extraArgsText = extraArgs.map((arg) => singleQuote(arg)).join(" ")
+
+  const remote = [
+    "nohup",
+    "vllm",
+    "serve",
+    singleQuote(input.model),
+    "--host",
+    singleQuote("0.0.0.0"),
+    "--port",
+    String(port),
+    extraArgsText,
+    ">",
+    singleQuote(logFile),
+    "2>&1",
+    "&",
+    "echo $!",
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  const result = await runCommand(commandForPod(pod, remote))
+  if (result.code !== 0) {
+    throw new Error(result.stderr || "Failed to start model process")
+  }
+
+  const pid = Number.parseInt(result.stdout, 10)
+  const record: ModelProcess = {
+    name: input.name,
+    pod: pod.name,
+    model: input.model,
+    port,
+    pid: Number.isFinite(pid) ? pid : undefined,
+    logFile,
+    extraArgs,
+    startedAt: Date.now(),
+  }
+  state.models[input.name] = record
+  await writeState(state)
+  return record
+}
+
+export async function stopModel(name: string) {
+  const state = await readState()
+  const model = state.models[name]
+  if (!model) return undefined
+  const pod = requirePod(state, model.pod)
+
+  const remote = model.pid
+    ? `kill ${model.pid}`
+    : `pkill -f ${singleQuote(`vllm serve ${model.model}`)}`
+
+  const result = await runCommand(commandForPod(pod, remote))
+  if (result.code !== 0 && !/No such process/i.test(result.stderr)) {
+    throw new Error(result.stderr || "Failed to stop model process")
+  }
+
+  delete state.models[name]
+  await writeState(state)
+  return model
+}
+
+export async function listModels() {
+  const state = await readState()
+  const models = Object.values(state.models).sort((a, b) => a.name.localeCompare(b.name))
+  const withStatus = await Promise.all(
+    models.map(async (model) => {
+      let status: "running" | "stopped" | "unknown" = "unknown"
+      if (model.pid) {
+        try {
+          const probe = await runPodSsh({
+            name: model.pod,
+            command: `kill -0 ${model.pid} >/dev/null 2>&1 && echo running || echo stopped`,
+          })
+          if (probe.stdout.includes("running")) status = "running"
+          else if (probe.stdout.includes("stopped")) status = "stopped"
+        } catch {
+          status = "unknown"
+        }
+      }
+      return { ...model, status }
+    }),
+  )
+  return withStatus
+}
+
+export async function streamModelLogs(input: { name: string; follow?: boolean; lines?: number }) {
+  const state = await readState()
+  const model = state.models[input.name]
+  if (!model) throw new Error(`Model process not found: ${input.name}`)
+  const pod = requirePod(state, model.pod)
+  const lines = Math.max(1, input.lines ?? 200)
+  const follow = input.follow !== false
+  const tailCmd = `tail -n ${lines} ${follow ? "-f " : ""}${singleQuote(model.logFile)}`
+  return runInteractive(commandForPod(pod, tailCmd))
+}
+
+export async function inspectPodsConfig() {
+  const state = await readState()
+  return {
+    stateFile: stateFilepath(),
+    activePod: state.activePod,
+    pods: Object.values(state.pods),
+    models: Object.values(state.models),
+  }
+}
+
+export async function stateFileExists() {
+  return Filesystem.exists(stateFilepath())
+}
+
+log.info("pods manager loaded")

--- a/packages/zee/src/pods/manager.ts
+++ b/packages/zee/src/pods/manager.ts
@@ -194,7 +194,7 @@ export async function startModel(input: {
   const state = await readState()
   const pod = requirePod(state, input.pod)
   const port = input.port ?? 8000
-  const logFile = input.logFile ?? `~/zee-vllm-${input.name}.log`
+  const logFile = input.logFile ?? `/tmp/zee-vllm-${input.name}.log`
   const extraArgs = input.extraArgs ?? []
   const extraArgsText = extraArgs.map((arg) => singleQuote(arg)).join(" ")
 

--- a/packages/zee/test/pods/manager.test.ts
+++ b/packages/zee/test/pods/manager.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import { listPods, removePod, setActivePod, setupPod } from "../../src/pods/manager"
+
+describe("pods manager", () => {
+  test("setup, set-active, and remove lifecycle works", async () => {
+    await using tmp = await tmpdir()
+    const prev = process.env.ZEE_TEST_HOME
+    process.env.ZEE_TEST_HOME = tmp.path
+    try {
+      await setupPod({ name: "dc1", ssh: "ssh root@1.2.3.4" })
+      let listed = await listPods()
+      expect(listed.activePod).toBe("dc1")
+      expect(listed.pods.length).toBe(1)
+
+      await setupPod({ name: "a", ssh: "ssh root@a" })
+      await setupPod({ name: "b", ssh: "ssh root@b", setActive: false })
+
+      await setActivePod("b")
+      listed = await listPods()
+      expect(listed.activePod).toBe("b")
+
+      const removed = await removePod("b")
+      expect(removed?.name).toBe("b")
+
+      listed = await listPods()
+      expect(listed.activePod).toBe("dc1")
+      expect(listed.pods.map((p) => p.name)).toEqual(["a", "dc1"])
+    } finally {
+      process.env.ZEE_TEST_HOME = prev
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add `zee pods` command group for remote GPU pod management
- implement pod registry/state manager (setup/list/active/remove)
- add remote model process lifecycle support (`start/stop/models/logs`) and SSH helpers (`shell/ssh`)
- wire the command into the CLI entrypoint
- add pods manager lifecycle tests

Closes #297

## Validation
- `cd packages/zee && bun test test/pods/manager.test.ts`
