### PR TITLE
Fix #338: normalize absolute sessionFile paths for canonical storage

### DIFF
--- a/packages/zee/Swabble/src/config/sessions/paths.test.ts
+++ b/packages/zee/Swabble/src/config/sessions/paths.test.ts
@@ -1,0 +1,46 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveSessionFilePath, resolveSessionTranscriptsDirForAgent } from "./paths.js";
+
+describe("session paths", () => {
+  it("normalizes absolute sessionFile paths within the agent sessions directory", () => {
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    const absolutePath = path.join(sessionsDir, "abc-123.jsonl");
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: absolutePath },
+      { agentId: "main" },
+    );
+
+    expect(resolved).toBe(path.resolve(sessionsDir, "abc-123.jsonl"));
+  });
+
+  it("normalizes absolute sessionFile paths with topic suffixes within the sessions directory", () => {
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    const absolutePath = path.join(sessionsDir, "abc-123-topic-42.jsonl");
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: absolutePath },
+      { agentId: "main" },
+    );
+
+    expect(resolved).toBe(path.resolve(sessionsDir, "abc-123-topic-42.jsonl"));
+  });
+
+  it("leaves absolute sessionFile paths outside the sessions directory unchanged", () => {
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    const outsidePath = path.resolve(path.dirname(sessionsDir), "work", "sessions", "abc-123.jsonl");
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: outsidePath },
+      { agentId: "main" },
+    );
+
+    expect(resolved).toBe(outsidePath);
+  });
+});

--- a/packages/zee/Swabble/src/config/sessions/paths.ts
+++ b/packages/zee/Swabble/src/config/sessions/paths.ts
@@ -49,13 +49,37 @@ export function resolveSessionTranscriptPath(
   return path.join(resolveAgentSessionsDir(agentId), fileName);
 }
 
+function normalizeAbsoluteSessionFilePathWithinSessionsDir(params: {
+  sessionsDir: string;
+  sessionFile: string;
+}): string | undefined {
+  const resolvedBase = path.resolve(params.sessionsDir);
+  const resolvedCandidate = path.resolve(params.sessionFile);
+  const relative = path.relative(resolvedBase, resolvedCandidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return undefined;
+  }
+  return path.resolve(resolvedBase, relative);
+}
+
 export function resolveSessionFilePath(
   sessionId: string,
   entry?: SessionEntry,
   opts?: { agentId?: string },
 ): string {
   const candidate = entry?.sessionFile?.trim();
-  return candidate ? candidate : resolveSessionTranscriptPath(sessionId, opts?.agentId);
+  if (!candidate) {
+    return resolveSessionTranscriptPath(sessionId, opts?.agentId);
+  }
+  if (!path.isAbsolute(candidate)) {
+    return candidate;
+  }
+  const sessionsDir = resolveAgentSessionsDir(opts?.agentId);
+  const normalized = normalizeAbsoluteSessionFilePathWithinSessionsDir({
+    sessionsDir,
+    sessionFile: candidate,
+  });
+  return normalized ?? candidate;
 }
 
 export function resolveStorePath(store?: string, opts?: { agentId?: string }) {


### PR DESCRIPTION
## Summary
- normalize absolute `sessionFile` values that point inside the agent sessions directory
- keep existing behavior for relative paths and absolute paths outside the sessions directory
- add regression tests for in-dir absolute paths, topic-suffixed absolute paths, and outside-dir absolute paths

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/config/sessions/paths.test.ts`

Closes #338