### PR TITLE
fix(opencode-sync): runtime internals parity for #315

### DIFF
--- a/packages/zee/Swabble/src/entry.ts
+++ b/packages/zee/Swabble/src/entry.ts
@@ -7,9 +7,11 @@ import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import { isTruthyEnvValue } from "./infra/env.js";
 import { installProcessWarningFilter } from "./infra/warnings.js";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
+import { installParentProcessGuard, PARENT_PID_ENV } from "./process/parent-guard.js";
 
 process.title = "zee";
 installProcessWarningFilter();
+installParentProcessGuard();
 
 if (process.argv.includes("--no-color")) {
   process.env.NO_COLOR = "1";
@@ -46,7 +48,10 @@ function ensureExperimentalWarningSuppressed(): boolean {
 
   const child = spawn(process.execPath, [...process.execArgv, ...process.argv.slice(1)], {
     stdio: "inherit",
-    env: process.env,
+    env: {
+      ...process.env,
+      [PARENT_PID_ENV]: String(process.pid),
+    },
   });
 
   attachChildProcessBridge(child);

--- a/packages/zee/Swabble/src/process/command-queue.test.ts
+++ b/packages/zee/Swabble/src/process/command-queue.test.ts
@@ -16,7 +16,7 @@ vi.mock("../logging/diagnostic.js", () => ({
   diagnosticLogger: diagnosticMocks.diag,
 }));
 
-import { enqueueCommand, getQueueSize } from "./command-queue.js";
+import { clearCommandLane, enqueueCommand, enqueueCommandInLane, getQueueSize } from "./command-queue.js";
 
 describe("command queue", () => {
   beforeEach(() => {
@@ -84,5 +84,41 @@ describe("command queue", () => {
     expect(waited).not.toBeNull();
     expect(waited as number).toBeGreaterThanOrEqual(5);
     expect(queuedAhead).toBe(0);
+  });
+
+  it("rejects queued tasks when a lane is cleared", async () => {
+    const lane = `test-clear-${Date.now()}`;
+    let releaseFirst: (() => void) | undefined;
+    let firstStarted = false;
+
+    const first = enqueueCommandInLane(lane, async () => {
+      firstStarted = true;
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      return "first";
+    });
+
+    await vi.waitFor(() => {
+      expect(firstStarted).toBe(true);
+    });
+
+    const second = enqueueCommandInLane(lane, async () => "second");
+
+    await vi.waitFor(() => {
+      expect(getQueueSize(lane)).toBe(2);
+    });
+
+    const removed = clearCommandLane(lane);
+    expect(removed).toBe(1);
+
+    await expect(second).rejects.toMatchObject({
+      name: "AbortError",
+      message: expect.stringContaining(`command lane cleared: ${lane}`),
+    });
+
+    releaseFirst?.();
+    await expect(first).resolves.toBe("first");
+    expect(getQueueSize(lane)).toBe(0);
   });
 });

--- a/packages/zee/Swabble/src/process/command-queue.ts
+++ b/packages/zee/Swabble/src/process/command-queue.ts
@@ -25,6 +25,13 @@ type LaneState = {
 
 const lanes = new Map<string, LaneState>();
 
+function createLaneClearedError(lane: string): Error {
+  const err = new Error(`command lane cleared: ${lane}`);
+  err.name = "AbortError";
+  (err as Error & { code?: string }).code = "ERR_COMMAND_LANE_CLEARED";
+  return err;
+}
+
 function getLaneState(lane: string): LaneState {
   const existing = lanes.get(lane);
   if (existing) return existing;
@@ -146,7 +153,13 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
   const cleaned = lane.trim() || CommandLane.Main;
   const state = lanes.get(cleaned);
   if (!state) return 0;
-  const removed = state.queue.length;
-  state.queue.length = 0;
+  const pending = state.queue.splice(0);
+  const removed = pending.length;
+  if (removed > 0) {
+    const err = createLaneClearedError(cleaned);
+    for (const entry of pending) {
+      entry.reject(err);
+    }
+  }
   return removed;
 }

--- a/packages/zee/Swabble/src/process/parent-guard.test.ts
+++ b/packages/zee/Swabble/src/process/parent-guard.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  isProcessAlive,
+  parseParentPid,
+  resolveParentGuardPid,
+  shouldExitForMissingParent,
+  installParentProcessGuard,
+} from "./parent-guard.js";
+
+describe("parent guard", () => {
+  it("parses valid parent pids", () => {
+    expect(parseParentPid("42")).toBe(42);
+    expect(parseParentPid("  99  ")).toBe(99);
+  });
+
+  it("rejects invalid parent pids", () => {
+    expect(parseParentPid(undefined)).toBeUndefined();
+    expect(parseParentPid("")).toBeUndefined();
+    expect(parseParentPid("1")).toBeUndefined();
+    expect(parseParentPid("-5")).toBeUndefined();
+    expect(parseParentPid("abc")).toBeUndefined();
+  });
+
+  it("resolves explicit parent pid from env first", () => {
+    const pid = resolveParentGuardPid({
+      env: { ZEE_PARENT_PID: "777", ZEE_IS_SUBAGENT: "1" },
+      ppid: 55,
+    });
+    expect(pid).toBe(777);
+  });
+
+  it("falls back to ppid for subagents", () => {
+    const pid = resolveParentGuardPid({
+      env: { ZEE_IS_SUBAGENT: "true" },
+      ppid: 456,
+    });
+    expect(pid).toBe(456);
+  });
+
+  it("supports disabling the guard via env", () => {
+    const pid = resolveParentGuardPid({
+      env: { ZEE_IS_SUBAGENT: "1", ZEE_DISABLE_PARENT_GUARD: "1" },
+      ppid: 456,
+    });
+    expect(pid).toBeUndefined();
+  });
+
+  it("treats EPERM as process alive", () => {
+    const alive = isProcessAlive(123, () => {
+      const err = new Error("eperm") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    });
+    expect(alive).toBe(true);
+  });
+
+  it("detects missing parent conditions", () => {
+    expect(
+      shouldExitForMissingParent({
+        expectedParentPid: 10,
+        currentPpid: 1,
+        parentAlive: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldExitForMissingParent({
+        expectedParentPid: 10,
+        currentPpid: 20,
+        parentAlive: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldExitForMissingParent({
+        expectedParentPid: 10,
+        currentPpid: 10,
+        parentAlive: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldExitForMissingParent({
+        expectedParentPid: 10,
+        currentPpid: 10,
+        parentAlive: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("exits immediately when parent is gone", () => {
+    const exitFn = vi.fn();
+    const setIntervalFn = vi.fn((fn: () => void) => {
+      // parent guard runs an immediate check, so no need to trigger interval.
+      return { unref: vi.fn(), fn } as unknown as NodeJS.Timeout;
+    });
+    const clearIntervalFn = vi.fn();
+    const logger = vi.fn();
+
+    const guard = installParentProcessGuard({
+      expectedParentPid: 12345,
+      getPpid: () => 1,
+      isAlive: () => false,
+      setIntervalFn,
+      clearIntervalFn,
+      exitFn,
+      logger,
+    });
+
+    expect(guard).toBeDefined();
+    expect(setIntervalFn).toHaveBeenCalledTimes(1);
+    expect(exitFn).toHaveBeenCalledWith(0);
+    expect(logger).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips daemon process by default", () => {
+    const setIntervalFn = vi.fn();
+    const guard = installParentProcessGuard({
+      expectedParentPid: 12345,
+      argv: ["node", "zee", "daemon"],
+      setIntervalFn,
+    });
+    expect(guard).toBeUndefined();
+    expect(setIntervalFn).not.toHaveBeenCalled();
+  });
+});
+

--- a/packages/zee/Swabble/src/process/parent-guard.ts
+++ b/packages/zee/Swabble/src/process/parent-guard.ts
@@ -1,0 +1,141 @@
+import process from "node:process";
+
+import { isTruthyEnvValue } from "../infra/env.js";
+
+export const PARENT_PID_ENV = "ZEE_PARENT_PID";
+export const SUBAGENT_ENV = "ZEE_IS_SUBAGENT";
+export const DISABLE_PARENT_GUARD_ENV = "ZEE_DISABLE_PARENT_GUARD";
+const DEFAULT_CHECK_INTERVAL_MS = 2_000;
+
+export type ParentGuardOptions = {
+  env?: NodeJS.ProcessEnv;
+  argv?: string[];
+  ppid?: number;
+  pid?: number;
+};
+
+export function parseParentPid(value: string | undefined): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return undefined;
+  const normalized = Math.floor(parsed);
+  if (normalized <= 1) return undefined;
+  return normalized;
+}
+
+export function resolveParentGuardPid(options: ParentGuardOptions = {}): number | undefined {
+  const env = options.env ?? process.env;
+  if (isTruthyEnvValue(env[DISABLE_PARENT_GUARD_ENV])) return undefined;
+
+  const explicit = parseParentPid(env[PARENT_PID_ENV]);
+  if (explicit !== undefined) return explicit;
+
+  const isSubagent = isTruthyEnvValue(env[SUBAGENT_ENV]);
+  if (!isSubagent) return undefined;
+
+  const ppid = options.ppid ?? process.ppid;
+  if (!Number.isFinite(ppid) || ppid <= 1) return undefined;
+  return Math.floor(ppid);
+}
+
+export function isProcessAlive(
+  pid: number,
+  killFn: (pid: number, signal?: number | NodeJS.Signals) => void = process.kill,
+): boolean {
+  try {
+    killFn(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EPERM") return true;
+    return false;
+  }
+}
+
+export function shouldExitForMissingParent(params: {
+  expectedParentPid: number;
+  currentPpid: number;
+  parentAlive: boolean;
+}): boolean {
+  if (params.currentPpid <= 1) return true;
+  if (params.currentPpid !== params.expectedParentPid) return true;
+  if (!params.parentAlive) return true;
+  return false;
+}
+
+export type InstallParentGuardOptions = {
+  expectedParentPid?: number;
+  intervalMs?: number;
+  env?: NodeJS.ProcessEnv;
+  argv?: string[];
+  getPpid?: () => number;
+  isAlive?: (pid: number) => boolean;
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+  onOrphaned?: (expectedParentPid: number) => void;
+  exitFn?: (code?: number) => never | void;
+  logger?: (line: string) => void;
+};
+
+export function installParentProcessGuard(
+  options: InstallParentGuardOptions = {},
+): { stop: () => void } | undefined {
+  const env = options.env ?? process.env;
+  const argv = options.argv ?? process.argv;
+  const pid = process.pid;
+  const expectedParentPid = options.expectedParentPid ?? resolveParentGuardPid({ env });
+  if (!expectedParentPid || expectedParentPid <= 1 || expectedParentPid === pid) {
+    return undefined;
+  }
+
+  // Never parent-guard the long-running daemon service unless explicitly requested.
+  const daemonCommand = argv.slice(2)[0] === "daemon";
+  if (daemonCommand && !isTruthyEnvValue(env.ZEE_FORCE_PARENT_GUARD)) {
+    return undefined;
+  }
+
+  const getPpid = options.getPpid ?? (() => process.ppid);
+  const isAlive = options.isAlive ?? ((parentPid: number) => isProcessAlive(parentPid));
+  const setIntervalFn = options.setIntervalFn ?? setInterval;
+  const clearIntervalFn = options.clearIntervalFn ?? clearInterval;
+  const exitFn = options.exitFn ?? ((code?: number) => process.exit(code));
+  const logger = options.logger ?? ((line: string) => console.error(line));
+  const checkIntervalMs =
+    typeof options.intervalMs === "number" && options.intervalMs >= 200
+      ? Math.floor(options.intervalMs)
+      : DEFAULT_CHECK_INTERVAL_MS;
+
+  let stopped = false;
+  const stop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    clearIntervalFn(timer);
+  };
+
+  const check = (): void => {
+    if (stopped) return;
+    const currentPpid = getPpid();
+    const parentAlive = isAlive(expectedParentPid);
+    if (
+      shouldExitForMissingParent({
+        expectedParentPid,
+        currentPpid,
+        parentAlive,
+      })
+    ) {
+      stop();
+      options.onOrphaned?.(expectedParentPid);
+      logger(`[zee] parent process ${expectedParentPid} is gone; exiting to prevent orphaned workers.`);
+      exitFn(0);
+    }
+  };
+
+  const timer = setIntervalFn(check, checkIntervalMs);
+  timer.unref?.();
+  process.once("exit", stop);
+  check();
+  return { stop };
+}
+

--- a/packages/zee/src/mcp/index.ts
+++ b/packages/zee/src/mcp/index.ts
@@ -802,6 +802,9 @@ export namespace MCP {
         env: {
           ...process.env,
           ZEE_ROOT: process.env.ZEE_ROOT || zeeRoot,
+          ZEE_MCP_SERVER: "1",
+          ZEE_MCP_SERVER_NAME: key,
+          ZEE_PARENT_PID: String(process.pid),
           ...(cmd === "zee" ? { BUN_BE_BUN: "1" } : {}),
           ...mcp.environment,
         },

--- a/packages/zee/test/mcp/parent-guard.test.ts
+++ b/packages/zee/test/mcp/parent-guard.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { installMcpParentGuard, parseParentPid } from "../../../../src/mcp/servers/parent-guard.ts"
+
+describe("mcp parent guard", () => {
+  test("parseParentPid validates numbers", () => {
+    expect(parseParentPid(undefined)).toBeUndefined()
+    expect(parseParentPid("")).toBeUndefined()
+    expect(parseParentPid("abc")).toBeUndefined()
+    expect(parseParentPid("1")).toBeUndefined()
+    expect(parseParentPid("42")).toBe(42)
+  })
+
+  test("installMcpParentGuard exits when parent is gone", () => {
+    let exited: number | undefined
+    let callback: (() => void) | undefined
+
+    const guard = installMcpParentGuard("memory", {
+      env: { ZEE_PARENT_PID: "777" },
+      getPpid: () => 1,
+      isAlive: () => false,
+      logger: () => {},
+      exitFn: (code?: number) => {
+        exited = code
+      },
+      setIntervalFn: ((fn: () => void) => {
+        callback = fn
+        return { unref() {} } as unknown as NodeJS.Timeout
+      }) as typeof setInterval,
+      clearIntervalFn: (() => {}) as typeof clearInterval,
+    })
+
+    expect(guard).toBeDefined()
+    expect(exited).toBe(0)
+
+    // Ensure callback can be called without throwing
+    callback?.()
+  })
+})

--- a/src/mcp/servers/calendar.ts
+++ b/src/mcp/servers/calendar.ts
@@ -14,12 +14,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerCalendarTools } from "./calendar-tools.js";
+import { installMcpParentGuard } from "./parent-guard.js";
 
 // Create server
 const server = new McpServer({
   name: "calendar",
   version: "1.0.0",
 });
+
+installMcpParentGuard("calendar");
 
 registerCalendarTools(server);
 

--- a/src/mcp/servers/consciousness.ts
+++ b/src/mcp/servers/consciousness.ts
@@ -15,12 +15,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { installMcpParentGuard } from "./parent-guard.js";
 
 // Create server
 const server = new McpServer({
   name: "consciousness",
   version: "1.0.0",
 });
+
+installMcpParentGuard("consciousness");
 
 // =============================================================================
 // Types for IIT calculations

--- a/src/mcp/servers/memory.ts
+++ b/src/mcp/servers/memory.ts
@@ -14,6 +14,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { getMemory } from "../../memory/unified.js";
 import type { MemoryCategory } from "../../memory/types.js";
+import { installMcpParentGuard } from "./parent-guard.js";
 
 const MEMORY_CATEGORIES = [
   "conversation",
@@ -31,6 +32,8 @@ const server = new McpServer({
   name: "memory",
   version: "1.0.0",
 });
+
+installMcpParentGuard("memory");
 
 // =============================================================================
 // memory_store - Store information in memory

--- a/src/mcp/servers/parent-guard.ts
+++ b/src/mcp/servers/parent-guard.ts
@@ -1,0 +1,84 @@
+const DEFAULT_INTERVAL_MS = 2_000
+
+export function parseParentPid(value: string | undefined): number | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  const parsed = Number.parseInt(trimmed, 10)
+  if (!Number.isFinite(parsed) || parsed <= 1) return undefined
+  return parsed
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === "EPERM") return true
+    return false
+  }
+}
+
+export function installMcpParentGuard(
+  serverName: string,
+  options: {
+    env?: NodeJS.ProcessEnv
+    intervalMs?: number
+    getPpid?: () => number
+    isAlive?: (pid: number) => boolean
+    exitFn?: (code?: number) => never | void
+    logger?: (line: string) => void
+    setIntervalFn?: typeof setInterval
+    clearIntervalFn?: typeof clearInterval
+  } = {},
+): { stop: () => void } | undefined {
+  const env = options.env ?? process.env
+  const expectedParentPid = parseParentPid(env.ZEE_PARENT_PID)
+  if (!expectedParentPid) return undefined
+
+  const getPpid = options.getPpid ?? (() => process.ppid)
+  const isAlive = options.isAlive ?? isPidAlive
+  const exitFn = options.exitFn ?? ((code?: number) => process.exit(code))
+  const logger =
+    options.logger ??
+    ((line: string) => {
+      console.error(line)
+    })
+  const setIntervalFn = options.setIntervalFn ?? setInterval
+  const clearIntervalFn = options.clearIntervalFn ?? clearInterval
+
+  const intervalMs =
+    typeof options.intervalMs === "number" && options.intervalMs >= 250
+      ? Math.floor(options.intervalMs)
+      : DEFAULT_INTERVAL_MS
+
+  let stopped = false
+
+  const stop = () => {
+    if (stopped) return
+    stopped = true
+    clearIntervalFn(timer)
+  }
+
+  const check = () => {
+    if (stopped) return
+    const currentPpid = getPpid()
+    const parentAlive = isAlive(expectedParentPid)
+    if (currentPpid <= 1 || currentPpid !== expectedParentPid || !parentAlive) {
+      stop()
+      logger(
+        `[zee-mcp:${serverName}] parent process ${expectedParentPid} is gone; exiting to prevent orphaned MCP workers.`,
+      )
+      exitFn(0)
+    }
+  }
+
+  const timer = setIntervalFn(check, intervalMs)
+  timer.unref?.()
+
+  process.once("exit", stop)
+  check()
+
+  return { stop }
+}

--- a/src/mcp/servers/portfolio.ts
+++ b/src/mcp/servers/portfolio.ts
@@ -19,6 +19,7 @@ import { existsSync } from "node:fs";
 import { delimiter } from "node:path";
 import { getSafeEnv } from "../../util/safe-env.js";
 import { Stanley } from "../../paths.js";
+import { installMcpParentGuard } from "./parent-guard.js";
 
 type StanleyResult = {
   ok: boolean;
@@ -77,6 +78,8 @@ const server = new McpServer({
   name: "portfolio",
   version: "1.0.0",
 });
+
+installMcpParentGuard("portfolio");
 
 // =============================================================================
 // portfolio_status - Get portfolio holdings and performance


### PR DESCRIPTION
Closes #315

## What this PR does
- adds parent-process guards to prevent orphaned worker processes in Swabble and MCP server children
- propagates parent PID metadata into spawned MCP processes (`ZEE_PARENT_PID`, server marker envs)
- adds runtime check that exits child workers when the expected parent disappears
- hardens command-lane cleanup by rejecting queued tasks with explicit `AbortError` when a lane is cleared
- wires MCP server entrypoints (`calendar`, `consciousness`, `memory`, `portfolio`) to the new parent guard

## Parity mapping for #315
Implemented (theme-aligned):
- server/runtime process-lifecycle hardening
- orphan-process prevention for MCP workers and spawned child flows
- command queue safety under lane clear/teardown scenarios

N/A with rationale:
- app/UI and workspace UX commits mapped into this runtime-themed issue are outside this runtime PR scope
- unrelated snapshot/UI regressions from source theme are tracked in other opencode-sync issues

## Verification
- `pnpm exec vitest run src/process/command-queue.test.ts src/process/parent-guard.test.ts` (in `packages/zee/Swabble`)
- `pnpm build` (in `packages/zee/Swabble`)
- `bun test test/mcp/parent-guard.test.ts` (in `packages/zee`)
