### PR TITLE
Fix #335: wait for embedded agent idle before flushing pending tool results

### DIFF
--- a/packages/zee/Swabble/src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts
+++ b/packages/zee/Swabble/src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { flushPendingToolResultsAfterIdle } from "./pi-embedded-runner/wait-for-idle-before-flush.js";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+type FakeSessionManager = {
+  flushed: number;
+  flushPendingToolResults: () => void;
+};
+
+function createSessionManager(): FakeSessionManager {
+  return {
+    flushed: 0,
+    flushPendingToolResults() {
+      this.flushed += 1;
+    },
+  };
+}
+
+describe("flushPendingToolResultsAfterIdle", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for idle before flush", async () => {
+    const idle = deferred<void>();
+    const sessionManager = createSessionManager();
+
+    const flushPromise = flushPendingToolResultsAfterIdle({
+      agent: { waitForIdle: () => idle.promise },
+      sessionManager,
+      timeoutMs: 1_000,
+    });
+
+    await Promise.resolve();
+    expect(sessionManager.flushed).toBe(0);
+
+    idle.resolve();
+    await flushPromise;
+
+    expect(sessionManager.flushed).toBe(1);
+  });
+
+  it("flushes after timeout when idle never resolves", async () => {
+    vi.useFakeTimers();
+    const sessionManager = createSessionManager();
+
+    const flushPromise = flushPendingToolResultsAfterIdle({
+      agent: { waitForIdle: () => new Promise<void>(() => {}) },
+      sessionManager,
+      timeoutMs: 30,
+    });
+
+    await vi.advanceTimersByTimeAsync(30);
+    await flushPromise;
+
+    expect(sessionManager.flushed).toBe(1);
+  });
+
+  it("clears timeout handle when waitForIdle resolves first", async () => {
+    vi.useFakeTimers();
+    const sessionManager = createSessionManager();
+
+    await flushPendingToolResultsAfterIdle({
+      agent: { waitForIdle: async () => {} },
+      sessionManager,
+      timeoutMs: 30_000,
+    });
+
+    expect(sessionManager.flushed).toBe(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/zee/Swabble/src/agents/pi-embedded-runner/compact.ts
+++ b/packages/zee/Swabble/src/agents/pi-embedded-runner/compact.ts
@@ -65,6 +65,7 @@ import { splitSdkTools } from "./tool-split.js";
 import type { EmbeddedPiCompactResult } from "./types.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { describeUnknownError, mapThinkingLevel, resolveExecToolDefaults } from "./utils.js";
+import { flushPendingToolResultsAfterIdle } from "./wait-for-idle-before-flush.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 
 export type CompactEmbeddedPiSessionParams = {
@@ -413,7 +414,10 @@ export async function compactEmbeddedPiSessionDirect(
           },
         };
       } finally {
-        sessionManager.flushPendingToolResults?.();
+        await flushPendingToolResultsAfterIdle({
+          agent: session?.agent,
+          sessionManager,
+        });
         session.dispose();
       }
     } finally {

--- a/packages/zee/Swabble/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/packages/zee/Swabble/src/agents/pi-embedded-runner/run/attempt.ts
@@ -75,6 +75,7 @@ import { splitSdkTools } from "../tool-split.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
+import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 import { buildTtsSystemPromptHint } from "../../../tts/tts.js";
 import { isTimeoutError } from "../../failover-error.js";
@@ -501,7 +502,10 @@ export async function runEmbeddedAttempt(
           activeSession.agent.replaceMessages(limited);
         }
       } catch (err) {
-        sessionManager.flushPendingToolResults?.();
+        await flushPendingToolResultsAfterIdle({
+          agent: activeSession?.agent,
+          sessionManager,
+        });
         activeSession.dispose();
         throw err;
       }
@@ -841,7 +845,17 @@ export async function runEmbeddedAttempt(
       };
     } finally {
       // Always tear down the session (and release the lock) before we leave this attempt.
-      sessionManager?.flushPendingToolResults?.();
+      //
+      // BUGFIX: Wait for the agent to be truly idle before flushing pending tool results.
+      // pi-agent-core's auto-retry resolves waitForRetry() on assistant message receipt,
+      // *before* tool execution completes in the retried agent loop. Without this wait,
+      // flushPendingToolResults() fires while tools are still executing, inserting
+      // synthetic "missing tool result" errors and causing silent agent failures.
+      // See: https://github.com/openclaw/openclaw/issues/8643
+      await flushPendingToolResultsAfterIdle({
+        agent: session?.agent,
+        sessionManager,
+      });
       session?.dispose();
       await sessionLock.release();
     }

--- a/packages/zee/Swabble/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
+++ b/packages/zee/Swabble/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
@@ -1,0 +1,45 @@
+type IdleAwareAgent = {
+  waitForIdle?: (() => Promise<void>) | undefined;
+};
+
+type ToolResultFlushManager = {
+  flushPendingToolResults?: (() => void) | undefined;
+};
+
+export const DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS = 30_000;
+
+async function waitForAgentIdleBestEffort(
+  agent: IdleAwareAgent | null | undefined,
+  timeoutMs: number,
+): Promise<void> {
+  const waitForIdle = agent?.waitForIdle;
+  if (typeof waitForIdle !== "function") {
+    return;
+  }
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      waitForIdle.call(agent),
+      new Promise<void>((resolve) => {
+        timeoutHandle = setTimeout(resolve, timeoutMs);
+        timeoutHandle.unref?.();
+      }),
+    ]);
+  } catch {
+    // Best-effort during cleanup.
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+export async function flushPendingToolResultsAfterIdle(opts: {
+  agent: IdleAwareAgent | null | undefined;
+  sessionManager: ToolResultFlushManager | null | undefined;
+  timeoutMs?: number;
+}): Promise<void> {
+  await waitForAgentIdleBestEffort(opts.agent, opts.timeoutMs ?? DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS);
+  opts.sessionManager?.flushPendingToolResults?.();
+}


### PR DESCRIPTION
## Summary
- add `flushPendingToolResultsAfterIdle` helper to gate synthetic tool-result flushing behind an idle wait with timeout
- use that helper in embedded runner attempt cleanup paths and compaction cleanup path
- add regression tests covering idle wait, timeout fallback, and timer cleanup

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts`
- `cd packages/zee/Swabble && bunx vitest run src/agents/session-tool-result-guard.test.ts` *(fails in this environment with `TypeError: onExit is not a function` from `proper-lockfile` before tests execute)*

Closes #335