### PR TITLE
Fix #368: prune expired auth-failure entries instead of clearing all

### DIFF
--- a/packages/zee/Swabble/src/config/types.gateway.ts
+++ b/packages/zee/Swabble/src/config/types.gateway.ts
@@ -51,6 +51,19 @@ export type TalkConfig = {
 
 export type GatewayAuthMode = "token" | "password";
 
+export type GatewayAuthRateLimitConfig = {
+  /** Enable auth rate limiting and lockouts (default: true). */
+  enabled?: boolean;
+  /** Sliding window for failed auth attempts in milliseconds (default: 60000). */
+  windowMs?: number;
+  /** Max failed attempts per client IP within the window (default: 20). */
+  maxAttemptsPerIp?: number;
+  /** Max failed attempts per token/password within the window (default: 10). */
+  maxAttemptsPerToken?: number;
+  /** Lockout duration in milliseconds after limit is exceeded (default: 300000). */
+  lockoutMs?: number;
+};
+
 export type GatewayAuthConfig = {
   /** Authentication mode for Gateway connections. Defaults to token when set. */
   mode?: GatewayAuthMode;
@@ -60,6 +73,8 @@ export type GatewayAuthConfig = {
   password?: string;
   /** Allow Tailscale identity headers when serve mode is enabled. */
   allowTailscale?: boolean;
+  /** Optional auth rate limiting controls. */
+  rateLimit?: GatewayAuthRateLimitConfig;
 };
 
 export type GatewayTailscaleMode = "off" | "serve" | "funnel";

--- a/packages/zee/Swabble/src/config/zod-schema.ts
+++ b/packages/zee/Swabble/src/config/zod-schema.ts
@@ -350,6 +350,16 @@ export const ZeeSchema = z
             token: z.string().optional(),
             password: z.string().optional(),
             allowTailscale: z.boolean().optional(),
+            rateLimit: z
+              .object({
+                enabled: z.boolean().optional(),
+                windowMs: z.number().int().positive().optional(),
+                maxAttemptsPerIp: z.number().int().positive().optional(),
+                maxAttemptsPerToken: z.number().int().positive().optional(),
+                lockoutMs: z.number().int().positive().optional(),
+              })
+              .strict()
+              .optional(),
           })
           .strict()
           .optional(),

--- a/packages/zee/Swabble/src/gateway/auth-rate-limit.test.ts
+++ b/packages/zee/Swabble/src/gateway/auth-rate-limit.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __testing,
+  checkGatewayAuthRateLimit,
+  clearGatewayAuthRateLimit,
+  recordGatewayAuthFailure,
+  resolveGatewayAuthClientIp,
+} from "./auth-rate-limit.js";
+
+describe("auth rate limiter", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __testing.reset();
+    vi.useRealTimers();
+  });
+
+  it("locks out by IP after repeated failures and unlocks after lockout", () => {
+    let now = Date.parse("2026-02-13T12:00:00.000Z");
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const cfg = {
+      enabled: true,
+      windowMs: 60_000,
+      maxAttemptsPerIp: 2,
+      maxAttemptsPerToken: 10,
+      lockoutMs: 5_000,
+    };
+
+    expect(recordGatewayAuthFailure({ cfg, ip: "10.0.0.1" }).limited).toBe(false);
+    const second = recordGatewayAuthFailure({ cfg, ip: "10.0.0.1" });
+    expect(second.limited).toBe(true);
+    expect((second.retryAfterMs ?? 0) > 0).toBe(true);
+
+    expect(checkGatewayAuthRateLimit({ cfg, ip: "10.0.0.1" }).limited).toBe(true);
+    now += 5_100;
+    expect(checkGatewayAuthRateLimit({ cfg, ip: "10.0.0.1" }).limited).toBe(false);
+  });
+
+  it("supports token/password-based lockouts independent of IP", () => {
+    const now = Date.parse("2026-02-13T12:00:00.000Z");
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const cfg = {
+      enabled: true,
+      windowMs: 60_000,
+      maxAttemptsPerIp: 50,
+      maxAttemptsPerToken: 2,
+      lockoutMs: 10_000,
+    };
+
+    expect(recordGatewayAuthFailure({ cfg, tokenOrPassword: "secret-token" }).limited).toBe(false);
+    const second = recordGatewayAuthFailure({ cfg, tokenOrPassword: "secret-token" });
+    expect(second.limited).toBe(true);
+
+    expect(checkGatewayAuthRateLimit({ cfg, tokenOrPassword: "another-secret" }).limited).toBe(
+      false,
+    );
+  });
+
+  it("clears lock state on successful auth", () => {
+    const cfg = {
+      enabled: true,
+      windowMs: 60_000,
+      maxAttemptsPerIp: 1,
+      maxAttemptsPerToken: 1,
+      lockoutMs: 60_000,
+    };
+    const blocked = recordGatewayAuthFailure({
+      cfg,
+      ip: "127.0.0.1",
+      tokenOrPassword: "abc",
+    });
+    expect(blocked.limited).toBe(true);
+    clearGatewayAuthRateLimit({ ip: "127.0.0.1", tokenOrPassword: "abc" });
+    expect(
+      checkGatewayAuthRateLimit({
+        cfg,
+        ip: "127.0.0.1",
+        tokenOrPassword: "abc",
+      }).limited,
+    ).toBe(false);
+  });
+
+  it("resolves client IP from request with forwarded headers", () => {
+    const ip = resolveGatewayAuthClientIp({
+      req: {
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: {
+          "x-forwarded-for": "203.0.113.7, 127.0.0.1",
+          "x-real-ip": "203.0.113.7",
+        },
+      } as never,
+      trustedProxies: ["127.0.0.1"],
+    });
+    expect(ip).toBe("203.0.113.7");
+  });
+});

