### PR TITLE
fix(session): preserve resolved model on compaction continue

### DIFF
--- a/packages/zee/src/session/compaction.ts
+++ b/packages/zee/src/session/compaction.ts
@@ -220,7 +220,12 @@ When constructing the summary, try to stick to this template:
           created: Date.now(),
         },
         agent: userMessage.agent,
-        model: userMessage.model,
+        // Persist the resolved model used during compaction so follow-up turns
+        // don't inherit stale provider/model metadata from the parent message.
+        model: {
+          providerID: model.providerID,
+          modelID: model.id,
+        },
       })
       await Session.updatePart({
         id: Identifier.ascending("part"),


### PR DESCRIPTION
## Summary
- persist the resolved compaction model metadata on the synthetic continue user message
- avoid carrying stale provider/model metadata from the parent message

## Testing
- bun test test/session/compaction.test.ts

Closes #311