### PR TITLE
chore(build): add root build scripts and runtime engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "packageManager": "bun@1.3.5",
   "scripts": {
     "dev": "bun run --cwd packages/zee --conditions=browser src/index.ts",
+    "build:zee": "bun run --cwd packages/zee build",
+    "verify:binary": "cd packages/zee && bun run build && ./script/verify-binary.sh",
     "boundaries:check": "depcruise --config .dependency-cruiser.cjs --ts-config $(pwd)/packages/zee/tsconfig.json --output-type err packages/zee/src",
     "typecheck": "bun run --cwd packages/zee typecheck",
     "prepare": "husky",
@@ -86,6 +88,10 @@
     "google-auth-library": "9.15.1",
     "jsonc-parser": "3.3.1",
     "typescript": "catalog:"
+  },
+  "engines": {
+    "bun": ">=1.3.5",
+    "node": ">=22.0.0"
   },
   "license": "MIT",
   "prettier": {


### PR DESCRIPTION
## Summary
- add root build scripts for package-level build and binary verification
- add Bun/Node engine metadata to make runtime requirements explicit

## Validation
- node -e "const p=require('./package.json'); console.log(p.scripts['build:zee']); console.log(p.scripts['verify:binary']); console.log(JSON.stringify(p.engines));"

Closes #328