--- a/packages/zee/Swabble/src/gateway/auth-rate-limit.test.ts
+++ b/packages/zee/Swabble/src/gateway/auth-rate-limit.test.ts
@@ -93,4 +93,26 @@ describe("auth rate limiter", () => {
     });
     expect(ip).toBe("203.0.113.7");
   });
+
+  it("prunes only expired entries without clearing active lock state", () => {
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const cfg = {
+      enabled: true,
+      windowMs: 1_000,
+      maxAttemptsPerIp: 1,
+      maxAttemptsPerToken: 1,
+      lockoutMs: 1_000,
+    };
+
+    // Old state that should be pruned.
+    expect(recordGatewayAuthFailure({ cfg, ip: "10.0.0.1" }).limited).toBe(true);
+
+    // Fresh state that must remain after pruning.
+    now = 3_000;
+    expect(recordGatewayAuthFailure({ cfg, ip: "10.0.0.2" }).limited).toBe(true);
+
+    // Cleanup runs during checks.
+    expect(checkGatewayAuthRateLimit({ cfg, ip: "10.0.0.2" }).limited).toBe(true);
+  });
 });

--- a/packages/zee/Swabble/src/gateway/auth-rate-limit.ts
+++ b/packages/zee/Swabble/src/gateway/auth-rate-limit.ts
@@ -64,12 +64,9 @@ function resolveKeys(params: {
 
 function cleanupExpired(nowMs: number, cfg: ResolvedRateLimitConfig): void {
   const ttl = Math.max(cfg.windowMs, cfg.lockoutMs) * 2;
-  for (const state of keyStates.values()) {
+  for (const [key, state] of keyStates.entries()) {
     if (nowMs - state.touchedAt > ttl && state.lockUntilMs < nowMs) {
-      // Initial implementation clears the whole map once old state is detected.
-      // Follow-up hardening changes this to prune only expired entries.
-      keyStates.clear();
-      return;
+      keyStates.delete(key);
     }
   }
 }

--- a/packages/zee/Swabble/src/gateway/auth-rate-limit.ts
+++ b/packages/zee/Swabble/src/gateway/auth-rate-limit.ts
@@ -1,0 +1,200 @@
+import { createHash } from "node:crypto";
+import type { IncomingMessage } from "node:http";
+
+import type { GatewayAuthRateLimitConfig } from "../config/types.gateway.js";
+import { resolveGatewayClientIp } from "./net.js";
+
+type RateLimitState = {
+  failures: number;
+  windowStartedAt: number;
+  lockUntilMs: number;
+  touchedAt: number;
+};
+
+type ResolvedRateLimitConfig = Required<GatewayAuthRateLimitConfig>;
+
+const DEFAULT_RATE_LIMIT: ResolvedRateLimitConfig = {
+  enabled: true,
+  windowMs: 60_000,
+  maxAttemptsPerIp: 20,
+  maxAttemptsPerToken: 10,
+  lockoutMs: 300_000,
+};
+
+const keyStates = new Map<string, RateLimitState>();
+
+function resolveRateLimitConfig(
+  cfg?: GatewayAuthRateLimitConfig,
+): ResolvedRateLimitConfig {
+  return {
+    enabled: cfg?.enabled ?? DEFAULT_RATE_LIMIT.enabled,
+    windowMs: cfg?.windowMs ?? DEFAULT_RATE_LIMIT.windowMs,
+    maxAttemptsPerIp: cfg?.maxAttemptsPerIp ?? DEFAULT_RATE_LIMIT.maxAttemptsPerIp,
+    maxAttemptsPerToken: cfg?.maxAttemptsPerToken ?? DEFAULT_RATE_LIMIT.maxAttemptsPerToken,
+    lockoutMs: cfg?.lockoutMs ?? DEFAULT_RATE_LIMIT.lockoutMs,
+  };
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function fingerprintSecret(secret: string): string {
+  const normalized = secret.trim();
+  if (!normalized) return "";
+  return createHash("sha256").update(normalized).digest("hex");
+}
+
+function resolveKeys(params: {
+  ip?: string;
+  tokenOrPassword?: string;
+}): Array<{ key: string; limit: number }> {
+  const keys: Array<{ key: string; limit: number }> = [];
+  if (params.ip?.trim()) {
+    keys.push({ key: `ip:${params.ip.trim()}`, limit: 0 });
+  }
+  if (params.tokenOrPassword?.trim()) {
+    const fingerprint = fingerprintSecret(params.tokenOrPassword);
+    if (fingerprint) {
+      keys.push({ key: `secret:${fingerprint}`, limit: 0 });
+    }
+  }
+  return keys;
+}
+
+function cleanupExpired(nowMs: number, cfg: ResolvedRateLimitConfig): void {
+  const ttl = Math.max(cfg.windowMs, cfg.lockoutMs) * 2;
+  for (const state of keyStates.values()) {
+    if (nowMs - state.touchedAt > ttl && state.lockUntilMs < nowMs) {
+      // Initial implementation clears the whole map once old state is detected.
+      // Follow-up hardening changes this to prune only expired entries.
+      keyStates.clear();
+      return;
+    }
+  }
+}
+
+function checkKeyLocked(key: string, nowMs: number): number {
+  const state = keyStates.get(key);
+  if (!state) return 0;
+  if (state.lockUntilMs <= nowMs) return 0;
+  return Math.max(1, state.lockUntilMs - nowMs);
+}
+
+function noteFailure(params: {
+  key: string;
+  nowMs: number;
+  cfg: ResolvedRateLimitConfig;
+  limit: number;
+}): number {
+  const { key, nowMs, cfg, limit } = params;
+  if (limit <= 0) return 0;
+  const state = keyStates.get(key) ?? {
+    failures: 0,
+    windowStartedAt: nowMs,
+    lockUntilMs: 0,
+    touchedAt: nowMs,
+  };
+
+  if (state.lockUntilMs > nowMs) {
+    state.touchedAt = nowMs;
+    keyStates.set(key, state);
+    return state.lockUntilMs - nowMs;
+  }
+
+  if (nowMs - state.windowStartedAt >= cfg.windowMs) {
+    state.failures = 0;
+    state.windowStartedAt = nowMs;
+  }
+
+  state.failures += 1;
+  state.touchedAt = nowMs;
+  if (state.failures >= limit) {
+    state.lockUntilMs = nowMs + cfg.lockoutMs;
+    state.failures = 0;
+  }
+  keyStates.set(key, state);
+  return state.lockUntilMs > nowMs ? state.lockUntilMs - nowMs : 0;
+}
+
+export function resolveGatewayAuthClientIp(params: {
+  req: IncomingMessage;
+  trustedProxies?: string[];
+}): string | undefined {
+  return resolveGatewayClientIp({
+    remoteAddr: params.req.socket?.remoteAddress ?? "",
+    forwardedFor: headerValue(params.req.headers?.["x-forwarded-for"]),
+    realIp: headerValue(params.req.headers?.["x-real-ip"]),
+    trustedProxies: params.trustedProxies,
+  });
+}
+
+export function checkGatewayAuthRateLimit(params: {
+  cfg?: GatewayAuthRateLimitConfig;
+  ip?: string;
+  tokenOrPassword?: string;
+}): { limited: boolean; retryAfterMs?: number } {
+  const config = resolveRateLimitConfig(params.cfg);
+  if (!config.enabled) return { limited: false };
+  const nowMs = Date.now();
+  cleanupExpired(nowMs, config);
+  const keys = resolveKeys(params);
+  if (keys.length === 0) return { limited: false };
+
+  let retryAfterMs = 0;
+  for (const entry of keys) {
+    const lockedMs = checkKeyLocked(entry.key, nowMs);
+    if (lockedMs > retryAfterMs) retryAfterMs = lockedMs;
+  }
+  if (retryAfterMs > 0) {
+    return { limited: true, retryAfterMs };
+  }
+  return { limited: false };
+}
+
+export function recordGatewayAuthFailure(params: {
+  cfg?: GatewayAuthRateLimitConfig;
+  ip?: string;
+  tokenOrPassword?: string;
+}): { limited: boolean; retryAfterMs?: number } {
+  const config = resolveRateLimitConfig(params.cfg);
+  if (!config.enabled) return { limited: false };
+  const nowMs = Date.now();
+  cleanupExpired(nowMs, config);
+  const keys = resolveKeys(params);
+  if (keys.length === 0) return { limited: false };
+
+  let retryAfterMs = 0;
+  for (const entry of keys) {
+    const limit = entry.key.startsWith("ip:") ? config.maxAttemptsPerIp : config.maxAttemptsPerToken;
+    const lockedMs = noteFailure({
+      key: entry.key,
+      nowMs,
+      cfg: config,
+      limit,
+    });
+    if (lockedMs > retryAfterMs) retryAfterMs = lockedMs;
+  }
+  if (retryAfterMs > 0) {
+    return { limited: true, retryAfterMs };
+  }
+  return { limited: false };
+}
+
+export function clearGatewayAuthRateLimit(params: {
+  ip?: string;
+  tokenOrPassword?: string;
+}): void {
+  for (const entry of resolveKeys(params)) {
+    keyStates.delete(entry.key);
+  }
+}
+
+export const __testing = {
+  reset(): void {
+    keyStates.clear();
+  },
+  snapshot(): Array<{ key: string; value: RateLimitState }> {
+    return Array.from(keyStates.entries()).map(([key, value]) => ({ key, value: { ...value } }));
+  },
+};

--- a/packages/zee/Swabble/src/gateway/http-common.ts
+++ b/packages/zee/Swabble/src/gateway/http-common.ts
@@ -25,6 +25,23 @@ export function sendUnauthorized(res: ServerResponse) {
   });
 }
 
+export function sendTooManyRequests(res: ServerResponse, retryAfterMs?: number) {
+  if (typeof retryAfterMs === "number" && Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+    const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+    res.setHeader("Retry-After", String(retryAfterSeconds));
+  }
+  sendJson(res, 429, {
+    error: {
+      message: "Too many authentication attempts. Please retry later.",
+      type: "rate_limit_error",
+      retry_after_ms:
+        typeof retryAfterMs === "number" && Number.isFinite(retryAfterMs) && retryAfterMs > 0
+          ? Math.ceil(retryAfterMs)
+          : undefined,
+    },
+  });
+}
+
 export function sendInvalidRequest(res: ServerResponse, message: string) {
   sendJson(res, 400, {
     error: { message, type: "invalid_request_error" },

--- a/packages/zee/Swabble/src/gateway/server-http.ts
+++ b/packages/zee/Swabble/src/gateway/server-http.ts
@@ -26,6 +26,12 @@ import { checkBrowserOrigin } from "./origin-check.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
+import {
+  checkGatewayAuthRateLimit,
+  clearGatewayAuthRateLimit,
+  recordGatewayAuthFailure,
+  resolveGatewayAuthClientIp,
+} from "./auth-rate-limit.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -76,13 +82,46 @@ export function createHooksRequestHandler(
       sendJson(res, 400, { ok: false, error: "token query parameter is not allowed" });
       return true;
     }
+    const configSnapshot = loadConfig();
+    const rateLimitCfg = configSnapshot.gateway?.auth?.rateLimit;
+    const clientIp = resolveGatewayAuthClientIp({
+      req,
+      trustedProxies: configSnapshot.gateway?.trustedProxies,
+    });
     const token = extractHookToken(req);
+    const preLimit = checkGatewayAuthRateLimit({
+      cfg: rateLimitCfg,
+      ip: clientIp,
+      tokenOrPassword: token,
+    });
+    if (preLimit.limited) {
+      sendJson(res, 429, {
+        ok: false,
+        error: "Too many authentication attempts",
+        retryAfterMs: preLimit.retryAfterMs,
+      });
+      return true;
+    }
     if (!token || token !== hooksConfig.token) {
+      const failure = recordGatewayAuthFailure({
+        cfg: rateLimitCfg,
+        ip: clientIp,
+        tokenOrPassword: token,
+      });
+      if (failure.limited) {
+        sendJson(res, 429, {
+          ok: false,
+          error: "Too many authentication attempts",
+          retryAfterMs: failure.retryAfterMs,
+        });
+        return true;
+      }
       res.statusCode = 401;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Unauthorized");
       return true;
     }
+    clearGatewayAuthRateLimit({ ip: clientIp, tokenOrPassword: token });
     if (req.method !== "POST") {
       res.statusCode = 405;
       res.setHeader("Allow", "POST");

--- a/packages/zee/Swabble/src/gateway/server.hooks.e2e.test.ts
+++ b/packages/zee/Swabble/src/gateway/server.hooks.e2e.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import { drainSystemEvents, peekSystemEvents } from "../infra/system-events.js";
+import { __testing as authRateLimitTesting } from "./auth-rate-limit.js";
 import {
   cronIsolatedRun,
   getFreePort,
@@ -152,6 +153,46 @@ describe("gateway server hooks", () => {
       expect(resBadJson.status).toBe(400);
     } finally {
       await server.close();
+    }
+  });
+
+  test("rate limits repeated unauthorized hook auth attempts", async () => {
+    testState.hooksConfig = { enabled: true, token: "hook-secret" };
+    const { writeConfigFile } = await import("../config/config.js");
+    await writeConfigFile({
+      gateway: {
+        auth: {
+          rateLimit: {
+            enabled: true,
+            windowMs: 60_000,
+            maxAttemptsPerIp: 2,
+            maxAttemptsPerToken: 2,
+            lockoutMs: 60_000,
+          },
+        },
+      },
+    } as any);
+
+    const port = await getFreePort();
+    const server = await startGatewayServer(port);
+    try {
+      const first = await fetch(`http://127.0.0.1:${port}/hooks/wake`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "Ping" }),
+      });
+      expect(first.status).toBe(401);
+
+      const second = await fetch(`http://127.0.0.1:${port}/hooks/wake`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "Ping" }),
+      });
+      expect(second.status).toBe(429);
+    } finally {
+      await server.close();
+      await writeConfigFile({} as any);
+      authRateLimitTesting.reset();
     }
   });
 });

