### PR TITLE
Fix #337: normalize session key casing and prune legacy variants

### DIFF
--- a/packages/zee/Swabble/src/gateway/server-methods/agent.test.ts
+++ b/packages/zee/Swabble/src/gateway/server-methods/agent.test.ts
@@ -5,27 +5,33 @@ import { agentHandlers } from "./agent.js";
 
 const mocks = vi.hoisted(() => ({
   loadSessionEntry: vi.fn(),
+  canonicalizeSpawnedByForAgent: vi.fn((_cfg, _agentId, spawnedBy) => spawnedBy),
+  pruneLegacyStoreKeys: vi.fn(),
+  resolveGatewaySessionStoreTarget: vi.fn(({ key }: { key: string }) => ({
+    canonicalKey: key,
+    storeKeys: [key],
+  })),
   updateSessionStore: vi.fn(),
   agentCommand: vi.fn(),
   registerAgentRunContext: vi.fn(),
 }));
 
 vi.mock("../session-utils.js", () => ({
+  canonicalizeSpawnedByForAgent: mocks.canonicalizeSpawnedByForAgent,
   loadSessionEntry: mocks.loadSessionEntry,
+  pruneLegacyStoreKeys: mocks.pruneLegacyStoreKeys,
+  resolveGatewaySessionStoreTarget: mocks.resolveGatewaySessionStoreTarget,
 }));
 
