### PR TITLE
Fix #333: enforce 0600 credential modes for channel auth files

### DIFF
--- a/packages/zee/Swabble/src/infra/zee-auth-store.ts
+++ b/packages/zee/Swabble/src/infra/zee-auth-store.ts
@@ -27,6 +27,17 @@ function readZeeAuthStoreCached(env: NodeJS.ProcessEnv = process.env): ZeeAuthSt
   for (const candidate of resolveZeeAuthPaths(env)) {
     try {
       if (!fs.existsSync(candidate)) continue;
+      if (process.platform !== "win32") {
+        try {
+          const stats = fs.statSync(candidate);
+          const mode = stats.mode & 0o777;
+          if (stats.isFile() && (mode & 0o077) !== 0) {
+            fs.chmodSync(candidate, 0o600);
+          }
+        } catch {
+          // Best effort only.
+        }
+      }
       const raw = fs.readFileSync(candidate, "utf-8");
       const parsed = JSON.parse(raw) as ZeeAuthStore;
       cachedStore = parsed;
@@ -51,4 +62,3 @@ export function getZeeAuthApiKeySync(providerId: string): string | undefined {
   if (entry?.type === "api" && key) return key;
   return undefined;
 }
-

--- a/packages/zee/Swabble/src/web/auth-store.ts
+++ b/packages/zee/Swabble/src/web/auth-store.ts
@@ -25,9 +25,25 @@ export function resolveWebCredsBackupPath(authDir: string): string {
   return path.join(authDir, "creds.json.bak");
 }
 
+export function enforcePosixCredentialPermissions(filePath: string): void {
+  if (process.platform === "win32") return;
+  try {
+    const stats = fsSync.statSync(filePath);
+    if (!stats.isFile()) return;
+    const mode = stats.mode & 0o777;
+    if ((mode & 0o077) !== 0) {
+      fsSync.chmodSync(filePath, 0o600);
+    }
+  } catch {
+    // Best effort only.
+  }
+}
+
 export function hasWebCredsSync(authDir: string): boolean {
   try {
-    const stats = fsSync.statSync(resolveWebCredsPath(authDir));
+    const credsPath = resolveWebCredsPath(authDir);
+    enforcePosixCredentialPermissions(credsPath);
+    const stats = fsSync.statSync(credsPath);
     return stats.isFile() && stats.size > 1;
   } catch {
     return false;
@@ -57,12 +73,15 @@ export function maybeRestoreCredsFromBackup(authDir: string): void {
       return;
     }
 
+    enforcePosixCredentialPermissions(backupPath);
     const backupRaw = readCredsJsonRaw(backupPath);
     if (!backupRaw) return;
 
     // Ensure backup is parseable before restoring.
     JSON.parse(backupRaw);
     fsSync.copyFileSync(backupPath, credsPath);
+    enforcePosixCredentialPermissions(backupPath);
+    enforcePosixCredentialPermissions(credsPath);
     logger.warn({ credsPath }, "restored corrupted WhatsApp creds.json from backup");
   } catch {
     // ignore
@@ -79,6 +98,7 @@ export async function webAuthExists(authDir: string = resolveDefaultWebAuthDir()
     return false;
   }
   try {
+    enforcePosixCredentialPermissions(credsPath);
     const stats = await fs.stat(credsPath);
     if (!stats.isFile() || stats.size <= 1) return false;
     const raw = await fs.readFile(credsPath, "utf-8");

--- a/packages/zee/Swabble/src/web/session.test.ts
+++ b/packages/zee/Swabble/src/web/session.test.ts
@@ -227,4 +227,44 @@ describe("web session", () => {
     statSpy.mockRestore();
     readSpy.mockRestore();
   });
+
+  it("enforces strict permissions on creds and backup files after save", async () => {
+    const credsSuffix = path.join(".zee", "credentials", "whatsapp", "default", "creds.json");
+    const backupSuffix = path.join(".zee", "credentials", "whatsapp", "default", "creds.json.bak");
+
+    const chmodSpy = vi.spyOn(fsSync, "chmodSync").mockImplementation(() => {});
+    const copySpy = vi.spyOn(fsSync, "copyFileSync").mockImplementation(() => {});
+    const existsSpy = vi.spyOn(fsSync, "existsSync").mockImplementation((p) => {
+      if (typeof p !== "string") return false;
+      return p.endsWith(credsSuffix);
+    });
+    const statSpy = vi.spyOn(fsSync, "statSync").mockImplementation((p) => {
+      if (typeof p === "string" && (p.endsWith(credsSuffix) || p.endsWith(backupSuffix))) {
+        return { isFile: () => true, size: 12, mode: 0o644 } as never;
+      }
+      throw new Error(`unexpected statSync path: ${String(p)}`);
+    });
+    const readSpy = vi.spyOn(fsSync, "readFileSync").mockImplementation((p) => {
+      if (typeof p === "string" && p.endsWith(credsSuffix)) {
+        return "{}" as never;
+      }
+      throw new Error(`unexpected readFileSync path: ${String(p)}`);
+    });
+
+    await createWaSocket(false, false);
+    const sock = getLastSocket();
+
+    sock.ev.emit("creds.update", {});
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(copySpy).toHaveBeenCalled();
+    expect(chmodSpy).toHaveBeenCalled();
+    expect(chmodSpy.mock.calls.every((args) => args[1] === 0o600)).toBe(true);
+
+    chmodSpy.mockRestore();
+    copySpy.mockRestore();
+    existsSpy.mockRestore();
+    statSpy.mockRestore();
+    readSpy.mockRestore();
+  });
 });

--- a/packages/zee/Swabble/src/web/session.ts
+++ b/packages/zee/Swabble/src/web/session.ts
@@ -15,6 +15,7 @@ import { VERSION } from "../version.js";
 import { formatCliCommand } from "../cli/command-format.js";
 
 import {
+  enforcePosixCredentialPermissions,
   maybeRestoreCredsFromBackup,
   resolveDefaultWebAuthDir,
   resolveWebCredsBackupPath,
@@ -120,6 +121,7 @@ async function safeSaveCreds(
       try {
         JSON.parse(raw);
         fsSync.copyFileSync(credsPath, backupPath);
+        enforcePosixCredentialPermissions(backupPath);
       } catch {
         // keep existing backup
       }
@@ -129,6 +131,8 @@ async function safeSaveCreds(
   }
   try {
     await Promise.resolve(saveCreds());
+    enforcePosixCredentialPermissions(resolveWebCredsPath(authDir));
+    enforcePosixCredentialPermissions(resolveWebCredsBackupPath(authDir));
   } catch (err) {
     logger.warn({ error: String(err) }, "failed saving WhatsApp creds");
   }


### PR DESCRIPTION
Closes #333

Upstream parity: openclaw/openclaw#10529

## What changed
- Enforced POSIX `0600` permissions for Zee auth-store credentials before read (`infra/zee-auth-store.ts`).
- Added reusable credential permission hardening helper for WhatsApp Web credential files (`web/auth-store.ts`).
- Applied permission hardening during session save/backup flows in `web/session.ts`.
- Added regression coverage in `web/session.test.ts` to verify strict permission enforcement path.

## Validation
- ✅ `vitest run src/web/session.test.ts`
- ✅ `vitest run src/web/logout.test.ts`
- ⚠️ `bun run build` in `packages/zee` fails in this environment due unresolved local dependency `@clawhub/registry@file:../../../claw-registry`.

## Scope
In scope:
- Channel credential file mode hardening for POSIX platforms.

Out of scope:
- Credential input normalization UX flows.