--- a/packages/zee/Swabble/src/gateway/tools-invoke-http.test.ts
+++ b/packages/zee/Swabble/src/gateway/tools-invoke-http.test.ts
@@ -5,6 +5,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 
 import { installGatewayTestHooks, getFreePort, startGatewayServer } from "./test-helpers.server.js";
+import { __testing as authRateLimitTesting } from "./auth-rate-limit.js";
 import { resetTestPluginRegistry, setTestPluginRegistry, testState } from "./test-helpers.mocks.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { CONFIG_PATH } from "../config/config.js";
@@ -15,6 +16,7 @@ beforeEach(() => {
   // Ensure these tests are not affected by host env vars.
   delete process.env.ZEE_GATEWAY_TOKEN;
   delete process.env.ZEE_GATEWAY_PASSWORD;
+  authRateLimitTesting.reset();
 });
 
 const resolveGatewayToken = (): string => {
@@ -227,6 +229,70 @@ describe("POST /tools/invoke", () => {
     expect(res.status).toBe(401);
 
     await server.close();
+  });
+
+  it("rate limits repeated unauthorized requests", async () => {
+    testState.agentsConfig = {
+      list: [
+        {
+          id: "main",
+          tools: {
+            allow: ["sessions_list"],
+          },
+        },
+      ],
+    } as any;
+
+    const { writeConfigFile } = await import("../config/config.js");
+    await writeConfigFile({
+      gateway: {
+        auth: {
+          rateLimit: {
+            enabled: true,
+            windowMs: 60_000,
+            maxAttemptsPerIp: 2,
+            maxAttemptsPerToken: 2,
+            lockoutMs: 60_000,
+          },
+        },
+      },
+    } as any);
+
+    const port = await getFreePort();
+    const server = await startGatewayServer(port, {
+      bind: "loopback",
+      auth: { mode: "token", token: "t" },
+    });
+
+    try {
+      const res1 = await fetch(`http://127.0.0.1:${port}/tools/invoke`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tool: "sessions_list",
+          action: "json",
+          args: {},
+          sessionKey: "main",
+        }),
+      });
+      expect(res1.status).toBe(401);
+
+      const res2 = await fetch(`http://127.0.0.1:${port}/tools/invoke`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tool: "sessions_list",
+          action: "json",
+          args: {},
+          sessionKey: "main",
+        }),
+      });
+      expect(res2.status).toBe(429);
+    } finally {
+      await server.close();
+      await writeConfigFile({} as any);
+      authRateLimitTesting.reset();
+    }
   });
 
   it("returns 404 when tool is not allowlisted", async () => {

--- a/packages/zee/Swabble/src/gateway/tools-invoke-http.ts
+++ b/packages/zee/Swabble/src/gateway/tools-invoke-http.ts
@@ -23,12 +23,19 @@ import { isSubagentSessionKey } from "../routing/session-key.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 
 import { authorizeGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
+import {
+  checkGatewayAuthRateLimit,
+  clearGatewayAuthRateLimit,
+  recordGatewayAuthFailure,
+  resolveGatewayAuthClientIp,
+} from "./auth-rate-limit.js";
 import { getBearerToken, getHeader } from "./http-utils.js";
 import {
   readJsonBodyOrError,
   sendInvalidRequest,
   sendJson,
   sendMethodNotAllowed,
+  sendTooManyRequests,
   sendUnauthorized,
 } from "./http-common.js";
 
@@ -158,6 +165,20 @@ export async function handleToolsInvokeHttpRequest(
 
   const cfg = loadConfig();
   const token = getBearerToken(req);
+  const rateLimitCfg = cfg.gateway?.auth?.rateLimit;
+  const clientIp = resolveGatewayAuthClientIp({
+    req,
+    trustedProxies: opts.trustedProxies ?? cfg.gateway?.trustedProxies,
+  });
+  const preLimit = checkGatewayAuthRateLimit({
+    cfg: rateLimitCfg,
+    ip: clientIp,
+    tokenOrPassword: token,
+  });
+  if (preLimit.limited) {
+    sendTooManyRequests(res, preLimit.retryAfterMs);
+    return true;
+  }
   const authResult = await authorizeGatewayConnect({
     auth: opts.auth,
     connectAuth: token ? { token, password: token } : null,
@@ -165,9 +186,19 @@ export async function handleToolsInvokeHttpRequest(
     trustedProxies: opts.trustedProxies ?? cfg.gateway?.trustedProxies,
   });
   if (!authResult.ok) {
-    sendUnauthorized(res);
+    const failure = recordGatewayAuthFailure({
+      cfg: rateLimitCfg,
+      ip: clientIp,
+      tokenOrPassword: token,
+    });
+    if (failure.limited) {
+      sendTooManyRequests(res, failure.retryAfterMs);
+    } else {
+      sendUnauthorized(res);
+    }
     return true;
   }
+  clearGatewayAuthRateLimit({ ip: clientIp, tokenOrPassword: token });
 
   const bodyUnknown = await readJsonBodyOrError(req, res, opts.maxBodyBytes ?? DEFAULT_BODY_BYTES);
   if (bodyUnknown === undefined) return true;


### PR DESCRIPTION
Closes #368

Upstream parity: openclaw/openclaw#15848

## Note
This PR is intentionally stacked on top of #378 (`fix/openclaw-15035-issue-331`) because it is a focused follow-up to the new auth rate-limiter implementation.

## What changed
- Updated gateway auth rate-limit cleanup to prune only expired entries.
- Preserved active lock state for non-expired keys.
- Added regression test covering mixed expired + active state cleanup.

## Validation
- ✅ `vitest run src/gateway/auth-rate-limit.test.ts` (5 tests passing)

## Scope
In scope:
- Auth failure state retention/pruning behavior.

Out of scope:
- New auth endpoints or policy/config surface.
