### PR TITLE
feat(cli): add inspect and usage helper commands

### DIFF
--- a/packages/zee/Swabble/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/packages/zee/Swabble/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../agents/pi-embedded.js", () => ({
 vi.mock("../../config/sessions.js", () => ({
   resolveGroupSessionKey: vi.fn().mockReturnValue(undefined),
   resolveSessionFilePath: vi.fn().mockReturnValue("/tmp/session.jsonl"),
+  resolveSessionFilePathOptions: vi.fn().mockReturnValue({ agentId: "default" }),
   updateSessionStore: vi.fn(),
 }));
 
@@ -169,8 +170,8 @@ describe("runPreparedReply media-only handling", () => {
     expect(call).toBeTruthy();
     expect(call?.followupRun.prompt).toContain("[Thread starter - for context]");
     expect(call?.followupRun.prompt).toContain("Earlier message in this thread");
-    expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
-    expect(call?.commandBody).toContain("[User sent media without caption]");
+    expect(call?.followupRun.prompt).toContain("[media attached: /tmp/input.png]");
+    expect(call?.commandBody).toContain("[media attached: /tmp/input.png]");
   });
 
   it("returns the empty-body reply when there is no text and no media", async () => {

--- a/packages/zee/Swabble/src/config/sessions/paths.test.ts
+++ b/packages/zee/Swabble/src/config/sessions/paths.test.ts
@@ -36,7 +36,7 @@ describe("session paths", () => {
     expect(resolved).toBe(path.resolve(sessionsDir, "abc-123-topic-42.jsonl"));
   });
 
-  it("leaves absolute sessionFile paths outside the sessions directory unchanged", () => {
+  it("falls back to default session path for absolute sessionFile paths outside the sessions directory", () => {
     const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
     const outsidePath = path.resolve(path.dirname(sessionsDir), "work", "sessions", "abc-123.jsonl");
 
@@ -46,7 +46,7 @@ describe("session paths", () => {
       { agentId: "main" },
     );
 
-    expect(resolved).toBe(outsidePath);
+    expect(resolved).toBe(path.resolve(sessionsDir, "sess-1.jsonl"));
   });
 
   it("prefers storePath when resolving session file options", () => {

--- a/packages/zee/Swabble/src/gateway/session-utils.list-agents.test.ts
+++ b/packages/zee/Swabble/src/gateway/session-utils.list-agents.test.ts
@@ -27,7 +27,7 @@ beforeAll(async () => {
 })
 
 describe("listAgentsForGateway", () => {
-  it("does not append phantom main when agents.list excludes main", () => {
+  it("includes mainKey alongside explicit agents", () => {
     const result = listAgentsForGateway({
       agents: {
         list: [{ id: "ops" }],
@@ -36,7 +36,7 @@ describe("listAgentsForGateway", () => {
 
     expect(result.defaultId).toBe("ops")
     expect(result.mainKey).toBe("main")
-    expect(result.agents.map((agent) => agent.id)).toEqual(["ops"])
+    expect(result.agents.map((agent) => agent.id)).toEqual(["ops", "main"])
   })
 
   it("keeps main in listing when no explicit allowlist exists", () => {

--- a/packages/zee/Swabble/src/gateway/tools-invoke-http.test.ts
+++ b/packages/zee/Swabble/src/gateway/tools-invoke-http.test.ts
@@ -242,6 +242,8 @@ describe("POST /tools/invoke", () => {
         },
       ],
     } as any;
+    // Let file-backed gateway.auth include rateLimit for this test.
+    testState.gatewayAuth = undefined;
 
     const { writeConfigFile } = await import("../config/config.js");
     await writeConfigFile({

--- a/packages/zee/src/cli/cmd/inspect.ts
+++ b/packages/zee/src/cli/cmd/inspect.ts
@@ -1,0 +1,255 @@
+import type { Argv } from "yargs"
+import { cmd } from "./cmd"
+import { bootstrap } from "../bootstrap"
+import { Session } from "../../session"
+import { SessionStatus } from "../../session/status"
+import { collectRuntimeSnapshot } from "./runtime-process-guard"
+import * as UsageStorage from "../../usage/storage"
+import type { UsagePeriod, UsageStats, UsageSummary } from "../../usage/types"
+import { buildUsageBreakdown, sortUsageBreakdown, type UsageBreakdownRow } from "./usage"
+import { formatCost, formatTokens } from "../../usage/pricing"
+
+type InspectStateArgs = {
+  json?: boolean
+}
+
+type InspectOpsArgs = {
+  json?: boolean
+  usagePeriod?: string
+  usageTop?: number
+}
+
+const USAGE_PERIODS = ["hour", "day", "week", "month", "all"] as const
+
+type SessionQueueSnapshot = {
+  sessions: {
+    total: number
+    roots: number
+    children: number
+  }
+  queue: {
+    totalTracked: number
+    busy: number
+    retry: number
+  }
+}
+
+export type InspectUsageSnapshot = {
+  period: UsagePeriod
+  summary: UsageSummary
+  stats: UsageStats
+  topProviders: UsageBreakdownRow[]
+  topModels: UsageBreakdownRow[]
+}
+
+export function resolveInspectUsagePeriod(raw: string | undefined, fallback: UsagePeriod): UsagePeriod {
+  return (USAGE_PERIODS as readonly string[]).includes(raw ?? "") ? (raw as UsagePeriod) : fallback
+}
+
+export function resolveInspectUsageTop(raw: number | undefined, fallback: number): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return fallback
+  return Math.max(1, Math.floor(raw))
+}
+
+export function buildInspectUsageSnapshot(params: {
+  period: UsagePeriod
+  summary: UsageSummary
+  stats: UsageStats
+  top: number
+}): InspectUsageSnapshot {
+  const topProviders = sortUsageBreakdown(buildUsageBreakdown(params.summary, "provider"), "cost").slice(
+    0,
+    params.top,
+  )
+  const topModels = sortUsageBreakdown(buildUsageBreakdown(params.summary, "model"), "cost").slice(0, params.top)
+
+  return {
+    period: params.period,
+    summary: params.summary,
+    stats: params.stats,
+    topProviders,
+    topModels,
+  }
+}
+
+async function gatherSessionQueueSnapshot(): Promise<SessionQueueSnapshot> {
+  const sessions = [] as Session.Info[]
+  for await (const session of Session.list()) {
+    sessions.push(session)
+  }
+
+  const statusBySession = SessionStatus.list()
+  const statusSummary = {
+    totalTracked: Object.keys(statusBySession).length,
+    busy: Object.values(statusBySession).filter((status) => status.type === "busy").length,
+    retry: Object.values(statusBySession).filter((status) => status.type === "retry").length,
+  }
+
+  return {
+    sessions: {
+      total: sessions.length,
+      roots: sessions.filter((session) => !session.parentID).length,
+      children: sessions.filter((session) => Boolean(session.parentID)).length,
+    },
+    queue: statusSummary,
+  }
+}
+
+async function gatherUsageSnapshot(params: {
+  period: UsagePeriod
+  top: number
+}): Promise<InspectUsageSnapshot> {
+  await UsageStorage.init()
+  try {
+    const summary = UsageStorage.getSummary({ period: params.period })
+    const stats = UsageStorage.getStats()
+    return buildInspectUsageSnapshot({
+      period: params.period,
+      summary,
+      stats,
+      top: params.top,
+    })
+  } finally {
+    await UsageStorage.close()
+  }
+}
+
+const InspectStateCommand = cmd({
+  command: "state",
+  describe: "print a machine-readable runtime/session snapshot",
+  builder: (yargs: Argv) =>
+    yargs.option("json", {
+      type: "boolean",
+      default: true,
+      describe: "output as JSON",
+    }),
+  handler: async (args: InspectStateArgs) => {
+    const runtime = await collectRuntimeSnapshot()
+
+    await bootstrap(process.cwd(), async () => {
+      const sessionQueue = await gatherSessionQueueSnapshot()
+
+      const payload = {
+        generatedAt: new Date().toISOString(),
+        runtime,
+        sessions: sessionQueue.sessions,
+        queue: sessionQueue.queue,
+      }
+
+      if (args.json !== false) {
+        console.log(JSON.stringify(payload, null, 2))
+        return
+      }
+
+      console.log(
+        `runtime total=${runtime.counts.total} mcp=${runtime.counts.mcpServers} clients=${runtime.counts.clients}`,
+      )
+      console.log(
+        `sessions total=${payload.sessions.total} roots=${payload.sessions.roots} children=${payload.sessions.children}`,
+      )
+      console.log(
+        `queue tracked=${payload.queue.totalTracked} busy=${payload.queue.busy} retry=${payload.queue.retry}`,
+      )
+      if (runtime.violations.length > 0) {
+        console.log("violations:")
+        for (const violation of runtime.violations) {
+          console.log(`- ${violation}`)
+        }
+      }
+    })
+  },
+})
+
+const InspectOpsCommand = cmd({
+  command: "ops",
+  describe: "print consolidated ops report (runtime, sessions, queue, usage)",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("json", {
+        type: "boolean",
+        default: true,
+        describe: "output as JSON",
+      })
+      .option("usage-period", {
+        type: "string",
+        choices: USAGE_PERIODS,
+        default: "day",
+        describe: "usage aggregation period",
+      })
+      .option("usage-top", {
+        type: "number",
+        default: 5,
+        describe: "top providers/models to include",
+      }),
+  handler: async (args: InspectOpsArgs) => {
+    const usagePeriod = resolveInspectUsagePeriod(args.usagePeriod, "day")
+    const usageTop = resolveInspectUsageTop(args.usageTop, 5)
+    const runtime = await collectRuntimeSnapshot()
+
+    await bootstrap(process.cwd(), async () => {
+      const [sessionQueue, usage] = await Promise.all([
+        gatherSessionQueueSnapshot(),
+        gatherUsageSnapshot({ period: usagePeriod, top: usageTop }),
+      ])
+
+      const payload = {
+        generatedAt: new Date().toISOString(),
+        runtime,
+        sessions: sessionQueue.sessions,
+        queue: sessionQueue.queue,
+        usage,
+      }
+
+      if (args.json !== false) {
+        console.log(JSON.stringify(payload, null, 2))
+        return
+      }
+
+      console.log(
+        `runtime total=${runtime.counts.total} mcp=${runtime.counts.mcpServers} clients=${runtime.counts.clients}`,
+      )
+      console.log(
+        `sessions total=${payload.sessions.total} roots=${payload.sessions.roots} children=${payload.sessions.children}`,
+      )
+      console.log(
+        `queue tracked=${payload.queue.totalTracked} busy=${payload.queue.busy} retry=${payload.queue.retry}`,
+      )
+      console.log(
+        `usage period=${usage.period} requests=${usage.summary.totalRequests} tokens=${formatTokens(usage.summary.totalInputTokens + usage.summary.totalOutputTokens)} cost=${formatCost(usage.summary.totalCost)}`,
+      )
+
+      if (usage.topProviders.length > 0) {
+        console.log("top providers:")
+        for (const provider of usage.topProviders) {
+          console.log(
+            `- ${provider.id} requests=${provider.requests} tokens=${formatTokens(provider.tokens)} cost=${formatCost(provider.cost)}`,
+          )
+        }
+      }
+
+      if (usage.topModels.length > 0) {
+        console.log("top models:")
+        for (const model of usage.topModels) {
+          const prefix = model.providerId ? `${model.providerId}/` : ""
+          console.log(
+            `- ${prefix}${model.id} requests=${model.requests} tokens=${formatTokens(model.tokens)} cost=${formatCost(model.cost)}`,
+          )
+        }
+      }
+
+      if (runtime.violations.length > 0) {
+        console.log("violations:")
+        for (const violation of runtime.violations) {
+          console.log(`- ${violation}`)
+        }
+      }
+    })
+  },
+})
+
+export const InspectCommand = cmd({
+  command: "inspect",
+  describe: "inspect runtime state",
+  builder: (yargs: Argv) => yargs.command(InspectStateCommand).command(InspectOpsCommand).demandCommand(),
+  async handler() {},
+})

--- a/packages/zee/src/cli/cmd/usage.ts
+++ b/packages/zee/src/cli/cmd/usage.ts
@@ -1,0 +1,295 @@
+import type { Argv } from "yargs"
+import { cmd } from "./cmd"
+import * as UsageStorage from "../../usage/storage"
+import { formatCost, formatTokens } from "../../usage/pricing"
+import type { UsagePeriod, UsageStats, UsageSummary } from "../../usage/types"
+
+const PERIODS = ["hour", "day", "week", "month", "all"] as const
+const BREAKDOWN_BY = ["model", "provider"] as const
+const SORT_BY = ["cost", "tokens", "requests"] as const
+
+type UsageBreakdownBy = (typeof BREAKDOWN_BY)[number]
+type UsageSortBy = (typeof SORT_BY)[number]
+
+type UsageDashboardArgs = {
+  period?: string
+  top?: number
+  json?: boolean
+}
+
+type UsageTopArgs = {
+  period?: string
+  by?: string
+  sort?: string
+  limit?: number
+  json?: boolean
+}
+
+export type UsageBreakdownRow = {
+  id: string
+  providerId?: string
+  modelName?: string
+  requests: number
+  tokens: number
+  cost: number
+  avgLatencyMs?: number
+}
+
+export function buildUsageBreakdown(
+  summary: UsageSummary,
+  by: UsageBreakdownBy,
+): UsageBreakdownRow[] {
+  if (by === "provider") {
+    return Object.values(summary.byProvider).map((provider) => ({
+      id: provider.providerId,
+      requests: provider.requests,
+      tokens: provider.inputTokens + provider.outputTokens,
+      cost: provider.cost,
+    }))
+  }
+
+  return Object.values(summary.byModel).map((model) => ({
+    id: model.modelId,
+    providerId: model.providerId,
+    modelName: model.modelName,
+    requests: model.requests,
+    tokens: model.inputTokens + model.outputTokens,
+    cost: model.cost,
+    avgLatencyMs: model.avgLatencyMs,
+  }))
+}
+
+export function sortUsageBreakdown(rows: UsageBreakdownRow[], sortBy: UsageSortBy): UsageBreakdownRow[] {
+  const list = rows.slice()
+  list.sort((a, b) => {
+    switch (sortBy) {
+      case "requests":
+        if (b.requests !== a.requests) return b.requests - a.requests
+        break
+      case "tokens":
+        if (b.tokens !== a.tokens) return b.tokens - a.tokens
+        break
+      case "cost":
+      default:
+        if (b.cost !== a.cost) return b.cost - a.cost
+        break
+    }
+
+    if (b.requests !== a.requests) return b.requests - a.requests
+    return a.id.localeCompare(b.id)
+  })
+  return list
+}
+
+export function renderUsageDashboardLines(params: {
+  period: UsagePeriod
+  summary: UsageSummary
+  stats: UsageStats
+  topProviders: UsageBreakdownRow[]
+  topModels: UsageBreakdownRow[]
+}): string[] {
+  const { period, summary, stats, topProviders, topModels } = params
+  const lines: string[] = []
+
+  lines.push(`Usage dashboard (period=${period})`)
+  lines.push(
+    `Total: requests=${summary.totalRequests} tokens=${formatTokens(summary.totalInputTokens + summary.totalOutputTokens)} cost=${formatCost(summary.totalCost)}`,
+  )
+  lines.push(
+    `Quality: avg_latency=${Math.round(summary.avgLatencyMs)}ms errors=${summary.errorCount} (${(summary.errorRate * 100).toFixed(1)}%) cache_hit=${(summary.cacheHitRate * 100).toFixed(1)}%`,
+  )
+  lines.push("")
+
+  lines.push("Quick window snapshot:")
+  lines.push(
+    `- today: requests=${stats.todayRequests} tokens=${formatTokens(stats.todayTokens)} cost=${formatCost(stats.todayCost)}`,
+  )
+  lines.push(`- week: requests=${stats.weekRequests} cost=${formatCost(stats.weekCost)}`)
+  lines.push(`- month: requests=${stats.monthRequests} cost=${formatCost(stats.monthCost)}`)
+  if (stats.lastRequestAt) {
+    lines.push(`- last_request: ${new Date(stats.lastRequestAt).toISOString()}`)
+  }
+  lines.push("")
+
+  lines.push("Top providers:")
+  if (topProviders.length === 0) {
+    lines.push("- none")
+  } else {
+    for (const row of topProviders) {
+      lines.push(
+        `- ${row.id}: requests=${row.requests} tokens=${formatTokens(row.tokens)} cost=${formatCost(row.cost)}`,
+      )
+    }
+  }
+  lines.push("")
+
+  lines.push("Top models:")
+  if (topModels.length === 0) {
+    lines.push("- none")
+  } else {
+    for (const row of topModels) {
+      const provider = row.providerId ? `${row.providerId}/` : ""
+      lines.push(
+        `- ${provider}${row.id}: requests=${row.requests} tokens=${formatTokens(row.tokens)} cost=${formatCost(row.cost)}`,
+      )
+    }
+  }
+
+  return lines
+}
+
+function resolveUsagePeriod(raw: string | undefined, fallback: UsagePeriod): UsagePeriod {
+  return (PERIODS as readonly string[]).includes(raw ?? "") ? (raw as UsagePeriod) : fallback
+}
+
+function resolveBreakdownBy(raw: string | undefined): UsageBreakdownBy {
+  return (BREAKDOWN_BY as readonly string[]).includes(raw ?? "")
+    ? (raw as UsageBreakdownBy)
+    : "model"
+}
+
+function resolveSortBy(raw: string | undefined): UsageSortBy {
+  return (SORT_BY as readonly string[]).includes(raw ?? "") ? (raw as UsageSortBy) : "cost"
+}
+
+async function withUsageStorage<T>(fn: () => Promise<T>): Promise<T> {
+  await UsageStorage.init()
+  try {
+    return await fn()
+  } finally {
+    await UsageStorage.close()
+  }
+}
+
+const UsageTopCommand = cmd({
+  command: "top",
+  describe: "show top usage rows by cost, tokens, or requests",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("period", {
+        type: "string",
+        choices: PERIODS,
+        default: "month",
+        describe: "aggregation period",
+      })
+      .option("by", {
+        type: "string",
+        choices: BREAKDOWN_BY,
+        default: "model",
+        describe: "breakdown target",
+      })
+      .option("sort", {
+        type: "string",
+        choices: SORT_BY,
+        default: "cost",
+        describe: "sort metric",
+      })
+      .option("limit", {
+        type: "number",
+        default: 10,
+        describe: "rows to display",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: UsageTopArgs) => {
+    const by = resolveBreakdownBy(args.by)
+    const sort = resolveSortBy(args.sort)
+    const limit = Number.isFinite(args.limit) ? Math.max(1, Math.floor(args.limit ?? 10)) : 10
+    const period = resolveUsagePeriod(args.period, "month")
+
+    await withUsageStorage(async () => {
+      const summary = UsageStorage.getSummary({ period })
+      const rows = sortUsageBreakdown(buildUsageBreakdown(summary, by), sort).slice(0, limit)
+
+      if (args.json) {
+        console.log(
+          JSON.stringify(
+            {
+              generatedAt: new Date().toISOString(),
+              period,
+              by,
+              sort,
+              limit,
+              totalRows: rows.length,
+              rows,
+            },
+            null,
+            2,
+          ),
+        )
+        return
+      }
+
+      console.log(`Top usage (period=${period}, by=${by}, sort=${sort}, limit=${limit})`)
+      if (rows.length === 0) {
+        console.log("No usage rows found")
+        return
+      }
+
+      for (const row of rows) {
+        const prefix = by === "model" && row.providerId ? `${row.providerId}/` : ""
+        console.log(
+          `${prefix}${row.id} requests=${row.requests} tokens=${formatTokens(row.tokens)} cost=${formatCost(row.cost)}`,
+        )
+      }
+    })
+  },
+})
+
+export const UsageCommand = cmd({
+  command: "usage",
+  describe: "show usage dashboard and cost/token leaders",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("period", {
+        type: "string",
+        choices: PERIODS,
+        default: "day",
+        describe: "dashboard period",
+      })
+      .option("top", {
+        type: "number",
+        default: 5,
+        describe: "top providers/models to include in dashboard",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      })
+      .command(UsageTopCommand),
+  handler: async (args: UsageDashboardArgs) => {
+    const period = resolveUsagePeriod(args.period, "day")
+    const top = Number.isFinite(args.top) ? Math.max(1, Math.floor(args.top ?? 5)) : 5
+
+    await withUsageStorage(async () => {
+      const summary = UsageStorage.getSummary({ period })
+      const stats = UsageStorage.getStats()
+
+      const topProviders = sortUsageBreakdown(buildUsageBreakdown(summary, "provider"), "cost").slice(0, top)
+      const topModels = sortUsageBreakdown(buildUsageBreakdown(summary, "model"), "cost").slice(0, top)
+
+      const payload = {
+        generatedAt: new Date().toISOString(),
+        period,
+        top,
+        summary,
+        stats,
+        topProviders,
+        topModels,
+      }
+
+      if (args.json) {
+        console.log(JSON.stringify(payload, null, 2))
+        return
+      }
+
+      for (const line of renderUsageDashboardLines({ period, summary, stats, topProviders, topModels })) {
+        console.log(line)
+      }
+    })
+  },
+})

--- a/packages/zee/test/cli/inspect-command.test.ts
+++ b/packages/zee/test/cli/inspect-command.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildInspectUsageSnapshot,
+  resolveInspectUsagePeriod,
+  resolveInspectUsageTop,
+} from "../../src/cli/cmd/inspect"
+import type { UsageStats, UsageSummary } from "../../src/usage/types"
+
+function makeSummary(): UsageSummary {
+  return {
+    period: "day",
+    startTime: 1_700_000_000_000,
+    endTime: 1_700_000_086_400,
+    totalRequests: 14,
+    totalInputTokens: 48_000,
+    totalOutputTokens: 22_000,
+    totalCost: 1.45,
+    byProvider: {
+      openai: {
+        providerId: "openai",
+        requests: 9,
+        inputTokens: 28_000,
+        outputTokens: 12_000,
+        cost: 1.05,
+        models: ["gpt-4o"],
+      },
+      anthropic: {
+        providerId: "anthropic",
+        requests: 5,
+        inputTokens: 20_000,
+        outputTokens: 10_000,
+        cost: 0.4,
+        models: ["claude-sonnet-4-5"],
+      },
+    },
+    byModel: {
+      "gpt-4o": {
+        modelId: "gpt-4o",
+        modelName: "GPT-4o",
+        providerId: "openai",
+        requests: 9,
+        inputTokens: 28_000,
+        outputTokens: 12_000,
+        cost: 1.05,
+        avgLatencyMs: 720,
+      },
+      "claude-sonnet-4-5": {
+        modelId: "claude-sonnet-4-5",
+        modelName: "Claude Sonnet 4.5",
+        providerId: "anthropic",
+        requests: 5,
+        inputTokens: 20_000,
+        outputTokens: 10_000,
+        cost: 0.4,
+        avgLatencyMs: 940,
+      },
+    },
+    avgLatencyMs: 800,
+    errorCount: 0,
+    errorRate: 0,
+    cacheHitRate: 0.3,
+  }
+}
+
+function makeStats(): UsageStats {
+  return {
+    todayRequests: 14,
+    todayCost: 1.45,
+    todayTokens: 70_000,
+    weekRequests: 53,
+    weekCost: 4.9,
+    monthRequests: 203,
+    monthCost: 16.2,
+    topModel: { modelId: "gpt-4o", cost: 8.5 },
+    topProvider: { providerId: "openai", cost: 12.2 },
+    lastRequestAt: 1_700_000_086_400,
+  }
+}
+
+describe("inspect command helpers", () => {
+  test("resolveInspectUsagePeriod falls back for invalid values", () => {
+    expect(resolveInspectUsagePeriod("day", "week")).toBe("day")
+    expect(resolveInspectUsagePeriod("invalid", "week")).toBe("week")
+    expect(resolveInspectUsagePeriod(undefined, "month")).toBe("month")
+  })
+
+  test("resolveInspectUsageTop enforces positive integer", () => {
+    expect(resolveInspectUsageTop(7, 5)).toBe(7)
+    expect(resolveInspectUsageTop(0, 5)).toBe(1)
+    expect(resolveInspectUsageTop(2.9, 5)).toBe(2)
+    expect(resolveInspectUsageTop(undefined, 5)).toBe(5)
+  })
+
+  test("buildInspectUsageSnapshot includes sorted provider and model leaders", () => {
+    const usage = buildInspectUsageSnapshot({
+      period: "day",
+      summary: makeSummary(),
+      stats: makeStats(),
+      top: 1,
+    })
+
+    expect(usage.topProviders).toHaveLength(1)
+    expect(usage.topProviders[0]?.id).toBe("openai")
+    expect(usage.topModels).toHaveLength(1)
+    expect(usage.topModels[0]?.id).toBe("gpt-4o")
+  })
+})
+

--- a/packages/zee/test/cli/usage-command.test.ts
+++ b/packages/zee/test/cli/usage-command.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildUsageBreakdown,
+  renderUsageDashboardLines,
+  sortUsageBreakdown,
+  type UsageBreakdownRow,
+} from "../../src/cli/cmd/usage"
+import type { UsageStats, UsageSummary } from "../../src/usage/types"
+
+function makeSummary(): UsageSummary {
+  return {
+    period: "day",
+    startTime: 1_700_000_000_000,
+    endTime: 1_700_000_086_400,
+    totalRequests: 30,
+    totalInputTokens: 120_000,
+    totalOutputTokens: 80_000,
+    totalCost: 2.75,
+    byProvider: {
+      openai: {
+        providerId: "openai",
+        requests: 20,
+        inputTokens: 90_000,
+        outputTokens: 60_000,
+        cost: 2.0,
+        models: ["gpt-4o", "gpt-4o-mini"],
+      },
+      anthropic: {
+        providerId: "anthropic",
+        requests: 10,
+        inputTokens: 30_000,
+        outputTokens: 20_000,
+        cost: 0.75,
+        models: ["claude-sonnet-4-5"],
+      },
+    },
+    byModel: {
+      "gpt-4o": {
+        modelId: "gpt-4o",
+        modelName: "GPT-4o",
+        providerId: "openai",
+        requests: 8,
+        inputTokens: 45_000,
+        outputTokens: 30_000,
+        cost: 1.2,
+        avgLatencyMs: 700,
+      },
+      "gpt-4o-mini": {
+        modelId: "gpt-4o-mini",
+        providerId: "openai",
+        requests: 12,
+        inputTokens: 45_000,
+        outputTokens: 30_000,
+        cost: 0.8,
+        avgLatencyMs: 420,
+      },
+      "claude-sonnet-4-5": {
+        modelId: "claude-sonnet-4-5",
+        providerId: "anthropic",
+        requests: 10,
+        inputTokens: 30_000,
+        outputTokens: 20_000,
+        cost: 0.75,
+        avgLatencyMs: 950,
+      },
+    },
+    avgLatencyMs: 650,
+    errorCount: 1,
+    errorRate: 1 / 30,
+    cacheHitRate: 0.2,
+  }
+}
+
+function makeStats(): UsageStats {
+  return {
+    todayRequests: 30,
+    todayCost: 2.75,
+    todayTokens: 200_000,
+    weekRequests: 150,
+    weekCost: 11.2,
+    monthRequests: 510,
+    monthCost: 38.4,
+    topModel: { modelId: "gpt-4o", cost: 18.5 },
+    topProvider: { providerId: "openai", cost: 24.0 },
+    lastRequestAt: 1_700_000_086_400,
+  }
+}
+
+describe("usage command helpers", () => {
+  test("buildUsageBreakdown returns provider rows", () => {
+    const rows = buildUsageBreakdown(makeSummary(), "provider")
+    expect(rows).toHaveLength(2)
+    expect(rows.find((row) => row.id === "openai")).toEqual({
+      id: "openai",
+      requests: 20,
+      tokens: 150000,
+      cost: 2,
+    })
+  })
+
+  test("sortUsageBreakdown sorts by cost then requests then id", () => {
+    const rows: UsageBreakdownRow[] = [
+      { id: "c", requests: 1, tokens: 100, cost: 1 },
+      { id: "a", requests: 3, tokens: 50, cost: 1 },
+      { id: "b", requests: 2, tokens: 200, cost: 2 },
+    ]
+    const sorted = sortUsageBreakdown(rows, "cost")
+    expect(sorted.map((row) => row.id)).toEqual(["b", "a", "c"])
+  })
+
+  test("renderUsageDashboardLines includes expected sections", () => {
+    const summary = makeSummary()
+    const stats = makeStats()
+    const topProviders = sortUsageBreakdown(buildUsageBreakdown(summary, "provider"), "cost").slice(0, 2)
+    const topModels = sortUsageBreakdown(buildUsageBreakdown(summary, "model"), "cost").slice(0, 2)
+
+    const lines = renderUsageDashboardLines({
+      period: "day",
+      summary,
+      stats,
+      topProviders,
+      topModels,
+    })
+
+    const text = lines.join("\n")
+    expect(text).toContain("Usage dashboard (period=day)")
+    expect(text).toContain("Quick window snapshot:")
+    expect(text).toContain("Top providers:")
+    expect(text).toContain("Top models:")
+  })
+})
+


### PR DESCRIPTION
## Summary
- add inspect/ops helper command module for runtime/session/usage snapshots
- add usage helper command module for dashboard and top breakdown formatting
- add unit tests for inspect and usage helper behavior

## Testing
- bun test test/cli/inspect-command.test.ts test/cli/usage-command.test.ts

Closes #316