### PR TITLE
fix(tool): reject non-regular files in read tool

### DIFF
--- a/packages/zee/src/tool/read.ts
+++ b/packages/zee/src/tool/read.ts
@@ -68,6 +68,15 @@ function isBlockedEnvFile(filename: string): boolean {
   return false
 }
 
+function describeNonRegularFile(stat: fs.Stats): string {
+  if (stat.isDirectory()) return "directory"
+  if (stat.isSocket()) return "socket"
+  if (stat.isFIFO()) return "named pipe"
+  if (stat.isCharacterDevice()) return "character device"
+  if (stat.isBlockDevice()) return "block device"
+  return "special file"
+}
+
 export const ReadTool = Tool.define("read", {
   description: DESCRIPTION,
   parameters: z.object({
@@ -102,8 +111,15 @@ export const ReadTool = Tool.define("read", {
       metadata: {},
     })
 
-    const file = Bun.file(filepath)
-    if (!(await file.exists())) {
+    let stat: fs.Stats | null = null
+    try {
+      stat = await fs.promises.stat(filepath)
+    } catch (error) {
+      const errno = error as NodeJS.ErrnoException
+      if (errno.code !== "ENOENT") throw error
+    }
+
+    if (!stat) {
       const dir = path.dirname(filepath)
       const base = path.basename(filepath)
       let suggestions: string[] = []
@@ -126,6 +142,12 @@ export const ReadTool = Tool.define("read", {
 
       throw new Error(`File not found: ${filepath}`)
     }
+
+    if (!stat.isFile()) {
+      throw new Error(`Cannot read non-regular file (${describeNonRegularFile(stat)}): ${filepath}`)
+    }
+
+    const file = Bun.file(filepath)
 
     const instructions = await InstructionPrompt.resolve(ctx.messages, filepath, ctx.messageID)
 

--- a/packages/zee/test/tool/read.test.ts
+++ b/packages/zee/test/tool/read.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
+import { createServer } from "node:net"
 import { ReadTool } from "../../src/tool/read"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
@@ -374,5 +375,34 @@ root_type Monster;`
         expect(result.output).toContain("table Monster")
       },
     })
+  })
+
+  test("rejects unix socket paths as non-regular files", async () => {
+    if (process.platform === "win32") return
+
+    await using tmp = await tmpdir({})
+    const socketPath = path.join(tmp.path, "daemon.sock")
+    const server = createServer()
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(socketPath, resolve)
+    })
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const read = await ReadTool.init()
+          await expect(read.execute({ filePath: socketPath }, ctx(tmp.path))).rejects.toThrow(
+            `Cannot read non-regular file (socket): ${socketPath}`,
+          )
+        },
+      })
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve())
+      })
+    }
   })
 })


### PR DESCRIPTION
## Summary
- check file type using fs.stat before reading
- reject sockets/directories/devices with a clear error message
- add unix socket coverage for read tool

## Testing
- bun test test/tool/read.test.ts

Closes #313