-vi.mock("../../config/sessions.js", async () => {
-  const actual = await vi.importActual<typeof import("../../config/sessions.js")>(
-    "../../config/sessions.js",
-  );
-  return {
-    ...actual,
-    updateSessionStore: mocks.updateSessionStore,
-    resolveAgentIdFromSessionKey: () => "main",
-    resolveExplicitAgentSessionKey: () => undefined,
-    resolveAgentMainSessionKey: () => "agent:main:main",
-  };
-});
+vi.mock("../../config/sessions.js", () => ({
+  updateSessionStore: mocks.updateSessionStore,
+  resolveAgentIdFromSessionKey: (key?: string) => {
+    const parts = String(key ?? "").split(":");
+    return parts[1] || "main";
+  },
+  resolveExplicitAgentSessionKey: () => undefined,
+  resolveAgentMainSessionKey: () => "agent:main:main",
+}));
 
 vi.mock("../../commands/agent.js", () => ({
   agentCommand: mocks.agentCommand,

--- a/packages/zee/Swabble/src/gateway/server-methods/agent.ts
+++ b/packages/zee/Swabble/src/gateway/server-methods/agent.ts
@@ -35,7 +35,12 @@ import {
   validateAgentParams,
   validateAgentWaitParams,
 } from "../protocol/index.js";
-import { loadSessionEntry } from "../session-utils.js";
+import {
+  canonicalizeSpawnedByForAgent,
+  loadSessionEntry,
+  pruneLegacyStoreKeys,
+  resolveGatewaySessionStoreTarget,
+} from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
 import { waitForAgentJob } from "./agent-job.js";
@@ -199,6 +204,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
     let resolvedSessionId = request.sessionId?.trim() || undefined;
+    let resolvedSessionKey = requestedSessionKey;
     let sessionEntry: SessionEntry | undefined;
     let bestEffortDeliver = false;
     let cfgForAgent: ReturnType<typeof loadConfig> | undefined;
@@ -209,7 +215,12 @@ export const agentHandlers: GatewayRequestHandlers = {
       const now = Date.now();
       const sessionId = entry?.sessionId ?? randomUUID();
       const labelValue = request.label?.trim() || entry?.label;
-      spawnedByValue = spawnedByValue || entry?.spawnedBy;
+      const sessionAgentId = resolveAgentIdFromSessionKey(canonicalKey);
+      spawnedByValue = canonicalizeSpawnedByForAgent(
+        cfg,
+        sessionAgentId,
+        spawnedByValue || entry?.spawnedBy,
+      );
       let inheritedGroup:
         | { groupId?: string; groupChannel?: string; groupSpace?: string }
         | undefined;
@@ -257,7 +268,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       const sendPolicy = resolveSendPolicy({
         cfg,
         entry,
-        sessionKey: requestedSessionKey,
+        sessionKey: canonicalKey,
         channel: entry?.channel,
         chatType: entry?.chatType,
       });
@@ -275,17 +286,28 @@ export const agentHandlers: GatewayRequestHandlers = {
       const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId });
       if (storePath) {
         await updateSessionStore(storePath, (store) => {
+          const target = resolveGatewaySessionStoreTarget({
+            cfg,
+            key: requestedSessionKey,
+            store,
+          });
+          pruneLegacyStoreKeys({
+            store,
+            canonicalKey: target.canonicalKey,
+            candidates: target.storeKeys,
+          });
           store[canonicalSessionKey] = nextEntry;
         });
       }
+      resolvedSessionKey = canonicalSessionKey;
       if (canonicalSessionKey === mainSessionKey || canonicalSessionKey === "global") {
         context.addChatRun(idem, {
-          sessionKey: requestedSessionKey,
+          sessionKey: canonicalSessionKey,
           clientRunId: idem,
         });
         bestEffortDeliver = true;
       }
-      registerAgentRunContext(idem, { sessionKey: requestedSessionKey });
+      registerAgentRunContext(idem, { sessionKey: canonicalSessionKey });
     }
 
     const runId = idem;
@@ -351,7 +373,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         images,
         to: resolvedTo,
         sessionId: resolvedSessionId,
-        sessionKey: requestedSessionKey,
+        sessionKey: resolvedSessionKey,
         thinking: request.thinking,
         deliver,
         deliveryTargetMode,

--- a/packages/zee/Swabble/src/gateway/server-methods/sessions.ts
+++ b/packages/zee/Swabble/src/gateway/server-methods/sessions.ts
@@ -29,6 +29,7 @@ import {
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
   loadSessionEntry,
+  pruneLegacyStoreKeys,
   readSessionPreviewItemsFromTranscript,
   resolveGatewaySessionStoreTarget,
   resolveSessionTranscriptCandidates,
@@ -39,6 +40,31 @@ import {
 import { applySessionsPatchToStore } from "../sessions-patch.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import type { GatewayRequestHandlers } from "./types.js";
+
+function migrateAndPruneSessionStoreKey(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  key: string;
+  store: Record<string, SessionEntry>;
+}) {
+  const target = resolveGatewaySessionStoreTarget({
+    cfg: params.cfg,
+    key: params.key,
+    store: params.store,
+  });
+  const primaryKey = target.canonicalKey;
+  if (!params.store[primaryKey]) {
+    const existingKey = target.storeKeys.find((candidate) => Boolean(params.store[candidate]));
+    if (existingKey) {
+      params.store[primaryKey] = params.store[existingKey];
+    }
+  }
+  pruneLegacyStoreKeys({
+    store: params.store,
+    canonicalKey: primaryKey,
+    candidates: target.storeKeys,
+  });
+  return { target, primaryKey, entry: params.store[primaryKey] };
+}
 
 export const sessionsHandlers: GatewayRequestHandlers = {
   "sessions.list": ({ params, respond }) => {
@@ -102,12 +128,12 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     for (const key of keys) {
       try {
-        const target = resolveGatewaySessionStoreTarget({ cfg, key });
-        const store = storeCache.get(target.storePath) ?? loadSessionStore(target.storePath);
-        storeCache.set(target.storePath, store);
-        const entry =
-          target.storeKeys.map((candidate) => store[candidate]).find(Boolean) ??
-          store[target.canonicalKey];
+        const targetForStore = resolveGatewaySessionStoreTarget({ cfg, key, scanLegacyKeys: false });
+        const store =
+          storeCache.get(targetForStore.storePath) ?? loadSessionStore(targetForStore.storePath);
+        storeCache.set(targetForStore.storePath, store);
+        const target = resolveGatewaySessionStoreTarget({ cfg, key, store });
+        const entry = target.storeKeys.map((candidate) => store[candidate]).find(Boolean);
         if (!entry?.sessionId) {
           previews.push({ key, status: "missing", items: [] });
           continue;
@@ -132,7 +158,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     respond(true, { ts: Date.now(), previews } satisfies SessionsPreviewResult, undefined);
   },
-  "sessions.resolve": ({ params, respond }) => {
+  "sessions.resolve": async ({ params, respond }) => {
     if (!validateSessionsResolveParams(params)) {
       respond(
         false,
@@ -147,7 +173,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const p = params as import("../protocol/index.js").SessionsResolveParams;
     const cfg = loadConfig();
 
-    const resolved = resolveSessionKeyFromResolveParams({ cfg, p });
+    const resolved = await resolveSessionKeyFromResolveParams({ cfg, p });
     if (!resolved.ok) {
       respond(false, undefined, resolved.error);
       return;
@@ -177,12 +203,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const target = resolveGatewaySessionStoreTarget({ cfg, key });
     const storePath = target.storePath;
     const applied = await updateSessionStore(storePath, async (store) => {
-      const primaryKey = target.storeKeys[0] ?? key;
-      const existingKey = target.storeKeys.find((candidate) => store[candidate]);
-      if (existingKey && existingKey !== primaryKey && !store[primaryKey]) {
-        store[primaryKey] = store[existingKey];
-        delete store[existingKey];
-      }
+      const { primaryKey } = migrateAndPruneSessionStoreKey({ cfg, key, store });
       return await applySessionsPatchToStore({
         cfg,
         store,
@@ -226,12 +247,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const target = resolveGatewaySessionStoreTarget({ cfg, key });
     const storePath = target.storePath;
     const next = await updateSessionStore(storePath, (store) => {
-      const primaryKey = target.storeKeys[0] ?? key;
-      const existingKey = target.storeKeys.find((candidate) => store[candidate]);
-      if (existingKey && existingKey !== primaryKey && !store[primaryKey]) {
-        store[primaryKey] = store[existingKey];
-        delete store[existingKey];
-      }
+      const { primaryKey } = migrateAndPruneSessionStoreKey({ cfg, key, store });
       const entry = store[primaryKey];
       const now = Date.now();
       const nextEntry: SessionEntry = {
@@ -319,12 +335,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
     }
     await updateSessionStore(storePath, (store) => {
-      const primaryKey = target.storeKeys[0] ?? key;
-      const existingKey = target.storeKeys.find((candidate) => store[candidate]);
-      if (existingKey && existingKey !== primaryKey && !store[primaryKey]) {
-        store[primaryKey] = store[existingKey];
-        delete store[existingKey];
-      }
+      const { primaryKey } = migrateAndPruneSessionStoreKey({ cfg, key, store });
       if (store[primaryKey]) delete store[primaryKey];
     });
 
@@ -376,13 +387,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const storePath = target.storePath;
     // Lock + read in a short critical section; transcript work happens outside.
     const compactTarget = await updateSessionStore(storePath, (store) => {
-      const primaryKey = target.storeKeys[0] ?? key;
-      const existingKey = target.storeKeys.find((candidate) => store[candidate]);
-      if (existingKey && existingKey !== primaryKey && !store[primaryKey]) {
-        store[primaryKey] = store[existingKey];
-        delete store[existingKey];
-      }
-      return { entry: store[primaryKey], primaryKey };
+      return migrateAndPruneSessionStoreKey({ cfg, key, store });
     });
     const entry = compactTarget.entry;
     const sessionId = entry?.sessionId;

--- a/packages/zee/Swabble/src/gateway/server-node-events.ts
+++ b/packages/zee/Swabble/src/gateway/server-node-events.ts
@@ -8,7 +8,11 @@ import { enqueueSystemEvent } from "../infra/system-events.js";
 import { normalizeMainKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import type { NodeEvent, NodeEventContext } from "./server-node-events-types.js";
-import { loadSessionEntry } from "./session-utils.js";
+import {
+  loadSessionEntry,
+  pruneLegacyStoreKeys,
+  resolveGatewaySessionStoreTarget,
+} from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
 
 export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt: NodeEvent) => {
@@ -31,10 +35,21 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       const rawMainKey = normalizeMainKey(cfg.session?.mainKey);
       const sessionKey = sessionKeyRaw.length > 0 ? sessionKeyRaw : rawMainKey;
       const { storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
+      const resolvedSessionKey = canonicalKey;
       const now = Date.now();
       const sessionId = entry?.sessionId ?? randomUUID();
       if (storePath) {
         await updateSessionStore(storePath, (store) => {
+          const target = resolveGatewaySessionStoreTarget({
+            cfg,
+            key: sessionKey,
+            store,
+          });
+          pruneLegacyStoreKeys({
+            store,
+            canonicalKey: target.canonicalKey,
+            candidates: target.storeKeys,
+          });
           store[canonicalKey] = {
             sessionId,
             updatedAt: now,
@@ -52,7 +67,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       // Ensure chat UI clients refresh when this run completes (even though it wasn't started via chat.send).
       // This maps agent bus events (keyed by sessionId) to chat events (keyed by clientRunId).
       ctx.addChatRun(sessionId, {
-        sessionKey,
+        sessionKey: resolvedSessionKey,
         clientRunId: `voice-${randomUUID()}`,
       });
 
@@ -60,7 +75,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         {
           message: text,
           sessionId,
-          sessionKey,
+          sessionKey: resolvedSessionKey,
           thinking: "low",
           deliver: false,
           messageChannel: "node",
@@ -102,10 +117,21 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       const sessionKeyRaw = (link?.sessionKey ?? "").trim();
       const sessionKey = sessionKeyRaw.length > 0 ? sessionKeyRaw : `node-${nodeId}`;
       const { storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
+      const resolvedSessionKey = canonicalKey;
       const now = Date.now();
       const sessionId = entry?.sessionId ?? randomUUID();
       if (storePath) {
         await updateSessionStore(storePath, (store) => {
+          const target = resolveGatewaySessionStoreTarget({
+            cfg,
+            key: sessionKey,
+            store,
+          });
+          pruneLegacyStoreKeys({
+            store,
+            canonicalKey: target.canonicalKey,
+            candidates: target.storeKeys,
+          });
           store[canonicalKey] = {
             sessionId,
             updatedAt: now,
@@ -124,7 +150,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         {
           message,
           sessionId,
-          sessionKey,
+          sessionKey: resolvedSessionKey,
           thinking: link?.thinking ?? undefined,
           deliver,
           to,

--- a/packages/zee/Swabble/src/gateway/session-utils.key-normalization.test.ts
+++ b/packages/zee/Swabble/src/gateway/session-utils.key-normalization.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  store: {} as Record<string, unknown>,
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: () => "/tmp/ops",
+  resolveDefaultAgentId: () => "ops",
+}));
+
+vi.mock("../agents/context.js", () => ({
+  lookupContextTokens: () => undefined,
+}));
+
+vi.mock("../agents/defaults.js", () => ({
+  DEFAULT_CONTEXT_TOKENS: 8192,
+  DEFAULT_MODEL: "gpt-4o-mini",
+  DEFAULT_PROVIDER: "openai",
+}));
+
+vi.mock("../agents/model-selection.js", () => ({
+  resolveConfiguredModelRef: () => ({ provider: "openai", model: "gpt-4o-mini" }),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({}),
+}));
+
+vi.mock("../config/paths.js", () => ({
+  resolveStateDir: () => "/tmp",
+}));
+
+vi.mock("../routing/session-key.js", () => ({
+  normalizeAgentId: (value: string) => value.trim().toLowerCase(),
+  normalizeMainKey: (value?: string) =>
+    typeof value === "string" && value.trim() ? value.trim().toLowerCase() : "main",
+  parseAgentSessionKey: (value: string) => {
+    const parts = value.split(":");
+    if (parts.length < 3 || parts[0] !== "agent") return null;
+    return { agentId: parts[1], rest: parts.slice(2).join(":") };
+  },
+}));
+
+vi.mock("../utils/delivery-context.js", () => ({
+  normalizeSessionDeliveryFields: () => ({
+    deliveryContext: undefined,
+    lastChannel: undefined,
+    lastTo: undefined,
+    lastAccountId: undefined,
+    lastThreadId: undefined,
+  }),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  buildGroupDisplayName: () => undefined,
+  canonicalizeMainSessionAlias: ({
+    cfg,
+    agentId,
+    sessionKey,
+  }: {
+    cfg: { session?: { mainKey?: string } };
+    agentId: string;
+    sessionKey: string;
+  }) => {
+    const lowered = sessionKey.toLowerCase();
+    const mainKey = (cfg.session?.mainKey ?? "main").toLowerCase();
+    if (lowered === `agent:${agentId}:main` || lowered === `agent:${agentId}:${mainKey}`) {
+      return `agent:${agentId}:${mainKey}`;
+    }
+    return lowered;
+  },
+  loadSessionStore: () => mocks.store,
+  resolveMainSessionKey: (cfg: { session?: { mainKey?: string } }) =>
+    `agent:ops:${(cfg.session?.mainKey ?? "main").toLowerCase()}`,
+  resolveStorePath: (store?: string, opts?: { agentId?: string }) => {
+    if (typeof store === "string" && store.trim()) {
+      return store.replace("{agentId}", opts?.agentId ?? "ops");
+    }
+    return `/tmp/${opts?.agentId ?? "ops"}/sessions.json`;
+  },
+}));
+
+vi.mock("./session-utils.fs.js", () => ({
+  archiveFileOnDisk: vi.fn(),
+  capArrayByJsonBytes: vi.fn(),
+  readFirstUserMessageFromTranscript: () => null,
+  readLastMessagePreviewFromTranscript: () => null,
+  readSessionPreviewItemsFromTranscript: vi.fn(),
+  readSessionMessages: vi.fn(),
+  resolveSessionTranscriptCandidates: vi.fn(),
+}));
+
+import {
+  findStoreKeysIgnoreCase,
+  pruneLegacyStoreKeys,
+  resolveGatewaySessionStoreTarget,
+  resolveSessionStoreKey,
+} from "./session-utils.js";
+
+describe("session key normalization", () => {
+  it("normalizes bare and prefixed keys to lowercase", () => {
+    const cfg = { session: { mainKey: "main" }, agents: { list: [{ id: "ops", default: true }] } };
+    expect(resolveSessionStoreKey({ cfg, sessionKey: "MySession" })).toBe("agent:ops:mysession");
+    expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:ops:CoP" })).toBe("agent:ops:cop");
+  });
+
+  it("resolves mixed-case main aliases", () => {
+    const cfg = { session: { mainKey: "work" }, agents: { list: [{ id: "ops", default: true }] } };
+    expect(resolveSessionStoreKey({ cfg, sessionKey: "MAIN" })).toBe("agent:ops:work");
+    expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:ops:MAIN" })).toBe("agent:ops:work");
+  });
+
+  it("includes legacy mixed-case keys in gateway target", () => {
+    mocks.store = {
+      "agent:ops:MySession": { sessionId: "s1", updatedAt: 1 },
+      "agent:ops:mysession": { sessionId: "s2", updatedAt: 2 },
+    };
+    const cfg = {
+      session: { mainKey: "main", store: "/tmp/sessions.json" },
+      agents: { list: [{ id: "ops", default: true }] },
+    };
+
+    const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:mysession" });
+    expect(target.canonicalKey).toBe("agent:ops:mysession");
+    expect(target.storeKeys).toEqual(
+      expect.arrayContaining(["agent:ops:mysession", "agent:ops:MySession"]),
+    );
+  });
+
+  it("finds and prunes legacy key variants", () => {
+    const store: Record<string, unknown> = {
+      "agent:ops:mysession": { sessionId: "new" },
+      "agent:ops:MySession": { sessionId: "old" },
+      "agent:ops:MYSession": { sessionId: "older" },
+    };
+
+    expect(findStoreKeysIgnoreCase(store, "agent:ops:mysession")).toHaveLength(3);
+    pruneLegacyStoreKeys({
+      store,
+      canonicalKey: "agent:ops:mysession",
+      candidates: ["agent:ops:mysession", "agent:ops:MySession", "agent:ops:MYSession"],
+    });
+
+    expect(Object.keys(store)).toEqual(["agent:ops:mysession"]);
+  });
+});

--- a/packages/zee/Swabble/src/gateway/session-utils.ts
+++ b/packages/zee/Swabble/src/gateway/session-utils.ts
@@ -161,8 +161,60 @@ export function loadSessionEntry(sessionKey: string) {
   const agentId = resolveSessionStoreAgentId(cfg, canonicalKey);
   const storePath = resolveStorePath(sessionCfg?.store, { agentId });
   const store = loadSessionStore(storePath);
-  const entry = store[canonicalKey];
-  return { cfg, storePath, store, entry, canonicalKey };
+  const match = findStoreMatch(store, canonicalKey, sessionKey.trim());
+  const legacyKey = match?.key !== canonicalKey ? match?.key : undefined;
+  return { cfg, storePath, store, entry: match?.entry, canonicalKey, legacyKey };
+}
+
+function findStoreMatch(
+  store: Record<string, SessionEntry>,
+  ...candidates: string[]
+): { entry: SessionEntry; key: string } | undefined {
+  for (const candidate of candidates) {
+    if (candidate && store[candidate]) {
+      return { entry: store[candidate], key: candidate };
+    }
+  }
+  const loweredSet = new Set(candidates.filter(Boolean).map((candidate) => candidate.toLowerCase()));
+  for (const key of Object.keys(store)) {
+    if (loweredSet.has(key.toLowerCase())) {
+      return { entry: store[key], key };
+    }
+  }
+  return undefined;
+}
+
+export function findStoreKeysIgnoreCase(store: Record<string, unknown>, targetKey: string): string[] {
+  const lowered = targetKey.toLowerCase();
+  const matches: string[] = [];
+  for (const key of Object.keys(store)) {
+    if (key.toLowerCase() === lowered) {
+      matches.push(key);
+    }
+  }
+  return matches;
+}
+
+export function pruneLegacyStoreKeys(params: {
+  store: Record<string, unknown>;
+  canonicalKey: string;
+  candidates?: string[];
+}) {
+  const canonical = params.canonicalKey;
+  const toDelete = new Set<string>();
+  for (const candidate of params.candidates ?? []) {
+    if (candidate && candidate !== canonical) {
+      toDelete.add(candidate);
+    }
+  }
+  for (const variant of findStoreKeysIgnoreCase(params.store, canonical)) {
+    if (variant !== canonical) {
+      toDelete.add(variant);
+    }
+  }
+  for (const candidate of toDelete) {
+    delete params.store[candidate];
+  }
 }
 
 export function classifySessionKey(key: string, entry?: SessionEntry): GatewaySessionRow["kind"] {
@@ -296,9 +348,10 @@ export function listAgentsForGateway(cfg: ZeeConfig): {
 }
 
 function canonicalizeSessionKeyForAgent(agentId: string, key: string): string {
-  if (key === "global" || key === "unknown") return key;
-  if (key.startsWith("agent:")) return key;
-  return `agent:${normalizeAgentId(agentId)}:${key}`;
+  const lowered = key.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") return lowered;
+  if (lowered.startsWith("agent:")) return lowered;
+  return `agent:${normalizeAgentId(agentId)}:${lowered}`;
 }
 
 function resolveDefaultStoreAgentId(cfg: ZeeConfig): string {
@@ -308,26 +361,27 @@ function resolveDefaultStoreAgentId(cfg: ZeeConfig): string {
 export function resolveSessionStoreKey(params: { cfg: ZeeConfig; sessionKey: string }): string {
   const raw = params.sessionKey.trim();
   if (!raw) return raw;
-  if (raw === "global" || raw === "unknown") return raw;
+  const loweredRaw = raw.toLowerCase();
+  if (loweredRaw === "global" || loweredRaw === "unknown") return loweredRaw;
 
-  const parsed = parseAgentSessionKey(raw);
+  const parsed = parseAgentSessionKey(loweredRaw);
   if (parsed) {
     const agentId = normalizeAgentId(parsed.agentId);
     const canonical = canonicalizeMainSessionAlias({
       cfg: params.cfg,
       agentId,
-      sessionKey: raw,
+      sessionKey: loweredRaw,
     });
-    if (canonical !== raw) return canonical;
-    return raw;
+    if (canonical !== loweredRaw) return canonical;
+    return loweredRaw;
   }
 
   const rawMainKey = normalizeMainKey(params.cfg.session?.mainKey);
-  if (raw === "main" || raw === rawMainKey) {
+  if (loweredRaw === "main" || loweredRaw === rawMainKey) {
     return resolveMainSessionKey(params.cfg);
   }
   const agentId = resolveDefaultStoreAgentId(params.cfg);
-  return canonicalizeSessionKeyForAgent(agentId, raw);
+  return canonicalizeSessionKeyForAgent(agentId, loweredRaw);
 }
 
 function resolveSessionStoreAgentId(cfg: ZeeConfig, canonicalKey: string): string {
@@ -339,15 +393,29 @@ function resolveSessionStoreAgentId(cfg: ZeeConfig, canonicalKey: string): strin
   return resolveDefaultStoreAgentId(cfg);
 }
 
-function canonicalizeSpawnedByForAgent(agentId: string, spawnedBy?: string): string | undefined {
+export function canonicalizeSpawnedByForAgent(
+  cfg: ZeeConfig,
+  agentId: string,
+  spawnedBy?: string,
+): string | undefined {
   const raw = spawnedBy?.trim();
   if (!raw) return undefined;
-  if (raw === "global" || raw === "unknown") return raw;
-  if (raw.startsWith("agent:")) return raw;
-  return `agent:${normalizeAgentId(agentId)}:${raw}`;
+  const lowered = raw.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") return lowered;
+  const prefixed = lowered.startsWith("agent:")
+    ? lowered
+    : `agent:${normalizeAgentId(agentId)}:${lowered}`;
+  const parsed = parseAgentSessionKey(prefixed);
+  const resolvedAgent = parsed?.agentId ? normalizeAgentId(parsed.agentId) : normalizeAgentId(agentId);
+  return canonicalizeMainSessionAlias({ cfg, agentId: resolvedAgent, sessionKey: prefixed });
 }
 
-export function resolveGatewaySessionStoreTarget(params: { cfg: ZeeConfig; key: string }): {
+export function resolveGatewaySessionStoreTarget(params: {
+  cfg: ZeeConfig;
+  key: string;
+  scanLegacyKeys?: boolean;
+  store?: Record<string, SessionEntry>;
+}): {
   agentId: string;
   storePath: string;
   canonicalKey: string;
@@ -363,13 +431,23 @@ export function resolveGatewaySessionStoreTarget(params: { cfg: ZeeConfig; key: 
   const storePath = resolveStorePath(storeConfig, { agentId });
 
   if (canonicalKey === "global" || canonicalKey === "unknown") {
-    const storeKeys = key && key !== canonicalKey ? [canonicalKey, key] : [key];
+    const storeKeys = key && key !== canonicalKey ? [canonicalKey, key] : [canonicalKey];
     return { agentId, storePath, canonicalKey, storeKeys };
   }
 
   const storeKeys = new Set<string>();
   storeKeys.add(canonicalKey);
   if (key && key !== canonicalKey) storeKeys.add(key);
+  if (params.scanLegacyKeys !== false) {
+    const store = params.store ?? loadSessionStore(storePath);
+    const scanTargets = new Set(storeKeys);
+    scanTargets.add(`agent:${agentId}:main`);
+    for (const targetKey of scanTargets) {
+      for (const variant of findStoreKeysIgnoreCase(store, targetKey)) {
+        storeKeys.add(variant);
+      }
+    }
+  }
   return {
     agentId,
     storePath,
@@ -380,25 +458,26 @@ export function resolveGatewaySessionStoreTarget(params: { cfg: ZeeConfig; key: 
 
 // Merge with existing entry based on latest timestamp to ensure data consistency and avoid overwriting with less complete data.
 function mergeSessionEntryIntoCombined(params: {
+  cfg: ZeeConfig;
   combined: Record<string, SessionEntry>;
   entry: SessionEntry;
   agentId: string;
   canonicalKey: string;
 }) {
-  const { combined, entry, agentId, canonicalKey } = params;
+  const { cfg, combined, entry, agentId, canonicalKey } = params;
   const existing = combined[canonicalKey];
 
   if (existing && (existing.updatedAt ?? 0) > (entry.updatedAt ?? 0)) {
     combined[canonicalKey] = {
       ...entry,
       ...existing,
-      spawnedBy: canonicalizeSpawnedByForAgent(agentId, existing.spawnedBy ?? entry.spawnedBy),
+      spawnedBy: canonicalizeSpawnedByForAgent(cfg, agentId, existing.spawnedBy ?? entry.spawnedBy),
     };
   } else {
     combined[canonicalKey] = {
       ...existing,
       ...entry,
-      spawnedBy: canonicalizeSpawnedByForAgent(agentId, entry.spawnedBy ?? existing?.spawnedBy),
+      spawnedBy: canonicalizeSpawnedByForAgent(cfg, agentId, entry.spawnedBy ?? existing?.spawnedBy),
     };
   }
 }
@@ -416,6 +495,7 @@ export function loadCombinedSessionStoreForGateway(cfg: ZeeConfig): {
     for (const [key, entry] of Object.entries(store)) {
       const canonicalKey = canonicalizeSessionKeyForAgent(defaultAgentId, key);
       mergeSessionEntryIntoCombined({
+        cfg,
         combined,
         entry,
         agentId: defaultAgentId,
@@ -433,6 +513,7 @@ export function loadCombinedSessionStoreForGateway(cfg: ZeeConfig): {
     for (const [key, entry] of Object.entries(store)) {
       const canonicalKey = canonicalizeSessionKeyForAgent(agentId, key);
       mergeSessionEntryIntoCombined({
+        cfg,
         combined,
         entry,
         agentId,

--- a/packages/zee/Swabble/src/gateway/sessions-resolve.ts
+++ b/packages/zee/Swabble/src/gateway/sessions-resolve.ts
@@ -1,5 +1,5 @@
 import type { ZeeConfig } from "../config/config.js";
-import { loadSessionStore } from "../config/sessions.js";
+import { loadSessionStore, updateSessionStore } from "../config/sessions.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
 import {
   ErrorCodes,
@@ -15,10 +15,10 @@ import {
 
 export type SessionsResolveResult = { ok: true; key: string } | { ok: false; error: ErrorShape };
 
-export function resolveSessionKeyFromResolveParams(params: {
+export async function resolveSessionKeyFromResolveParams(params: {
   cfg: ZeeConfig;
   p: SessionsResolveParams;
-}): SessionsResolveResult {
+}): Promise<SessionsResolveResult> {
   const { cfg, p } = params;
 
   const key = typeof p.key === "string" ? p.key.trim() : "";
@@ -46,13 +46,26 @@ export function resolveSessionKeyFromResolveParams(params: {
   if (hasKey) {
     const target = resolveGatewaySessionStoreTarget({ cfg, key });
     const store = loadSessionStore(target.storePath);
-    const existingKey = target.storeKeys.find((candidate) => store[candidate]);
-    if (!existingKey) {
+    if (store[target.canonicalKey]) {
+      return { ok: true, key: target.canonicalKey };
+    }
+    const legacyKey = target.storeKeys.find((candidate) => store[candidate]);
+    if (!legacyKey) {
       return {
         ok: false,
         error: errorShape(ErrorCodes.INVALID_REQUEST, `No session found: ${key}`),
       };
     }
+    await updateSessionStore(target.storePath, (next) => {
+      if (!next[target.canonicalKey] && next[legacyKey]) {
+        next[target.canonicalKey] = next[legacyKey];
+      }
+      for (const candidate of target.storeKeys) {
+        if (candidate !== target.canonicalKey && next[candidate]) {
+          delete next[candidate];
+        }
+      }
+    });
     return { ok: true, key: target.canonicalKey };
   }
 


### PR DESCRIPTION
## Summary
- normalize session key casing in gateway canonicalization paths to prevent mixed-case ghost sessions
- add case-insensitive key lookup/pruning helpers and use them in session, agent, and node-event write paths
- make `sessions.resolve` async so it can migrate legacy case-variant keys to canonical keys in-place
- ensure sessions patch/reset/delete/compact paths migrate + prune all legacy case variants
- add focused gateway key-normalization tests and adapt agent handler tests to the new helpers

## Testing
- `cd packages/zee/Swabble && bunx vitest run --config /tmp/vitest-no-setup.config.cjs src/gateway/session-utils.key-normalization.test.ts src/gateway/server-methods/agent.test.ts`

Closes #337