### PR TITLE
Fix #334: reset stale runtime state after SIGUSR1 in-process restart

### DIFF
--- a/packages/zee/Swabble/src/cli/gateway-cli/run-loop.test.ts
+++ b/packages/zee/Swabble/src/cli/gateway-cli/run-loop.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest"
+
+const acquireGatewayLock = vi.fn(async () => ({
+  release: vi.fn(async () => {}),
+}))
+const consumeGatewaySigusr1RestartAuthorization = vi.fn(() => true)
+const isGatewaySigusr1RestartExternallyAllowed = vi.fn(() => false)
+const getActiveTaskCount = vi.fn(() => 0)
+const waitForActiveTasks = vi.fn(async () => ({ drained: true }))
+const resetAllLanes = vi.fn()
+const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart"
+const gatewayLog = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}
+
+vi.mock("../../infra/gateway-lock.js", () => ({
+  acquireGatewayLock: () => acquireGatewayLock(),
+}))
+
+vi.mock("../../infra/restart.js", () => ({
+  consumeGatewaySigusr1RestartAuthorization: () => consumeGatewaySigusr1RestartAuthorization(),
+  isGatewaySigusr1RestartExternallyAllowed: () => isGatewaySigusr1RestartExternallyAllowed(),
+}))
+
+vi.mock("../../process/command-queue.js", () => ({
+  getActiveTaskCount: () => getActiveTaskCount(),
+  waitForActiveTasks: (timeoutMs: number) => waitForActiveTasks(timeoutMs),
+  resetAllLanes: () => resetAllLanes(),
+}))
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => gatewayLog,
+}))
+
+function removeNewSignalListeners(signal: NodeJS.Signals, existing: Set<(...args: unknown[]) => void>) {
+  for (const listener of process.listeners(signal)) {
+    const fn = listener as (...args: unknown[]) => void
+    if (!existing.has(fn)) {
+      process.removeListener(signal, fn)
+    }
+  }
+}
+
+describe("runGatewayLoop", () => {
+  it("restarts after SIGUSR1 even when drain times out, and resets lanes for the new iteration", async () => {
+    vi.clearAllMocks()
+    getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0)
+    waitForActiveTasks.mockResolvedValueOnce({ drained: false })
+
+    type StartServer = () => Promise<{
+      close: (opts: { reason: string; restartExpectedMs: number | null }) => Promise<void>
+    }>
+
+    const closeFirst = vi.fn(async () => {})
+    const closeSecond = vi.fn(async () => {})
+    const start = vi
+      .fn<StartServer>()
+      .mockResolvedValueOnce({ close: closeFirst })
+      .mockResolvedValueOnce({ close: closeSecond })
+      .mockRejectedValueOnce(new Error("stop-loop"))
+
+    const beforeSigterm = new Set(process.listeners("SIGTERM") as Array<(...args: unknown[]) => void>)
+    const beforeSigint = new Set(process.listeners("SIGINT") as Array<(...args: unknown[]) => void>)
+    const beforeSigusr1 = new Set(process.listeners("SIGUSR1") as Array<(...args: unknown[]) => void>)
+
+    const loopPromise = import("./run-loop.js").then(({ runGatewayLoop }) =>
+      runGatewayLoop({
+        start,
+        runtime: {
+          exit: vi.fn(),
+        } as { exit: (code: number) => never },
+      }),
+    )
+
+    try {
+      await vi.waitFor(() => {
+        expect(start).toHaveBeenCalledTimes(1)
+      })
+
+      process.emit("SIGUSR1")
+
+      await vi.waitFor(() => {
+        expect(start).toHaveBeenCalledTimes(2)
+      })
+
+      expect(waitForActiveTasks).toHaveBeenCalledWith(30_000)
+      expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG)
+      expect(closeFirst).toHaveBeenCalledWith({
+        reason: "gateway restarting",
+        restartExpectedMs: 1500,
+      })
+      expect(resetAllLanes).toHaveBeenCalledTimes(1)
+
+      process.emit("SIGUSR1")
+
+      await expect(loopPromise).rejects.toThrow("stop-loop")
+      expect(closeSecond).toHaveBeenCalledWith({
+        reason: "gateway restarting",
+        restartExpectedMs: 1500,
+      })
+      expect(resetAllLanes).toHaveBeenCalledTimes(2)
+    } finally {
+      removeNewSignalListeners("SIGTERM", beforeSigterm)
+      removeNewSignalListeners("SIGINT", beforeSigint)
+      removeNewSignalListeners("SIGUSR1", beforeSigusr1)
+    }
+  })
+})

--- a/packages/zee/Swabble/src/cli/gateway-cli/run-loop.ts
+++ b/packages/zee/Swabble/src/cli/gateway-cli/run-loop.ts
@@ -1,104 +1,125 @@
-import type { startGatewayServer } from "../../gateway/server.js";
-import { acquireGatewayLock } from "../../infra/gateway-lock.js";
+import type { startGatewayServer } from "../../gateway/server.js"
+import { acquireGatewayLock } from "../../infra/gateway-lock.js"
 import {
   consumeGatewaySigusr1RestartAuthorization,
   isGatewaySigusr1RestartExternallyAllowed,
-} from "../../infra/restart.js";
-import { createSubsystemLogger } from "../../logging/subsystem.js";
-import type { defaultRuntime } from "../../runtime.js";
+} from "../../infra/restart.js"
+import { createSubsystemLogger } from "../../logging/subsystem.js"
+import { getActiveTaskCount, resetAllLanes, waitForActiveTasks } from "../../process/command-queue.js"
+import { createRestartIterationHook } from "../../process/restart-recovery.js"
+import type { defaultRuntime } from "../../runtime.js"
 
-const gatewayLog = createSubsystemLogger("gateway");
+const gatewayLog = createSubsystemLogger("gateway")
 
-type GatewayRunSignalAction = "stop" | "restart";
+type GatewayRunSignalAction = "stop" | "restart"
+const DRAIN_TIMEOUT_MS = 30_000
+const SHUTDOWN_TIMEOUT_MS = 5_000
 
 export async function runGatewayLoop(params: {
-  start: () => Promise<Awaited<ReturnType<typeof startGatewayServer>>>;
-  runtime: typeof defaultRuntime;
+  start: () => Promise<Awaited<ReturnType<typeof startGatewayServer>>>
+  runtime: typeof defaultRuntime
 }) {
-  const lock = await acquireGatewayLock();
-  let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
-  let shuttingDown = false;
-  let restartResolver: (() => void) | null = null;
+  const lock = await acquireGatewayLock()
+  let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null
+  let shuttingDown = false
+  let restartResolver: (() => void) | null = null
 
   const cleanupSignals = () => {
-    process.removeListener("SIGTERM", onSigterm);
-    process.removeListener("SIGINT", onSigint);
-    process.removeListener("SIGUSR1", onSigusr1);
-  };
+    process.removeListener("SIGTERM", onSigterm)
+    process.removeListener("SIGINT", onSigint)
+    process.removeListener("SIGUSR1", onSigusr1)
+  }
 
   const request = (action: GatewayRunSignalAction, signal: string) => {
     if (shuttingDown) {
-      gatewayLog.info(`received ${signal} during shutdown; ignoring`);
-      return;
+      gatewayLog.info(`received ${signal} during shutdown; ignoring`)
+      return
     }
-    shuttingDown = true;
-    const isRestart = action === "restart";
-    gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`);
+    shuttingDown = true
+    const isRestart = action === "restart"
+    gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`)
 
+    const forceExitMs = isRestart ? DRAIN_TIMEOUT_MS + SHUTDOWN_TIMEOUT_MS : SHUTDOWN_TIMEOUT_MS
     const forceExitTimer = setTimeout(() => {
-      gatewayLog.error("shutdown timed out; exiting without full cleanup");
-      cleanupSignals();
-      params.runtime.exit(0);
-    }, 5000);
+      gatewayLog.error("shutdown timed out; exiting without full cleanup")
+      cleanupSignals()
+      params.runtime.exit(0)
+    }, forceExitMs)
 
     void (async () => {
       try {
+        if (isRestart) {
+          const activeTasks = getActiveTaskCount()
+          if (activeTasks > 0) {
+            gatewayLog.info(`draining ${activeTasks} active task(s) before restart (timeout ${DRAIN_TIMEOUT_MS}ms)`)
+            const { drained } = await waitForActiveTasks(DRAIN_TIMEOUT_MS)
+            if (drained) {
+              gatewayLog.info("all active tasks drained")
+            } else {
+              gatewayLog.warn("drain timeout reached; proceeding with restart")
+            }
+          }
+        }
+
         await server?.close({
           reason: isRestart ? "gateway restarting" : "gateway stopping",
           restartExpectedMs: isRestart ? 1500 : null,
-        });
+        })
       } catch (err) {
-        gatewayLog.error(`shutdown error: ${String(err)}`);
+        gatewayLog.error(`shutdown error: ${String(err)}`)
       } finally {
-        clearTimeout(forceExitTimer);
-        server = null;
+        clearTimeout(forceExitTimer)
+        server = null
         if (isRestart) {
-          shuttingDown = false;
-          restartResolver?.();
+          shuttingDown = false
+          restartResolver?.()
         } else {
-          cleanupSignals();
-          params.runtime.exit(0);
+          cleanupSignals()
+          params.runtime.exit(0)
         }
       }
-    })();
-  };
+    })()
+  }
 
   const onSigterm = () => {
-    gatewayLog.info("signal SIGTERM received");
-    request("stop", "SIGTERM");
-  };
+    gatewayLog.info("signal SIGTERM received")
+    request("stop", "SIGTERM")
+  }
   const onSigint = () => {
-    gatewayLog.info("signal SIGINT received");
-    request("stop", "SIGINT");
-  };
+    gatewayLog.info("signal SIGINT received")
+    request("stop", "SIGINT")
+  }
   const onSigusr1 = () => {
-    gatewayLog.info("signal SIGUSR1 received");
-    const authorized = consumeGatewaySigusr1RestartAuthorization();
+    gatewayLog.info("signal SIGUSR1 received")
+    const authorized = consumeGatewaySigusr1RestartAuthorization()
     if (!authorized && !isGatewaySigusr1RestartExternallyAllowed()) {
-      gatewayLog.warn(
-        "SIGUSR1 restart ignored (not authorized; enable commands.restart or use gateway tool).",
-      );
-      return;
+      gatewayLog.warn("SIGUSR1 restart ignored (not authorized; enable commands.restart or use gateway tool).")
+      return
     }
-    request("restart", "SIGUSR1");
-  };
+    request("restart", "SIGUSR1")
+  }
 
-  process.on("SIGTERM", onSigterm);
-  process.on("SIGINT", onSigint);
-  process.on("SIGUSR1", onSigusr1);
+  process.on("SIGTERM", onSigterm)
+  process.on("SIGINT", onSigint)
+  process.on("SIGUSR1", onSigusr1)
 
   try {
+    const onIteration = createRestartIterationHook(() => {
+      resetAllLanes()
+    })
+
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).
     // SIGTERM/SIGINT still exit after a graceful shutdown.
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      server = await params.start();
+      onIteration()
+      server = await params.start()
       await new Promise<void>((resolve) => {
-        restartResolver = resolve;
-      });
+        restartResolver = resolve
+      })
     }
   } finally {
-    await lock?.release();
-    cleanupSignals();
+    await lock?.release()
+    cleanupSignals()
   }
 }

--- a/packages/zee/Swabble/src/infra/heartbeat-runner.ts
+++ b/packages/zee/Swabble/src/infra/heartbeat-runner.ts
@@ -1,29 +1,25 @@
-import fs from "node:fs/promises";
-import path from "node:path";
+import fs from "node:fs/promises"
+import path from "node:path"
 
-import {
-  resolveAgentConfig,
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-} from "../agents/agent-scope.js";
-import { resolveUserTimezone } from "../agents/date-time.js";
-import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
-import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
+import { resolveAgentConfig, resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js"
+import { resolveUserTimezone } from "../agents/date-time.js"
+import { resolveEffectiveMessagesConfig } from "../agents/identity.js"
+import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js"
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   DEFAULT_HEARTBEAT_EVERY,
   isHeartbeatContentEffectivelyEmpty,
   resolveHeartbeatPrompt as resolveHeartbeatPromptText,
   stripHeartbeatToken,
-} from "../auto-reply/heartbeat.js";
-import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
-import { getReplyFromConfig } from "../auto-reply/reply.js";
-import type { ReplyPayload } from "../auto-reply/types.js";
-import { getChannelPlugin } from "../channels/plugins/index.js";
-import type { ChannelHeartbeatDeps } from "../channels/plugins/types.js";
-import { parseDurationMs } from "../cli/parse-duration.js";
-import type { ZeeConfig } from "../config/config.js";
-import { loadConfig } from "../config/config.js";
+} from "../auto-reply/heartbeat.js"
+import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js"
+import { getReplyFromConfig } from "../auto-reply/reply.js"
+import type { ReplyPayload } from "../auto-reply/types.js"
+import { getChannelPlugin } from "../channels/plugins/index.js"
+import type { ChannelHeartbeatDeps } from "../channels/plugins/types.js"
+import { parseDurationMs } from "../cli/parse-duration.js"
+import type { ZeeConfig } from "../config/config.js"
+import { loadConfig } from "../config/config.js"
 import {
   canonicalizeMainSessionAlias,
   loadSessionStore,
@@ -32,62 +28,59 @@ import {
   resolveStorePath,
   saveSessionStore,
   updateSessionStore,
-} from "../config/sessions.js";
-import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
-import { formatErrorMessage } from "../infra/errors.js";
-import { peekSystemEvents } from "../infra/system-events.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
-import { getQueueSize } from "../process/command-queue.js";
-import { CommandLane } from "../process/lanes.js";
-import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
-import { normalizeAgentId, toAgentStoreSessionKey } from "../routing/session-key.js";
-import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js";
-import { resolveHeartbeatVisibility } from "./heartbeat-visibility.js";
+} from "../config/sessions.js"
+import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js"
+import { formatErrorMessage } from "../infra/errors.js"
+import { peekSystemEvents } from "../infra/system-events.js"
+import { createSubsystemLogger } from "../logging/subsystem.js"
+import { getQueueSize } from "../process/command-queue.js"
+import { CommandLane } from "../process/lanes.js"
+import { defaultRuntime, type RuntimeEnv } from "../runtime.js"
+import { normalizeAgentId, toAgentStoreSessionKey } from "../routing/session-key.js"
+import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js"
+import { resolveHeartbeatVisibility } from "./heartbeat-visibility.js"
 import {
   type HeartbeatRunResult,
   type HeartbeatWakeHandler,
   requestHeartbeatNow,
   setHeartbeatWakeHandler,
-} from "./heartbeat-wake.js";
-import type { OutboundSendDeps } from "./outbound/deliver.js";
-import { deliverOutboundPayloads } from "./outbound/deliver.js";
-import {
-  resolveHeartbeatDeliveryTarget,
-  resolveHeartbeatSenderContext,
-} from "./outbound/targets.js";
+} from "./heartbeat-wake.js"
+import type { OutboundSendDeps } from "./outbound/deliver.js"
+import { deliverOutboundPayloads } from "./outbound/deliver.js"
+import { resolveHeartbeatDeliveryTarget, resolveHeartbeatSenderContext } from "./outbound/targets.js"
 
 type HeartbeatDeps = OutboundSendDeps &
   ChannelHeartbeatDeps & {
-    runtime?: RuntimeEnv;
-    getQueueSize?: (lane?: string) => number;
-    nowMs?: () => number;
-  };
+    runtime?: RuntimeEnv
+    getQueueSize?: (lane?: string) => number
+    nowMs?: () => number
+  }
 
-const log = createSubsystemLogger("gateway/heartbeat");
-let heartbeatsEnabled = true;
+const log = createSubsystemLogger("gateway/heartbeat")
+let heartbeatsEnabled = true
 
 export function setHeartbeatsEnabled(enabled: boolean) {
-  heartbeatsEnabled = enabled;
+  heartbeatsEnabled = enabled
 }
 
-type HeartbeatConfig = AgentDefaultsConfig["heartbeat"];
+type HeartbeatConfig = AgentDefaultsConfig["heartbeat"]
 type HeartbeatAgent = {
-  agentId: string;
-  heartbeat?: HeartbeatConfig;
-};
+  agentId: string
+  heartbeat?: HeartbeatConfig
+}
 
 export type HeartbeatSummary = {
-  enabled: boolean;
-  every: string;
-  everyMs: number | null;
-  prompt: string;
-  target: string;
-  model?: string;
-  ackMaxChars: number;
-};
+  enabled: boolean
+  every: string
+  everyMs: number | null
+  prompt: string
+  target: string
+  model?: string
+  ackMaxChars: number
+}
 
-const DEFAULT_HEARTBEAT_TARGET = "last";
-const ACTIVE_HOURS_TIME_PATTERN = /^([01]\d|2[0-3]|24):([0-5]\d)$/;
+const DEFAULT_HEARTBEAT_TARGET = "last"
+const ACTIVE_HOURS_TIME_PATTERN = /^([01]\d|2[0-3]|24):([0-5]\d)$/
 
 // Prompt used when an async exec has completed and the result should be relayed to the user.
 // This overrides the standard heartbeat prompt to ensure the model responds with the exec result
@@ -95,36 +88,36 @@ const ACTIVE_HOURS_TIME_PATTERN = /^([01]\d|2[0-3]|24):([0-5]\d)$/;
 const EXEC_EVENT_PROMPT =
   "An async command you ran earlier has completed. The result is shown in the system messages above. " +
   "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
-  "If it failed, explain what went wrong.";
+  "If it failed, explain what went wrong."
 
 function resolveActiveHoursTimezone(cfg: ZeeConfig, raw?: string): string {
-  const trimmed = raw?.trim();
+  const trimmed = raw?.trim()
   if (!trimmed || trimmed === "user") {
-    return resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
+    return resolveUserTimezone(cfg.agents?.defaults?.userTimezone)
   }
   if (trimmed === "local") {
-    const host = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return host?.trim() || "UTC";
+    const host = Intl.DateTimeFormat().resolvedOptions().timeZone
+    return host?.trim() || "UTC"
   }
   try {
-    new Intl.DateTimeFormat("en-US", { timeZone: trimmed }).format(new Date());
-    return trimmed;
+    new Intl.DateTimeFormat("en-US", { timeZone: trimmed }).format(new Date())
+    return trimmed
   } catch {
-    return resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
+    return resolveUserTimezone(cfg.agents?.defaults?.userTimezone)
   }
 }
 
 function parseActiveHoursTime(opts: { allow24: boolean }, raw?: string): number | null {
-  if (!raw || !ACTIVE_HOURS_TIME_PATTERN.test(raw)) return null;
-  const [hourStr, minuteStr] = raw.split(":");
-  const hour = Number(hourStr);
-  const minute = Number(minuteStr);
-  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+  if (!raw || !ACTIVE_HOURS_TIME_PATTERN.test(raw)) return null
+  const [hourStr, minuteStr] = raw.split(":")
+  const hour = Number(hourStr)
+  const minute = Number(minuteStr)
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null
   if (hour === 24) {
-    if (!opts.allow24 || minute !== 0) return null;
-    return 24 * 60;
+    if (!opts.allow24 || minute !== 0) return null
+    return 24 * 60
   }
-  return hour * 60 + minute;
+  return hour * 60 + minute
 }
 
 function resolveMinutesInTimeZone(nowMs: number, timeZone: string): number | null {
@@ -134,88 +127,79 @@ function resolveMinutesInTimeZone(nowMs: number, timeZone: string): number | nul
       hour: "2-digit",
       minute: "2-digit",
       hourCycle: "h23",
-    }).formatToParts(new Date(nowMs));
-    const map: Record<string, string> = {};
+    }).formatToParts(new Date(nowMs))
+    const map: Record<string, string> = {}
     for (const part of parts) {
-      if (part.type !== "literal") map[part.type] = part.value;
+      if (part.type !== "literal") map[part.type] = part.value
     }
-    const hour = Number(map.hour);
-    const minute = Number(map.minute);
-    if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
-    return hour * 60 + minute;
+    const hour = Number(map.hour)
+    const minute = Number(map.minute)
+    if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null
+    return hour * 60 + minute
   } catch {
-    return null;
+    return null
   }
 }
 
-function isWithinActiveHours(
-  cfg: ZeeConfig,
-  heartbeat?: HeartbeatConfig,
-  nowMs?: number,
-): boolean {
-  const active = heartbeat?.activeHours;
-  if (!active) return true;
+function isWithinActiveHours(cfg: ZeeConfig, heartbeat?: HeartbeatConfig, nowMs?: number): boolean {
+  const active = heartbeat?.activeHours
+  if (!active) return true
 
-  const startMin = parseActiveHoursTime({ allow24: false }, active.start);
-  const endMin = parseActiveHoursTime({ allow24: true }, active.end);
-  if (startMin === null || endMin === null) return true;
-  if (startMin === endMin) return true;
+  const startMin = parseActiveHoursTime({ allow24: false }, active.start)
+  const endMin = parseActiveHoursTime({ allow24: true }, active.end)
+  if (startMin === null || endMin === null) return true
+  if (startMin === endMin) return true
 
-  const timeZone = resolveActiveHoursTimezone(cfg, active.timezone);
-  const currentMin = resolveMinutesInTimeZone(nowMs ?? Date.now(), timeZone);
-  if (currentMin === null) return true;
+  const timeZone = resolveActiveHoursTimezone(cfg, active.timezone)
+  const currentMin = resolveMinutesInTimeZone(nowMs ?? Date.now(), timeZone)
+  if (currentMin === null) return true
 
   if (endMin > startMin) {
-    return currentMin >= startMin && currentMin < endMin;
+    return currentMin >= startMin && currentMin < endMin
   }
-  return currentMin >= startMin || currentMin < endMin;
+  return currentMin >= startMin || currentMin < endMin
 }
 
 type HeartbeatAgentState = {
-  agentId: string;
-  heartbeat?: HeartbeatConfig;
-  intervalMs: number;
-  lastRunMs?: number;
-  nextDueMs: number;
-};
+  agentId: string
+  heartbeat?: HeartbeatConfig
+  intervalMs: number
+  lastRunMs?: number
+  nextDueMs: number
+}
 
 export type HeartbeatRunner = {
-  stop: () => void;
-  updateConfig: (cfg: ZeeConfig) => void;
-};
+  stop: () => void
+  updateConfig: (cfg: ZeeConfig) => void
+}
 
 function hasExplicitHeartbeatAgents(cfg: ZeeConfig) {
-  const list = cfg.agents?.list ?? [];
-  return list.some((entry) => Boolean(entry?.heartbeat));
+  const list = cfg.agents?.list ?? []
+  return list.some((entry) => Boolean(entry?.heartbeat))
 }
 
 export function isHeartbeatEnabledForAgent(cfg: ZeeConfig, agentId?: string): boolean {
-  const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg));
-  const list = cfg.agents?.list ?? [];
-  const hasExplicit = hasExplicitHeartbeatAgents(cfg);
+  const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg))
+  const list = cfg.agents?.list ?? []
+  const hasExplicit = hasExplicitHeartbeatAgents(cfg)
   if (hasExplicit) {
-    return list.some(
-      (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
-    );
+    return list.some((entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId)
   }
-  return resolvedAgentId === resolveDefaultAgentId(cfg);
+  return resolvedAgentId === resolveDefaultAgentId(cfg)
 }
 
 function resolveHeartbeatConfig(cfg: ZeeConfig, agentId?: string): HeartbeatConfig | undefined {
-  const defaults = cfg.agents?.defaults?.heartbeat;
-  if (!agentId) return defaults;
-  const overrides = resolveAgentConfig(cfg, agentId)?.heartbeat;
-  if (!defaults && !overrides) return overrides;
-  return { ...defaults, ...overrides };
+  const defaults = cfg.agents?.defaults?.heartbeat
+  if (!agentId) return defaults
+  const overrides = resolveAgentConfig(cfg, agentId)?.heartbeat
+  if (!defaults && !overrides) return overrides
+  return { ...defaults, ...overrides }
 }
 
-export function resolveHeartbeatSummaryForAgent(
-  cfg: ZeeConfig,
-  agentId?: string,
-): HeartbeatSummary {
-  const defaults = cfg.agents?.defaults?.heartbeat;
-  const overrides = agentId ? resolveAgentConfig(cfg, agentId)?.heartbeat : undefined;
-  const enabled = isHeartbeatEnabledForAgent(cfg, agentId);
+export function resolveHeartbeatSummaryForAgent(cfg: ZeeConfig, agentId?: string): HeartbeatSummary {
+  const defaults = cfg.agents?.defaults?.heartbeat
+  const overrides = agentId ? resolveAgentConfig(cfg, agentId)?.heartbeat : undefined
+  const enabled = isHeartbeatEnabledForAgent(cfg, agentId)
 
   if (!enabled) {
     return {
@@ -226,25 +210,19 @@ export function resolveHeartbeatSummaryForAgent(
       target: defaults?.target ?? DEFAULT_HEARTBEAT_TARGET,
       model: defaults?.model,
       ackMaxChars: Math.max(0, defaults?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS),
-    };
+    }
   }
 
-  const merged = defaults || overrides ? { ...defaults, ...overrides } : undefined;
-  const every = merged?.every ?? defaults?.every ?? overrides?.every ?? DEFAULT_HEARTBEAT_EVERY;
-  const everyMs = resolveHeartbeatIntervalMs(cfg, undefined, merged);
-  const prompt = resolveHeartbeatPromptText(
-    merged?.prompt ?? defaults?.prompt ?? overrides?.prompt,
-  );
-  const target =
-    merged?.target ?? defaults?.target ?? overrides?.target ?? DEFAULT_HEARTBEAT_TARGET;
-  const model = merged?.model ?? defaults?.model ?? overrides?.model;
+  const merged = defaults || overrides ? { ...defaults, ...overrides } : undefined
+  const every = merged?.every ?? defaults?.every ?? overrides?.every ?? DEFAULT_HEARTBEAT_EVERY
+  const everyMs = resolveHeartbeatIntervalMs(cfg, undefined, merged)
+  const prompt = resolveHeartbeatPromptText(merged?.prompt ?? defaults?.prompt ?? overrides?.prompt)
+  const target = merged?.target ?? defaults?.target ?? overrides?.target ?? DEFAULT_HEARTBEAT_TARGET
+  const model = merged?.model ?? defaults?.model ?? overrides?.model
   const ackMaxChars = Math.max(
     0,
-    merged?.ackMaxChars ??
-      defaults?.ackMaxChars ??
-      overrides?.ackMaxChars ??
-      DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
-  );
+    merged?.ackMaxChars ?? defaults?.ackMaxChars ?? overrides?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  )
 
   return {
     enabled: true,
@@ -254,233 +232,208 @@ export function resolveHeartbeatSummaryForAgent(
     target,
     model,
     ackMaxChars,
-  };
+  }
 }
 
 function resolveHeartbeatAgents(cfg: ZeeConfig): HeartbeatAgent[] {
-  const list = cfg.agents?.list ?? [];
+  const list = cfg.agents?.list ?? []
   if (hasExplicitHeartbeatAgents(cfg)) {
     return list
       .filter((entry) => entry?.heartbeat)
       .map((entry) => {
-        const id = normalizeAgentId(entry.id);
-        return { agentId: id, heartbeat: resolveHeartbeatConfig(cfg, id) };
+        const id = normalizeAgentId(entry.id)
+        return { agentId: id, heartbeat: resolveHeartbeatConfig(cfg, id) }
       })
-      .filter((entry) => entry.agentId);
+      .filter((entry) => entry.agentId)
   }
-  const fallbackId = resolveDefaultAgentId(cfg);
-  return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }];
+  const fallbackId = resolveDefaultAgentId(cfg)
+  return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }]
 }
 
-export function resolveHeartbeatIntervalMs(
-  cfg: ZeeConfig,
-  overrideEvery?: string,
-  heartbeat?: HeartbeatConfig,
-) {
-  const raw =
-    overrideEvery ??
-    heartbeat?.every ??
-    cfg.agents?.defaults?.heartbeat?.every ??
-    DEFAULT_HEARTBEAT_EVERY;
-  if (!raw) return null;
-  const trimmed = String(raw).trim();
-  if (!trimmed) return null;
-  let ms: number;
+export function resolveHeartbeatIntervalMs(cfg: ZeeConfig, overrideEvery?: string, heartbeat?: HeartbeatConfig) {
+  const raw = overrideEvery ?? heartbeat?.every ?? cfg.agents?.defaults?.heartbeat?.every ?? DEFAULT_HEARTBEAT_EVERY
+  if (!raw) return null
+  const trimmed = String(raw).trim()
+  if (!trimmed) return null
+  let ms: number
   try {
-    ms = parseDurationMs(trimmed, { defaultUnit: "m" });
+    ms = parseDurationMs(trimmed, { defaultUnit: "m" })
   } catch {
-    return null;
+    return null
   }
-  if (ms <= 0) return null;
-  return ms;
+  if (ms <= 0) return null
+  return ms
 }
 
 export function resolveHeartbeatPrompt(cfg: ZeeConfig, heartbeat?: HeartbeatConfig) {
-  return resolveHeartbeatPromptText(heartbeat?.prompt ?? cfg.agents?.defaults?.heartbeat?.prompt);
+  return resolveHeartbeatPromptText(heartbeat?.prompt ?? cfg.agents?.defaults?.heartbeat?.prompt)
 }
 
 function resolveHeartbeatAckMaxChars(cfg: ZeeConfig, heartbeat?: HeartbeatConfig) {
   return Math.max(
     0,
-    heartbeat?.ackMaxChars ??
-      cfg.agents?.defaults?.heartbeat?.ackMaxChars ??
-      DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
-  );
+    heartbeat?.ackMaxChars ?? cfg.agents?.defaults?.heartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  )
 }
 
-function resolveHeartbeatSession(
-  cfg: ZeeConfig,
-  agentId?: string,
-  heartbeat?: HeartbeatConfig,
-) {
-  const sessionCfg = cfg.session;
-  const scope = sessionCfg?.scope ?? "per-sender";
-  const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg));
-  const mainSessionKey =
-    scope === "global" ? "global" : resolveAgentMainSessionKey({ cfg, agentId: resolvedAgentId });
-  const storeAgentId = scope === "global" ? resolveDefaultAgentId(cfg) : resolvedAgentId;
-  const storePath = resolveStorePath(sessionCfg?.store, { agentId: storeAgentId });
-  const store = loadSessionStore(storePath);
-  const mainEntry = store[mainSessionKey];
+function resolveHeartbeatSession(cfg: ZeeConfig, agentId?: string, heartbeat?: HeartbeatConfig) {
+  const sessionCfg = cfg.session
+  const scope = sessionCfg?.scope ?? "per-sender"
+  const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg))
+  const mainSessionKey = scope === "global" ? "global" : resolveAgentMainSessionKey({ cfg, agentId: resolvedAgentId })
+  const storeAgentId = scope === "global" ? resolveDefaultAgentId(cfg) : resolvedAgentId
+  const storePath = resolveStorePath(sessionCfg?.store, { agentId: storeAgentId })
+  const store = loadSessionStore(storePath)
+  const mainEntry = store[mainSessionKey]
 
   if (scope === "global") {
-    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
+    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry }
   }
 
-  const trimmed = heartbeat?.session?.trim() ?? "";
+  const trimmed = heartbeat?.session?.trim() ?? ""
   if (!trimmed) {
-    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
+    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry }
   }
 
-  const normalized = trimmed.toLowerCase();
+  const normalized = trimmed.toLowerCase()
   if (normalized === "main" || normalized === "global") {
-    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
+    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry }
   }
 
   const candidate = toAgentStoreSessionKey({
     agentId: resolvedAgentId,
     requestKey: trimmed,
     mainKey: cfg.session?.mainKey,
-  });
+  })
   const canonical = canonicalizeMainSessionAlias({
     cfg,
     agentId: resolvedAgentId,
     sessionKey: candidate,
-  });
+  })
   if (canonical !== "global") {
-    const sessionAgentId = resolveAgentIdFromSessionKey(canonical);
+    const sessionAgentId = resolveAgentIdFromSessionKey(canonical)
     if (sessionAgentId === normalizeAgentId(resolvedAgentId)) {
-      return { sessionKey: canonical, storePath, store, entry: store[canonical] };
+      return { sessionKey: canonical, storePath, store, entry: store[canonical] }
     }
   }
 
-  return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
+  return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry }
 }
 
 function resolveHeartbeatReplyPayload(
   replyResult: ReplyPayload | ReplyPayload[] | undefined,
 ): ReplyPayload | undefined {
-  if (!replyResult) return undefined;
-  if (!Array.isArray(replyResult)) return replyResult;
+  if (!replyResult) return undefined
+  if (!Array.isArray(replyResult)) return replyResult
   for (let idx = replyResult.length - 1; idx >= 0; idx -= 1) {
-    const payload = replyResult[idx];
-    if (!payload) continue;
+    const payload = replyResult[idx]
+    if (!payload) continue
     if (payload.text || payload.mediaUrl || (payload.mediaUrls && payload.mediaUrls.length > 0)) {
-      return payload;
+      return payload
     }
   }
-  return undefined;
+  return undefined
 }
 
-function resolveHeartbeatReasoningPayloads(
-  replyResult: ReplyPayload | ReplyPayload[] | undefined,
-): ReplyPayload[] {
-  const payloads = Array.isArray(replyResult) ? replyResult : replyResult ? [replyResult] : [];
+function resolveHeartbeatReasoningPayloads(replyResult: ReplyPayload | ReplyPayload[] | undefined): ReplyPayload[] {
+  const payloads = Array.isArray(replyResult) ? replyResult : replyResult ? [replyResult] : []
   return payloads.filter((payload) => {
-    const text = typeof payload.text === "string" ? payload.text : "";
-    return text.trimStart().startsWith("Reasoning:");
-  });
+    const text = typeof payload.text === "string" ? payload.text : ""
+    return text.trimStart().startsWith("Reasoning:")
+  })
 }
 
-async function restoreHeartbeatUpdatedAt(params: {
-  storePath: string;
-  sessionKey: string;
-  updatedAt?: number;
-}) {
-  const { storePath, sessionKey, updatedAt } = params;
-  if (typeof updatedAt !== "number") return;
-  const store = loadSessionStore(storePath);
-  const entry = store[sessionKey];
-  if (!entry) return;
-  const nextUpdatedAt = Math.max(entry.updatedAt ?? 0, updatedAt);
-  if (entry.updatedAt === nextUpdatedAt) return;
+async function restoreHeartbeatUpdatedAt(params: { storePath: string; sessionKey: string; updatedAt?: number }) {
+  const { storePath, sessionKey, updatedAt } = params
+  if (typeof updatedAt !== "number") return
+  const store = loadSessionStore(storePath)
+  const entry = store[sessionKey]
+  if (!entry) return
+  const nextUpdatedAt = Math.max(entry.updatedAt ?? 0, updatedAt)
+  if (entry.updatedAt === nextUpdatedAt) return
   await updateSessionStore(storePath, (nextStore) => {
-    const nextEntry = nextStore[sessionKey] ?? entry;
-    if (!nextEntry) return;
-    const resolvedUpdatedAt = Math.max(nextEntry.updatedAt ?? 0, updatedAt);
-    if (nextEntry.updatedAt === resolvedUpdatedAt) return;
-    nextStore[sessionKey] = { ...nextEntry, updatedAt: resolvedUpdatedAt };
-  });
+    const nextEntry = nextStore[sessionKey] ?? entry
+    if (!nextEntry) return
+    const resolvedUpdatedAt = Math.max(nextEntry.updatedAt ?? 0, updatedAt)
+    if (nextEntry.updatedAt === resolvedUpdatedAt) return
+    nextStore[sessionKey] = { ...nextEntry, updatedAt: resolvedUpdatedAt }
+  })
 }
 
-function normalizeHeartbeatReply(
-  payload: ReplyPayload,
-  responsePrefix: string | undefined,
-  ackMaxChars: number,
-) {
+function normalizeHeartbeatReply(payload: ReplyPayload, responsePrefix: string | undefined, ackMaxChars: number) {
   const stripped = stripHeartbeatToken(payload.text, {
     mode: "heartbeat",
     maxAckChars: ackMaxChars,
-  });
-  const hasMedia = Boolean(payload.mediaUrl || (payload.mediaUrls?.length ?? 0) > 0);
+  })
+  const hasMedia = Boolean(payload.mediaUrl || (payload.mediaUrls?.length ?? 0) > 0)
   if (stripped.shouldSkip && !hasMedia) {
     return {
       shouldSkip: true,
       text: "",
       hasMedia,
-    };
+    }
   }
-  let finalText = stripped.text;
+  let finalText = stripped.text
   if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
-    finalText = `${responsePrefix} ${finalText}`;
+    finalText = `${responsePrefix} ${finalText}`
   }
-  return { shouldSkip: false, text: finalText, hasMedia };
+  return { shouldSkip: false, text: finalText, hasMedia }
 }
 
 export async function runHeartbeatOnce(opts: {
-  cfg?: ZeeConfig;
-  agentId?: string;
-  heartbeat?: HeartbeatConfig;
-  reason?: string;
-  deps?: HeartbeatDeps;
+  cfg?: ZeeConfig
+  agentId?: string
+  heartbeat?: HeartbeatConfig
+  reason?: string
+  deps?: HeartbeatDeps
 }): Promise<HeartbeatRunResult> {
-  const cfg = opts.cfg ?? loadConfig();
-  const agentId = normalizeAgentId(opts.agentId ?? resolveDefaultAgentId(cfg));
-  const heartbeat = opts.heartbeat ?? resolveHeartbeatConfig(cfg, agentId);
+  const cfg = opts.cfg ?? loadConfig()
+  const agentId = normalizeAgentId(opts.agentId ?? resolveDefaultAgentId(cfg))
+  const heartbeat = opts.heartbeat ?? resolveHeartbeatConfig(cfg, agentId)
   if (!heartbeatsEnabled) {
-    return { status: "skipped", reason: "disabled" };
+    return { status: "skipped", reason: "disabled" }
   }
   if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
-    return { status: "skipped", reason: "disabled" };
+    return { status: "skipped", reason: "disabled" }
   }
   if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
-    return { status: "skipped", reason: "disabled" };
+    return { status: "skipped", reason: "disabled" }
   }
 
-  const startedAt = opts.deps?.nowMs?.() ?? Date.now();
+  const startedAt = opts.deps?.nowMs?.() ?? Date.now()
   if (!isWithinActiveHours(cfg, heartbeat, startedAt)) {
-    return { status: "skipped", reason: "quiet-hours" };
+    return { status: "skipped", reason: "quiet-hours" }
   }
 
-  const queueSize = (opts.deps?.getQueueSize ?? getQueueSize)(CommandLane.Main);
+  const queueSize = (opts.deps?.getQueueSize ?? getQueueSize)(CommandLane.Main)
   if (queueSize > 0) {
-    return { status: "skipped", reason: "requests-in-flight" };
+    return { status: "skipped", reason: "requests-in-flight" }
   }
 
   // Skip heartbeat if HEARTBEAT.md exists but has no actionable content.
   // This saves API calls/costs when the file is effectively empty (only comments/headers).
   // EXCEPTION: Don't skip for exec events - they have pending system events to process.
-  const isExecEventReason = opts.reason === "exec-event";
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
+  const isExecEventReason = opts.reason === "exec-event"
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId)
+  const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME)
   try {
-    const heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8");
+    const heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8")
     if (isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) && !isExecEventReason) {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "empty-heartbeat-file",
         durationMs: Date.now() - startedAt,
-      });
-      return { status: "skipped", reason: "empty-heartbeat-file" };
+      })
+      return { status: "skipped", reason: "empty-heartbeat-file" }
     }
   } catch {
     // File doesn't exist or can't be read - proceed with heartbeat.
     // The LLM prompt says "if it exists" so this is expected behavior.
   }
 
-  const { entry, sessionKey, storePath } = resolveHeartbeatSession(cfg, agentId, heartbeat);
-  const previousUpdatedAt = entry?.updatedAt;
-  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });
+  const { entry, sessionKey, storePath } = resolveHeartbeatSession(cfg, agentId, heartbeat)
+  const previousUpdatedAt = entry?.updatedAt
+  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat })
   const visibility =
     delivery.channel !== "none"
       ? resolveHeartbeatVisibility({
@@ -488,49 +441,47 @@ export async function runHeartbeatOnce(opts: {
           channel: delivery.channel,
           accountId: delivery.accountId,
         })
-      : { showOk: false, showAlerts: true, useIndicator: true };
-  const { sender } = resolveHeartbeatSenderContext({ cfg, entry, delivery });
-  const responsePrefix = resolveEffectiveMessagesConfig(cfg, agentId).responsePrefix;
+      : { showOk: false, showAlerts: true, useIndicator: true }
+  const { sender } = resolveHeartbeatSenderContext({ cfg, entry, delivery })
+  const responsePrefix = resolveEffectiveMessagesConfig(cfg, agentId).responsePrefix
 
   // Check if this is an exec event with pending exec completion system events.
   // If so, use a specialized prompt that instructs the model to relay the result
   // instead of the standard heartbeat prompt with "reply HEARTBEAT_OK".
-  const isExecEvent = opts.reason === "exec-event";
-  const pendingEvents = isExecEvent ? peekSystemEvents(sessionKey) : [];
-  const hasExecCompletion = pendingEvents.some((evt) => evt.includes("Exec finished"));
+  const isExecEvent = opts.reason === "exec-event"
+  const pendingEvents = isExecEvent ? peekSystemEvents(sessionKey) : []
+  const hasExecCompletion = pendingEvents.some((evt) => evt.includes("Exec finished"))
 
-  const prompt = hasExecCompletion ? EXEC_EVENT_PROMPT : resolveHeartbeatPrompt(cfg, heartbeat);
+  const prompt = hasExecCompletion ? EXEC_EVENT_PROMPT : resolveHeartbeatPrompt(cfg, heartbeat)
   const ctx = {
     Body: prompt,
     From: sender,
     To: sender,
     Provider: hasExecCompletion ? "exec-event" : "heartbeat",
     SessionKey: sessionKey,
-  };
+  }
   if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {
     emitHeartbeatEvent({
       status: "skipped",
       reason: "alerts-disabled",
       durationMs: Date.now() - startedAt,
       channel: delivery.channel !== "none" ? delivery.channel : undefined,
-    });
-    return { status: "skipped", reason: "alerts-disabled" };
+    })
+    return { status: "skipped", reason: "alerts-disabled" }
   }
 
-  const heartbeatOkText = responsePrefix ? `${responsePrefix} ${HEARTBEAT_TOKEN}` : HEARTBEAT_TOKEN;
-  const canAttemptHeartbeatOk = Boolean(
-    visibility.showOk && delivery.channel !== "none" && delivery.to,
-  );
+  const heartbeatOkText = responsePrefix ? `${responsePrefix} ${HEARTBEAT_TOKEN}` : HEARTBEAT_TOKEN
+  const canAttemptHeartbeatOk = Boolean(visibility.showOk && delivery.channel !== "none" && delivery.to)
   const maybeSendHeartbeatOk = async () => {
-    if (!canAttemptHeartbeatOk || delivery.channel === "none" || !delivery.to) return false;
-    const heartbeatPlugin = getChannelPlugin(delivery.channel);
+    if (!canAttemptHeartbeatOk || delivery.channel === "none" || !delivery.to) return false
+    const heartbeatPlugin = getChannelPlugin(delivery.channel)
     if (heartbeatPlugin?.heartbeat?.checkReady) {
       const readiness = await heartbeatPlugin.heartbeat.checkReady({
         cfg,
         accountId: delivery.accountId,
         deps: opts.deps,
-      });
-      if (!readiness.ok) return false;
+      })
+      if (!readiness.ok) return false
     }
     await deliverOutboundPayloads({
       cfg,
@@ -539,28 +490,25 @@ export async function runHeartbeatOnce(opts: {
       accountId: delivery.accountId,
       payloads: [{ text: heartbeatOkText }],
       deps: opts.deps,
-    });
-    return true;
-  };
+    })
+    return true
+  }
 
   try {
-    const replyResult = await getReplyFromConfig(ctx, { isHeartbeat: true }, cfg);
-    const replyPayload = resolveHeartbeatReplyPayload(replyResult);
-    const includeReasoning = heartbeat?.includeReasoning === true;
+    const replyResult = await getReplyFromConfig(ctx, { isHeartbeat: true }, cfg)
+    const replyPayload = resolveHeartbeatReplyPayload(replyResult)
+    const includeReasoning = heartbeat?.includeReasoning === true
     const reasoningPayloads = includeReasoning
       ? resolveHeartbeatReasoningPayloads(replyResult).filter((payload) => payload !== replyPayload)
-      : [];
+      : []
 
-    if (
-      !replyPayload ||
-      (!replyPayload.text && !replyPayload.mediaUrl && !replyPayload.mediaUrls?.length)
-    ) {
+    if (!replyPayload || (!replyPayload.text && !replyPayload.mediaUrl && !replyPayload.mediaUrls?.length)) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,
         updatedAt: previousUpdatedAt,
-      });
-      const okSent = await maybeSendHeartbeatOk();
+      })
+      const okSent = await maybeSendHeartbeatOk()
       emitHeartbeatEvent({
         status: "ok-empty",
         reason: opts.reason,
@@ -568,32 +516,30 @@ export async function runHeartbeatOnce(opts: {
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
         silent: !okSent,
         indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-empty") : undefined,
-      });
-      return { status: "ran", durationMs: Date.now() - startedAt };
+      })
+      return { status: "ran", durationMs: Date.now() - startedAt }
     }
 
-    const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
-    const normalized = normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars);
+    const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat)
+    const normalized = normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars)
     // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
     // The model should be responding with exec results, not ack tokens.
     // Also, if normalized.text is empty due to token stripping but we have exec completion,
     // fall back to the original reply text.
     const execFallbackText =
-      hasExecCompletion && !normalized.text.trim() && replyPayload.text?.trim()
-        ? replyPayload.text.trim()
-        : null;
+      hasExecCompletion && !normalized.text.trim() && replyPayload.text?.trim() ? replyPayload.text.trim() : null
     if (execFallbackText) {
-      normalized.text = execFallbackText;
-      normalized.shouldSkip = false;
+      normalized.text = execFallbackText
+      normalized.shouldSkip = false
     }
-    const shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia && !hasExecCompletion;
+    const shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia && !hasExecCompletion
     if (shouldSkipMain && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,
         updatedAt: previousUpdatedAt,
-      });
-      const okSent = await maybeSendHeartbeatOk();
+      })
+      const okSent = await maybeSendHeartbeatOk()
       emitHeartbeatEvent({
         status: "ok-token",
         reason: opts.reason,
@@ -601,33 +547,30 @@ export async function runHeartbeatOnce(opts: {
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
         silent: !okSent,
         indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-token") : undefined,
-      });
-      return { status: "ran", durationMs: Date.now() - startedAt };
+      })
+      return { status: "ran", durationMs: Date.now() - startedAt }
     }
 
-    const mediaUrls =
-      replyPayload.mediaUrls ?? (replyPayload.mediaUrl ? [replyPayload.mediaUrl] : []);
+    const mediaUrls = replyPayload.mediaUrls ?? (replyPayload.mediaUrl ? [replyPayload.mediaUrl] : [])
 
     // Suppress duplicate heartbeats (same payload) within a short window.
     // This prevents "nagging" when nothing changed but the model repeats the same items.
-    const prevHeartbeatText =
-      typeof entry?.lastHeartbeatText === "string" ? entry.lastHeartbeatText : "";
-    const prevHeartbeatAt =
-      typeof entry?.lastHeartbeatSentAt === "number" ? entry.lastHeartbeatSentAt : undefined;
+    const prevHeartbeatText = typeof entry?.lastHeartbeatText === "string" ? entry.lastHeartbeatText : ""
+    const prevHeartbeatAt = typeof entry?.lastHeartbeatSentAt === "number" ? entry.lastHeartbeatSentAt : undefined
     const isDuplicateMain =
       !shouldSkipMain &&
       !mediaUrls.length &&
       Boolean(prevHeartbeatText.trim()) &&
       normalized.text.trim() === prevHeartbeatText.trim() &&
       typeof prevHeartbeatAt === "number" &&
-      startedAt - prevHeartbeatAt < 24 * 60 * 60 * 1000;
+      startedAt - prevHeartbeatAt < 24 * 60 * 60 * 1000
 
     if (isDuplicateMain) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,
         updatedAt: previousUpdatedAt,
-      });
+      })
       emitHeartbeatEvent({
         status: "skipped",
         reason: "duplicate",
@@ -635,8 +578,8 @@ export async function runHeartbeatOnce(opts: {
         durationMs: Date.now() - startedAt,
         hasMedia: false,
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
-      });
-      return { status: "ran", durationMs: Date.now() - startedAt };
+      })
+      return { status: "ran", durationMs: Date.now() - startedAt }
     }
 
     // Reasoning payloads are text-only; any attachments stay on the main reply.
@@ -645,7 +588,7 @@ export async function runHeartbeatOnce(opts: {
           .map((payload) => payload.text)
           .filter((text): text is string => Boolean(text?.trim()))
           .join("\n")
-      : normalized.text;
+      : normalized.text
 
     if (delivery.channel === "none" || !delivery.to) {
       emitHeartbeatEvent({
@@ -654,12 +597,12 @@ export async function runHeartbeatOnce(opts: {
         preview: previewText?.slice(0, 200),
         durationMs: Date.now() - startedAt,
         hasMedia: mediaUrls.length > 0,
-      });
-      return { status: "ran", durationMs: Date.now() - startedAt };
+      })
+      return { status: "ran", durationMs: Date.now() - startedAt }
     }
 
     if (!visibility.showAlerts) {
-      await restoreHeartbeatUpdatedAt({ storePath, sessionKey, updatedAt: previousUpdatedAt });
+      await restoreHeartbeatUpdatedAt({ storePath, sessionKey, updatedAt: previousUpdatedAt })
       emitHeartbeatEvent({
         status: "skipped",
         reason: "alerts-disabled",
@@ -668,18 +611,18 @@ export async function runHeartbeatOnce(opts: {
         channel: delivery.channel,
         hasMedia: mediaUrls.length > 0,
         indicatorType: visibility.useIndicator ? resolveIndicatorType("sent") : undefined,
-      });
-      return { status: "ran", durationMs: Date.now() - startedAt };
+      })
+      return { status: "ran", durationMs: Date.now() - startedAt }
     }
 
-    const deliveryAccountId = delivery.accountId;
-    const heartbeatPlugin = getChannelPlugin(delivery.channel);
+    const deliveryAccountId = delivery.accountId
+    const heartbeatPlugin = getChannelPlugin(delivery.channel)
     if (heartbeatPlugin?.heartbeat?.checkReady) {
       const readiness = await heartbeatPlugin.heartbeat.checkReady({
         cfg,
         accountId: deliveryAccountId,
         deps: opts.deps,
-      });
+      })
       if (!readiness.ok) {
         emitHeartbeatEvent({
           status: "skipped",
@@ -688,12 +631,12 @@ export async function runHeartbeatOnce(opts: {
           durationMs: Date.now() - startedAt,
           hasMedia: mediaUrls.length > 0,
           channel: delivery.channel,
-        });
+        })
         log.info("heartbeat: channel not ready", {
           channel: delivery.channel,
           reason: readiness.reason,
-        });
-        return { status: "skipped", reason: readiness.reason };
+        })
+        return { status: "skipped", reason: readiness.reason }
       }
     }
 
@@ -714,19 +657,19 @@ export async function runHeartbeatOnce(opts: {
             ]),
       ],
       deps: opts.deps,
-    });
+    })
 
     // Record last delivered heartbeat payload for dedupe.
     if (!shouldSkipMain && normalized.text.trim()) {
-      const store = loadSessionStore(storePath);
-      const current = store[sessionKey];
+      const store = loadSessionStore(storePath)
+      const current = store[sessionKey]
       if (current) {
         store[sessionKey] = {
           ...current,
           lastHeartbeatText: normalized.text,
           lastHeartbeatSentAt: startedAt,
-        };
-        await saveSessionStore(storePath, store);
+        }
+        await saveSessionStore(storePath, store)
       }
     }
 
@@ -738,129 +681,129 @@ export async function runHeartbeatOnce(opts: {
       hasMedia: mediaUrls.length > 0,
       channel: delivery.channel,
       indicatorType: visibility.useIndicator ? resolveIndicatorType("sent") : undefined,
-    });
-    return { status: "ran", durationMs: Date.now() - startedAt };
+    })
+    return { status: "ran", durationMs: Date.now() - startedAt }
   } catch (err) {
-    const reason = formatErrorMessage(err);
+    const reason = formatErrorMessage(err)
     emitHeartbeatEvent({
       status: "failed",
       reason,
       durationMs: Date.now() - startedAt,
       channel: delivery.channel !== "none" ? delivery.channel : undefined,
       indicatorType: visibility.useIndicator ? resolveIndicatorType("failed") : undefined,
-    });
-    log.error(`heartbeat failed: ${reason}`, { error: reason });
-    return { status: "failed", reason };
+    })
+    log.error(`heartbeat failed: ${reason}`, { error: reason })
+    return { status: "failed", reason }
   }
 }
 
 export function startHeartbeatRunner(opts: {
-  cfg?: ZeeConfig;
-  runtime?: RuntimeEnv;
-  abortSignal?: AbortSignal;
-  runOnce?: typeof runHeartbeatOnce;
+  cfg?: ZeeConfig
+  runtime?: RuntimeEnv
+  abortSignal?: AbortSignal
+  runOnce?: typeof runHeartbeatOnce
 }): HeartbeatRunner {
-  const runtime = opts.runtime ?? defaultRuntime;
-  const runOnce = opts.runOnce ?? runHeartbeatOnce;
+  const runtime = opts.runtime ?? defaultRuntime
+  const runOnce = opts.runOnce ?? runHeartbeatOnce
   const state = {
     cfg: opts.cfg ?? loadConfig(),
     runtime,
     agents: new Map<string, HeartbeatAgentState>(),
     timer: null as NodeJS.Timeout | null,
     stopped: false,
-  };
-  let initialized = false;
+  }
+  let initialized = false
 
   const resolveNextDue = (now: number, intervalMs: number, prevState?: HeartbeatAgentState) => {
     if (typeof prevState?.lastRunMs === "number") {
-      return prevState.lastRunMs + intervalMs;
+      return prevState.lastRunMs + intervalMs
     }
     if (prevState && prevState.intervalMs === intervalMs && prevState.nextDueMs > now) {
-      return prevState.nextDueMs;
+      return prevState.nextDueMs
     }
-    return now + intervalMs;
-  };
+    return now + intervalMs
+  }
 
   const scheduleNext = () => {
-    if (state.stopped) return;
+    if (state.stopped) return
     if (state.timer) {
-      clearTimeout(state.timer);
-      state.timer = null;
+      clearTimeout(state.timer)
+      state.timer = null
     }
-    if (state.agents.size === 0) return;
-    const now = Date.now();
-    let nextDue = Number.POSITIVE_INFINITY;
+    if (state.agents.size === 0) return
+    const now = Date.now()
+    let nextDue = Number.POSITIVE_INFINITY
     for (const agent of state.agents.values()) {
-      if (agent.nextDueMs < nextDue) nextDue = agent.nextDueMs;
+      if (agent.nextDueMs < nextDue) nextDue = agent.nextDueMs
     }
-    if (!Number.isFinite(nextDue)) return;
-    const delay = Math.max(0, nextDue - now);
+    if (!Number.isFinite(nextDue)) return
+    const delay = Math.max(0, nextDue - now)
     state.timer = setTimeout(() => {
-      requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
-    }, delay);
-    state.timer.unref?.();
-  };
+      requestHeartbeatNow({ reason: "interval", coalesceMs: 0 })
+    }, delay)
+    state.timer.unref?.()
+  }
 
   const updateConfig = (cfg: ZeeConfig) => {
-    if (state.stopped) return;
-    const now = Date.now();
-    const prevAgents = state.agents;
-    const prevEnabled = prevAgents.size > 0;
-    const nextAgents = new Map<string, HeartbeatAgentState>();
-    const intervals: number[] = [];
+    if (state.stopped) return
+    const now = Date.now()
+    const prevAgents = state.agents
+    const prevEnabled = prevAgents.size > 0
+    const nextAgents = new Map<string, HeartbeatAgentState>()
+    const intervals: number[] = []
     for (const agent of resolveHeartbeatAgents(cfg)) {
-      const intervalMs = resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat);
-      if (!intervalMs) continue;
-      intervals.push(intervalMs);
-      const prevState = prevAgents.get(agent.agentId);
-      const nextDueMs = resolveNextDue(now, intervalMs, prevState);
+      const intervalMs = resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat)
+      if (!intervalMs) continue
+      intervals.push(intervalMs)
+      const prevState = prevAgents.get(agent.agentId)
+      const nextDueMs = resolveNextDue(now, intervalMs, prevState)
       nextAgents.set(agent.agentId, {
         agentId: agent.agentId,
         heartbeat: agent.heartbeat,
         intervalMs,
         lastRunMs: prevState?.lastRunMs,
         nextDueMs,
-      });
+      })
     }
 
-    state.cfg = cfg;
-    state.agents = nextAgents;
-    const nextEnabled = nextAgents.size > 0;
+    state.cfg = cfg
+    state.agents = nextAgents
+    const nextEnabled = nextAgents.size > 0
     if (!initialized) {
       if (!nextEnabled) {
-        log.info("heartbeat: disabled", { enabled: false });
+        log.info("heartbeat: disabled", { enabled: false })
       } else {
-        log.info("heartbeat: started", { intervalMs: Math.min(...intervals) });
+        log.info("heartbeat: started", { intervalMs: Math.min(...intervals) })
       }
-      initialized = true;
+      initialized = true
     } else if (prevEnabled !== nextEnabled) {
       if (!nextEnabled) {
-        log.info("heartbeat: disabled", { enabled: false });
+        log.info("heartbeat: disabled", { enabled: false })
       } else {
-        log.info("heartbeat: started", { intervalMs: Math.min(...intervals) });
+        log.info("heartbeat: started", { intervalMs: Math.min(...intervals) })
       }
     }
 
-    scheduleNext();
-  };
+    scheduleNext()
+  }
 
   const run: HeartbeatWakeHandler = async (params) => {
     if (!heartbeatsEnabled) {
-      return { status: "skipped", reason: "disabled" } satisfies HeartbeatRunResult;
+      return { status: "skipped", reason: "disabled" } satisfies HeartbeatRunResult
     }
     if (state.agents.size === 0) {
-      return { status: "skipped", reason: "disabled" } satisfies HeartbeatRunResult;
+      return { status: "skipped", reason: "disabled" } satisfies HeartbeatRunResult
     }
 
-    const reason = params?.reason;
-    const isInterval = reason === "interval";
-    const startedAt = Date.now();
-    const now = startedAt;
-    let ran = false;
+    const reason = params?.reason
+    const isInterval = reason === "interval"
+    const startedAt = Date.now()
+    const now = startedAt
+    let ran = false
 
     for (const agent of state.agents.values()) {
       if (isInterval && now < agent.nextDueMs) {
-        continue;
+        continue
       }
 
       const res = await runOnce({
@@ -869,33 +812,33 @@ export function startHeartbeatRunner(opts: {
         heartbeat: agent.heartbeat,
         reason,
         deps: { runtime: state.runtime },
-      });
+      })
       if (res.status === "skipped" && res.reason === "requests-in-flight") {
-        return res;
+        return res
       }
       if (res.status !== "skipped" || res.reason !== "disabled") {
-        agent.lastRunMs = now;
-        agent.nextDueMs = now + agent.intervalMs;
+        agent.lastRunMs = now
+        agent.nextDueMs = now + agent.intervalMs
       }
-      if (res.status === "ran") ran = true;
+      if (res.status === "ran") ran = true
     }
 
-    scheduleNext();
-    if (ran) return { status: "ran", durationMs: Date.now() - startedAt };
-    return { status: "skipped", reason: isInterval ? "not-due" : "disabled" };
-  };
+    scheduleNext()
+    if (ran) return { status: "ran", durationMs: Date.now() - startedAt }
+    return { status: "skipped", reason: isInterval ? "not-due" : "disabled" }
+  }
 
-  setHeartbeatWakeHandler(async (params) => run({ reason: params.reason }));
-  updateConfig(state.cfg);
+  const disposeWakeHandler = setHeartbeatWakeHandler(async (params) => run({ reason: params.reason }))
+  updateConfig(state.cfg)
 
   const cleanup = () => {
-    state.stopped = true;
-    setHeartbeatWakeHandler(null);
-    if (state.timer) clearTimeout(state.timer);
-    state.timer = null;
-  };
+    state.stopped = true
+    disposeWakeHandler()
+    if (state.timer) clearTimeout(state.timer)
+    state.timer = null
+  }
 
-  opts.abortSignal?.addEventListener("abort", cleanup, { once: true });
+  opts.abortSignal?.addEventListener("abort", cleanup, { once: true })
 
-  return { stop: cleanup, updateConfig };
+  return { stop: cleanup, updateConfig }
 }

--- a/packages/zee/Swabble/src/infra/heartbeat-wake.test.ts
+++ b/packages/zee/Swabble/src/infra/heartbeat-wake.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  hasHeartbeatWakeHandler,
+  hasPendingHeartbeatWake,
+  requestHeartbeatNow,
+  resetHeartbeatWakeStateForTests,
+  setHeartbeatWakeHandler,
+} from "./heartbeat-wake.js"
+
+describe("heartbeat-wake", () => {
+  beforeEach(() => {
+    resetHeartbeatWakeStateForTests()
+  })
+
+  afterEach(() => {
+    resetHeartbeatWakeStateForTests()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("coalesces multiple wake requests into one run", async () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" })
+    setHeartbeatWakeHandler(handler)
+
+    requestHeartbeatNow({ reason: "interval", coalesceMs: 200 })
+    requestHeartbeatNow({ reason: "exec-event", coalesceMs: 200 })
+    requestHeartbeatNow({ reason: "retry", coalesceMs: 200 })
+
+    expect(hasPendingHeartbeatWake()).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(199)
+    expect(handler).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({ reason: "exec-event" })
+    expect(hasPendingHeartbeatWake()).toBe(false)
+  })
+
+  it("retries requests-in-flight after the default retry delay", async () => {
+    vi.useFakeTimers()
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "skipped", reason: "requests-in-flight" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 })
+    setHeartbeatWakeHandler(handler)
+
+    requestHeartbeatNow({ reason: "interval", coalesceMs: 0 })
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler.mock.calls[1]?.[0]).toEqual({ reason: "interval" })
+  })
+
+  it("keeps retry cooldown even when a sooner request arrives", async () => {
+    vi.useFakeTimers()
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "skipped", reason: "requests-in-flight" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 })
+    setHeartbeatWakeHandler(handler)
+
+    requestHeartbeatNow({ reason: "interval", coalesceMs: 0 })
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    requestHeartbeatNow({ reason: "hook:wake", coalesceMs: 0 })
+    await vi.advanceTimersByTimeAsync(998)
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler.mock.calls[1]?.[0]).toEqual({ reason: "hook:wake" })
+  })
+
+  it("retries thrown handler errors after the default retry delay", async () => {
+    vi.useFakeTimers()
+    const handler = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ status: "skipped", reason: "disabled" })
+    setHeartbeatWakeHandler(handler)
+
+    requestHeartbeatNow({ reason: "exec-event", coalesceMs: 0 })
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler.mock.calls[1]?.[0]).toEqual({ reason: "exec-event" })
+  })
+
+  it("stale disposer does not clear a newer handler", async () => {
+    vi.useFakeTimers()
+    const handlerA = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 })
+    const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 })
+
+    const disposeA = setHeartbeatWakeHandler(handlerA)
+    const disposeB = setHeartbeatWakeHandler(handlerB)
+
+    disposeA()
+    expect(hasHeartbeatWakeHandler()).toBe(true)
+
+    requestHeartbeatNow({ reason: "interval", coalesceMs: 0 })
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handlerB).toHaveBeenCalledTimes(1)
+    expect(handlerA).not.toHaveBeenCalled()
+
+    disposeB()
+    expect(hasHeartbeatWakeHandler()).toBe(false)
+  })
+
+  it("preempts existing timer when a sooner schedule is requested", async () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 })
+    setHeartbeatWakeHandler(handler)
+
+    requestHeartbeatNow({ reason: "slow", coalesceMs: 5000 })
+    requestHeartbeatNow({ reason: "fast", coalesceMs: 100 })
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({ reason: "fast" })
+  })
+
+  it("keeps existing timer when later schedule is requested", async () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 })
+    setHeartbeatWakeHandler(handler)
+
+    requestHeartbeatNow({ reason: "fast", coalesceMs: 100 })
+    requestHeartbeatNow({ reason: "slow", coalesceMs: 5000 })
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not downgrade a higher-priority pending reason", async () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 })
+    setHeartbeatWakeHandler(handler)
+
+    requestHeartbeatNow({ reason: "exec-event", coalesceMs: 100 })
+    requestHeartbeatNow({ reason: "retry", coalesceMs: 100 })
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({ reason: "exec-event" })
+  })
+
+  it("resets running/scheduled flags when new handler is registered", async () => {
+    vi.useFakeTimers()
+
+    let resolveHang: () => void
+    const hangPromise = new Promise<void>((r) => {
+      resolveHang = r
+    })
+    const handlerA = vi.fn().mockReturnValue(hangPromise.then(() => ({ status: "ran" as const, durationMs: 1 })))
+    setHeartbeatWakeHandler(handlerA)
+
+    requestHeartbeatNow({ reason: "interval", coalesceMs: 0 })
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handlerA).toHaveBeenCalledTimes(1)
+
+    const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 })
+    setHeartbeatWakeHandler(handlerB)
+
+    requestHeartbeatNow({ reason: "interval", coalesceMs: 0 })
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handlerB).toHaveBeenCalledTimes(1)
+
+    resolveHang!()
+    await Promise.resolve()
+  })
+
+  it("clears stale retry cooldown when a new handler is registered", async () => {
+    vi.useFakeTimers()
+    const handlerA = vi.fn().mockResolvedValue({ status: "skipped", reason: "requests-in-flight" })
+    setHeartbeatWakeHandler(handlerA)
+
+    requestHeartbeatNow({ reason: "interval", coalesceMs: 0 })
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handlerA).toHaveBeenCalledTimes(1)
+
+    const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 })
+    setHeartbeatWakeHandler(handlerB)
+
+    requestHeartbeatNow({ reason: "manual", coalesceMs: 0 })
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handlerB).toHaveBeenCalledTimes(1)
+    expect(handlerB).toHaveBeenCalledWith({ reason: "manual" })
+  })
+
+  it("drains pending wake once a handler is registered", async () => {
+    vi.useFakeTimers()
+
+    requestHeartbeatNow({ reason: "manual", coalesceMs: 0 })
+    await vi.advanceTimersByTimeAsync(1)
+    expect(hasPendingHeartbeatWake()).toBe(true)
+
+    const handler = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" })
+    setHeartbeatWakeHandler(handler)
+
+    await vi.advanceTimersByTimeAsync(249)
+    expect(handler).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({ reason: "manual" })
+    expect(hasPendingHeartbeatWake()).toBe(false)
+  })
+})

--- a/packages/zee/Swabble/src/infra/heartbeat-wake.ts
+++ b/packages/zee/Swabble/src/infra/heartbeat-wake.ts
@@ -1,70 +1,185 @@
 export type HeartbeatRunResult =
   | { status: "ran"; durationMs: number }
   | { status: "skipped"; reason: string }
-  | { status: "failed"; reason: string };
+  | { status: "failed"; reason: string }
 
-export type HeartbeatWakeHandler = (opts: { reason?: string }) => Promise<HeartbeatRunResult>;
+export type HeartbeatWakeHandler = (opts: { reason?: string }) => Promise<HeartbeatRunResult>
 
-let handler: HeartbeatWakeHandler | null = null;
-let pendingReason: string | null = null;
-let scheduled = false;
-let running = false;
-let timer: NodeJS.Timeout | null = null;
-
-const DEFAULT_COALESCE_MS = 250;
-const DEFAULT_RETRY_MS = 1_000;
-
-function schedule(coalesceMs: number) {
-  if (timer) return;
-  timer = setTimeout(async () => {
-    timer = null;
-    scheduled = false;
-    const active = handler;
-    if (!active) return;
-    if (running) {
-      scheduled = true;
-      schedule(coalesceMs);
-      return;
-    }
-
-    const reason = pendingReason;
-    pendingReason = null;
-    running = true;
-    try {
-      const res = await active({ reason: reason ?? undefined });
-      if (res.status === "skipped" && res.reason === "requests-in-flight") {
-        // The main lane is busy; retry soon.
-        pendingReason = reason ?? "retry";
-        schedule(DEFAULT_RETRY_MS);
-      }
-    } catch {
-      // Error is already logged by the heartbeat runner; schedule a retry.
-      pendingReason = reason ?? "retry";
-      schedule(DEFAULT_RETRY_MS);
-    } finally {
-      running = false;
-      if (pendingReason || scheduled) schedule(coalesceMs);
-    }
-  }, coalesceMs);
-  timer.unref?.();
+type WakeTimerKind = "normal" | "retry"
+type PendingWakeReason = {
+  reason: string
+  priority: number
+  requestedAt: number
 }
 
-export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null) {
-  handler = next;
-  if (handler && pendingReason) {
-    schedule(DEFAULT_COALESCE_MS);
+let handler: HeartbeatWakeHandler | null = null
+let handlerGeneration = 0
+let pendingWake: PendingWakeReason | null = null
+let scheduled = false
+let running = false
+let timer: NodeJS.Timeout | null = null
+let timerDueAt: number | null = null
+let timerKind: WakeTimerKind | null = null
+
+const DEFAULT_COALESCE_MS = 250
+const DEFAULT_RETRY_MS = 1_000
+const HOOK_REASON_PREFIX = "hook:"
+const REASON_PRIORITY = {
+  RETRY: 0,
+  INTERVAL: 1,
+  DEFAULT: 2,
+  ACTION: 3,
+} as const
+
+function isActionWakeReason(reason: string): boolean {
+  return reason === "manual" || reason === "exec-event" || reason.startsWith(HOOK_REASON_PREFIX)
+}
+
+function resolveReasonPriority(reason: string): number {
+  if (reason === "retry") {
+    return REASON_PRIORITY.RETRY
+  }
+  if (reason === "interval") {
+    return REASON_PRIORITY.INTERVAL
+  }
+  if (isActionWakeReason(reason)) {
+    return REASON_PRIORITY.ACTION
+  }
+  return REASON_PRIORITY.DEFAULT
+}
+
+function normalizeWakeReason(reason?: string): string {
+  if (typeof reason !== "string") {
+    return "requested"
+  }
+  const trimmed = reason.trim()
+  return trimmed.length > 0 ? trimmed : "requested"
+}
+
+function queuePendingWakeReason(reason?: string, requestedAt = Date.now()) {
+  const normalizedReason = normalizeWakeReason(reason)
+  const next: PendingWakeReason = {
+    reason: normalizedReason,
+    priority: resolveReasonPriority(normalizedReason),
+    requestedAt,
+  }
+  if (!pendingWake) {
+    pendingWake = next
+    return
+  }
+  if (next.priority > pendingWake.priority) {
+    pendingWake = next
+    return
+  }
+  if (next.priority === pendingWake.priority && next.requestedAt >= pendingWake.requestedAt) {
+    pendingWake = next
+  }
+}
+
+function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
+  const delay = Number.isFinite(coalesceMs) ? Math.max(0, coalesceMs) : DEFAULT_COALESCE_MS
+  const dueAt = Date.now() + delay
+  if (timer) {
+    if (timerKind === "retry") {
+      return
+    }
+    if (typeof timerDueAt === "number" && timerDueAt <= dueAt) {
+      return
+    }
+    clearTimeout(timer)
+    timer = null
+    timerDueAt = null
+    timerKind = null
+  }
+  timerDueAt = dueAt
+  timerKind = kind
+  timer = setTimeout(async () => {
+    timer = null
+    timerDueAt = null
+    timerKind = null
+    scheduled = false
+    const active = handler
+    if (!active) return
+    if (running) {
+      scheduled = true
+      schedule(delay, kind)
+      return
+    }
+
+    const reason = pendingWake?.reason
+    pendingWake = null
+    running = true
+    try {
+      const res = await active({ reason: reason ?? undefined })
+      if (res.status === "skipped" && res.reason === "requests-in-flight") {
+        queuePendingWakeReason(reason ?? "retry")
+        schedule(DEFAULT_RETRY_MS, "retry")
+      }
+    } catch {
+      queuePendingWakeReason(reason ?? "retry")
+      schedule(DEFAULT_RETRY_MS, "retry")
+    } finally {
+      running = false
+      if (pendingWake || scheduled) {
+        schedule(delay, "normal")
+      }
+    }
+  }, delay)
+  timer.unref?.()
+}
+
+export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () => void {
+  handlerGeneration += 1
+  const generation = handlerGeneration
+  handler = next
+  if (next) {
+    if (timer) {
+      clearTimeout(timer)
+    }
+    timer = null
+    timerDueAt = null
+    timerKind = null
+    running = false
+    scheduled = false
+  }
+  if (handler && pendingWake) {
+    schedule(DEFAULT_COALESCE_MS, "normal")
+  }
+  return () => {
+    if (handlerGeneration !== generation) {
+      return
+    }
+    if (handler !== next) {
+      return
+    }
+    handlerGeneration += 1
+    handler = null
   }
 }
 
 export function requestHeartbeatNow(opts?: { reason?: string; coalesceMs?: number }) {
-  pendingReason = opts?.reason ?? pendingReason ?? "requested";
-  schedule(opts?.coalesceMs ?? DEFAULT_COALESCE_MS);
+  queuePendingWakeReason(opts?.reason)
+  schedule(opts?.coalesceMs ?? DEFAULT_COALESCE_MS, "normal")
 }
 
 export function hasHeartbeatWakeHandler() {
-  return handler !== null;
+  return handler !== null
 }
 
 export function hasPendingHeartbeatWake() {
-  return pendingReason !== null || Boolean(timer) || scheduled;
+  return pendingWake !== null || Boolean(timer) || scheduled
+}
+
+export function resetHeartbeatWakeStateForTests() {
+  if (timer) {
+    clearTimeout(timer)
+  }
+  timer = null
+  timerDueAt = null
+  timerKind = null
+  pendingWake = null
+  scheduled = false
+  running = false
+  handlerGeneration += 1
+  handler = null
 }

--- a/packages/zee/Swabble/src/process/command-queue.test.ts
+++ b/packages/zee/Swabble/src/process/command-queue.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const diagnosticMocks = vi.hoisted(() => ({
   logLaneEnqueue: vi.fn(),
@@ -8,81 +8,226 @@ const diagnosticMocks = vi.hoisted(() => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
-}));
+}))
 
 vi.mock("../logging/diagnostic.js", () => ({
   logLaneEnqueue: diagnosticMocks.logLaneEnqueue,
   logLaneDequeue: diagnosticMocks.logLaneDequeue,
   diagnosticLogger: diagnosticMocks.diag,
-}));
+}))
 
-import { enqueueCommand, getQueueSize } from "./command-queue.js";
+import {
+  enqueueCommand,
+  enqueueCommandInLane,
+  getActiveTaskCount,
+  getQueueSize,
+  resetAllLanes,
+  setCommandLaneConcurrency,
+  waitForActiveTasks,
+} from "./command-queue.js"
 
 describe("command queue", () => {
   beforeEach(() => {
-    diagnosticMocks.logLaneEnqueue.mockClear();
-    diagnosticMocks.logLaneDequeue.mockClear();
-    diagnosticMocks.diag.debug.mockClear();
-    diagnosticMocks.diag.warn.mockClear();
-    diagnosticMocks.diag.error.mockClear();
-  });
+    diagnosticMocks.logLaneEnqueue.mockClear()
+    diagnosticMocks.logLaneDequeue.mockClear()
+    diagnosticMocks.diag.debug.mockClear()
+    diagnosticMocks.diag.warn.mockClear()
+    diagnosticMocks.diag.error.mockClear()
+  })
+
+  it("resetAllLanes is safe when no lanes have been created", () => {
+    expect(getActiveTaskCount()).toBe(0)
+    expect(() => resetAllLanes()).not.toThrow()
+    expect(getActiveTaskCount()).toBe(0)
+  })
 
   it("runs tasks one at a time in order", async () => {
-    let active = 0;
-    let maxActive = 0;
-    const calls: number[] = [];
+    let active = 0
+    let maxActive = 0
+    const calls: number[] = []
 
     const makeTask = (id: number) => async () => {
-      active += 1;
-      maxActive = Math.max(maxActive, active);
-      calls.push(id);
-      await new Promise((resolve) => setTimeout(resolve, 15));
-      active -= 1;
-      return id;
-    };
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      calls.push(id)
+      await new Promise((resolve) => setTimeout(resolve, 15))
+      active -= 1
+      return id
+    }
 
     const results = await Promise.all([
       enqueueCommand(makeTask(1)),
       enqueueCommand(makeTask(2)),
       enqueueCommand(makeTask(3)),
-    ]);
+    ])
 
-    expect(results).toEqual([1, 2, 3]);
-    expect(calls).toEqual([1, 2, 3]);
-    expect(maxActive).toBe(1);
-    expect(getQueueSize()).toBe(0);
-  });
+    expect(results).toEqual([1, 2, 3])
+    expect(calls).toEqual([1, 2, 3])
+    expect(maxActive).toBe(1)
+    expect(getQueueSize()).toBe(0)
+  })
 
   it("logs enqueue depth after push", async () => {
-    const task = enqueueCommand(async () => {});
+    const task = enqueueCommand(async () => {})
 
-    expect(diagnosticMocks.logLaneEnqueue).toHaveBeenCalledTimes(1);
-    expect(diagnosticMocks.logLaneEnqueue.mock.calls[0]?.[1]).toBe(1);
+    expect(diagnosticMocks.logLaneEnqueue).toHaveBeenCalledTimes(1)
+    expect(diagnosticMocks.logLaneEnqueue.mock.calls[0]?.[1]).toBe(1)
 
-    await task;
-  });
+    await task
+  })
 
   it("invokes onWait callback when a task waits past the threshold", async () => {
-    let waited: number | null = null;
-    let queuedAhead: number | null = null;
+    let waited: number | null = null
+    let queuedAhead: number | null = null
 
     // First task holds the queue long enough to trigger wait notice.
     const first = enqueueCommand(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 30));
-    });
+      await new Promise((resolve) => setTimeout(resolve, 30))
+    })
 
     const second = enqueueCommand(async () => {}, {
       warnAfterMs: 5,
       onWait: (ms, ahead) => {
-        waited = ms;
-        queuedAhead = ahead;
+        waited = ms
+        queuedAhead = ahead
       },
-    });
+    })
 
-    await Promise.all([first, second]);
+    await Promise.all([first, second])
 
-    expect(waited).not.toBeNull();
-    expect(waited as number).toBeGreaterThanOrEqual(5);
-    expect(queuedAhead).toBe(0);
-  });
-});
+    expect(waited).not.toBeNull()
+    expect(waited as number).toBeGreaterThanOrEqual(5)
+    expect(queuedAhead).toBe(0)
+  })
+
+  it("getActiveTaskCount returns count of currently executing tasks", async () => {
+    let resolve1!: () => void
+    const blocker = new Promise<void>((r) => {
+      resolve1 = r
+    })
+
+    const task = enqueueCommand(async () => {
+      await blocker
+    })
+
+    await new Promise((r) => setTimeout(r, 5))
+    expect(getActiveTaskCount()).toBe(1)
+
+    resolve1()
+    await task
+    expect(getActiveTaskCount()).toBe(0)
+  })
+
+  it("waitForActiveTasks resolves immediately when no tasks are active", async () => {
+    const { drained } = await waitForActiveTasks(1000)
+    expect(drained).toBe(true)
+  })
+
+  it("waitForActiveTasks waits for active tasks to finish", async () => {
+    let resolve1!: () => void
+    const blocker = new Promise<void>((r) => {
+      resolve1 = r
+    })
+
+    const task = enqueueCommand(async () => {
+      await blocker
+    })
+
+    await new Promise((r) => setTimeout(r, 5))
+    const drainPromise = waitForActiveTasks(5000)
+    setTimeout(() => resolve1(), 50)
+
+    const { drained } = await drainPromise
+    expect(drained).toBe(true)
+
+    await task
+  })
+
+  it("waitForActiveTasks returns drained=false on timeout", async () => {
+    let resolve1!: () => void
+    const blocker = new Promise<void>((r) => {
+      resolve1 = r
+    })
+
+    const task = enqueueCommand(async () => {
+      await blocker
+    })
+
+    await new Promise((r) => setTimeout(r, 5))
+
+    const { drained } = await waitForActiveTasks(50)
+    expect(drained).toBe(false)
+
+    resolve1()
+    await task
+  })
+
+  it("resetAllLanes drains queued work immediately after reset", async () => {
+    const lane = `reset-test-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    setCommandLaneConcurrency(lane, 1)
+
+    let resolve1!: () => void
+    const blocker = new Promise<void>((r) => {
+      resolve1 = r
+    })
+
+    const task1 = enqueueCommandInLane(lane, async () => {
+      await blocker
+    })
+
+    await vi.waitFor(() => {
+      expect(getActiveTaskCount()).toBeGreaterThanOrEqual(1)
+    })
+
+    let task2Ran = false
+    const task2 = enqueueCommandInLane(lane, async () => {
+      task2Ran = true
+    })
+
+    await vi.waitFor(() => {
+      expect(getQueueSize(lane)).toBeGreaterThanOrEqual(2)
+    })
+    expect(task2Ran).toBe(false)
+
+    resetAllLanes()
+
+    resolve1()
+    await task1
+    await task2
+    expect(task2Ran).toBe(true)
+  })
+
+  it("waitForActiveTasks ignores tasks that start after the call", async () => {
+    const lane = `drain-snapshot-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    setCommandLaneConcurrency(lane, 2)
+
+    let resolve1!: () => void
+    const blocker1 = new Promise<void>((r) => {
+      resolve1 = r
+    })
+    let resolve2!: () => void
+    const blocker2 = new Promise<void>((r) => {
+      resolve2 = r
+    })
+
+    const first = enqueueCommandInLane(lane, async () => {
+      await blocker1
+    })
+    await new Promise((r) => setTimeout(r, 5))
+
+    const drainPromise = waitForActiveTasks(2000)
+
+    const second = enqueueCommandInLane(lane, async () => {
+      await blocker2
+    })
+    await new Promise((r) => setTimeout(r, 5))
+    expect(getActiveTaskCount()).toBeGreaterThanOrEqual(2)
+
+    resolve1()
+    const { drained } = await drainPromise
+    expect(drained).toBe(true)
+
+    resolve2()
+    await Promise.all([first, second])
+  })
+})

--- a/packages/zee/Swabble/src/process/command-queue.ts
+++ b/packages/zee/Swabble/src/process/command-queue.ts
@@ -1,5 +1,5 @@
-import { CommandLane } from "./lanes.js";
-import { diagnosticLogger as diag, logLaneDequeue, logLaneEnqueue } from "../logging/diagnostic.js";
+import { CommandLane } from "./lanes.js"
+import { diagnosticLogger as diag, logLaneDequeue, logLaneEnqueue } from "../logging/diagnostic.js"
 
 // Minimal in-process queue to serialize command executions.
 // Default lane ("main") preserves the existing behavior. Additional lanes allow
@@ -7,102 +7,115 @@ import { diagnosticLogger as diag, logLaneDequeue, logLaneEnqueue } from "../log
 // the main auto-reply workflow.
 
 type QueueEntry = {
-  task: () => Promise<unknown>;
-  resolve: (value: unknown) => void;
-  reject: (reason?: unknown) => void;
-  enqueuedAt: number;
-  warnAfterMs: number;
-  onWait?: (waitMs: number, queuedAhead: number) => void;
-};
+  task: () => Promise<unknown>
+  resolve: (value: unknown) => void
+  reject: (reason?: unknown) => void
+  enqueuedAt: number
+  warnAfterMs: number
+  onWait?: (waitMs: number, queuedAhead: number) => void
+}
 
 type LaneState = {
-  lane: string;
-  queue: QueueEntry[];
-  active: number;
-  maxConcurrent: number;
-  draining: boolean;
-};
+  lane: string
+  queue: QueueEntry[]
+  activeTaskIds: Set<number>
+  maxConcurrent: number
+  draining: boolean
+  generation: number
+}
 
-const lanes = new Map<string, LaneState>();
+const lanes = new Map<string, LaneState>()
+let nextTaskId = 1
 
 function getLaneState(lane: string): LaneState {
-  const existing = lanes.get(lane);
-  if (existing) return existing;
+  const existing = lanes.get(lane)
+  if (existing) return existing
   const created: LaneState = {
     lane,
     queue: [],
-    active: 0,
+    activeTaskIds: new Set(),
     maxConcurrent: 1,
     draining: false,
-  };
-  lanes.set(lane, created);
-  return created;
+    generation: 0,
+  }
+  lanes.set(lane, created)
+  return created
+}
+
+function completeTask(state: LaneState, taskId: number, taskGeneration: number): boolean {
+  if (taskGeneration !== state.generation) {
+    return false
+  }
+  state.activeTaskIds.delete(taskId)
+  return true
 }
 
 function drainLane(lane: string) {
-  const state = getLaneState(lane);
-  if (state.draining) return;
-  state.draining = true;
+  const state = getLaneState(lane)
+  if (state.draining) return
+  state.draining = true
 
   const pump = () => {
-    while (state.active < state.maxConcurrent && state.queue.length > 0) {
-      const entry = state.queue.shift() as QueueEntry;
-      const waitedMs = Date.now() - entry.enqueuedAt;
+    while (state.activeTaskIds.size < state.maxConcurrent && state.queue.length > 0) {
+      const entry = state.queue.shift() as QueueEntry
+      const waitedMs = Date.now() - entry.enqueuedAt
       if (waitedMs >= entry.warnAfterMs) {
-        entry.onWait?.(waitedMs, state.queue.length);
-        diag.warn(
-          `lane wait exceeded: lane=${lane} waitedMs=${waitedMs} queueAhead=${state.queue.length}`,
-        );
+        entry.onWait?.(waitedMs, state.queue.length)
+        diag.warn(`lane wait exceeded: lane=${lane} waitedMs=${waitedMs} queueAhead=${state.queue.length}`)
       }
-      logLaneDequeue(lane, waitedMs, state.queue.length);
-      state.active += 1;
+      logLaneDequeue(lane, waitedMs, state.queue.length)
+      const taskId = nextTaskId++
+      const taskGeneration = state.generation
+      state.activeTaskIds.add(taskId)
       void (async () => {
-        const startTime = Date.now();
+        const startTime = Date.now()
         try {
-          const result = await entry.task();
-          state.active -= 1;
-          diag.debug(
-            `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.active} queued=${state.queue.length}`,
-          );
-          pump();
-          entry.resolve(result);
-        } catch (err) {
-          state.active -= 1;
-          const isProbeLane = lane.startsWith("auth-probe:") || lane.startsWith("session:probe-");
-          if (!isProbeLane) {
-            diag.error(
-              `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${String(err)}"`,
-            );
+          const result = await entry.task()
+          const completedCurrentGeneration = completeTask(state, taskId, taskGeneration)
+          if (completedCurrentGeneration) {
+            diag.debug(
+              `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.activeTaskIds.size} queued=${state.queue.length}`,
+            )
+            pump()
           }
-          pump();
-          entry.reject(err);
+          entry.resolve(result)
+        } catch (err) {
+          const completedCurrentGeneration = completeTask(state, taskId, taskGeneration)
+          const isProbeLane = lane.startsWith("auth-probe:") || lane.startsWith("session:probe-")
+          if (!isProbeLane) {
+            diag.error(`lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${String(err)}"`)
+          }
+          if (completedCurrentGeneration) {
+            pump()
+          }
+          entry.reject(err)
         }
-      })();
+      })()
     }
-    state.draining = false;
-  };
+    state.draining = false
+  }
 
-  pump();
+  pump()
 }
 
 export function setCommandLaneConcurrency(lane: string, maxConcurrent: number) {
-  const cleaned = lane.trim() || CommandLane.Main;
-  const state = getLaneState(cleaned);
-  state.maxConcurrent = Math.max(1, Math.floor(maxConcurrent));
-  drainLane(cleaned);
+  const cleaned = lane.trim() || CommandLane.Main
+  const state = getLaneState(cleaned)
+  state.maxConcurrent = Math.max(1, Math.floor(maxConcurrent))
+  drainLane(cleaned)
 }
 
 export function enqueueCommandInLane<T>(
   lane: string,
   task: () => Promise<T>,
   opts?: {
-    warnAfterMs?: number;
-    onWait?: (waitMs: number, queuedAhead: number) => void;
+    warnAfterMs?: number
+    onWait?: (waitMs: number, queuedAhead: number) => void
   },
 ): Promise<T> {
-  const cleaned = lane.trim() || CommandLane.Main;
-  const warnAfterMs = opts?.warnAfterMs ?? 2_000;
-  const state = getLaneState(cleaned);
+  const cleaned = lane.trim() || CommandLane.Main
+  const warnAfterMs = opts?.warnAfterMs ?? 2_000
+  const state = getLaneState(cleaned)
   return new Promise<T>((resolve, reject) => {
     state.queue.push({
       task: () => task(),
@@ -111,42 +124,116 @@ export function enqueueCommandInLane<T>(
       enqueuedAt: Date.now(),
       warnAfterMs,
       onWait: opts?.onWait,
-    });
-    logLaneEnqueue(cleaned, state.queue.length + state.active);
-    drainLane(cleaned);
-  });
+    })
+    logLaneEnqueue(cleaned, state.queue.length + state.activeTaskIds.size)
+    drainLane(cleaned)
+  })
 }
 
 export function enqueueCommand<T>(
   task: () => Promise<T>,
   opts?: {
-    warnAfterMs?: number;
-    onWait?: (waitMs: number, queuedAhead: number) => void;
+    warnAfterMs?: number
+    onWait?: (waitMs: number, queuedAhead: number) => void
   },
 ): Promise<T> {
-  return enqueueCommandInLane(CommandLane.Main, task, opts);
+  return enqueueCommandInLane(CommandLane.Main, task, opts)
 }
 
 export function getQueueSize(lane: string = CommandLane.Main) {
-  const resolved = lane.trim() || CommandLane.Main;
-  const state = lanes.get(resolved);
-  if (!state) return 0;
-  return state.queue.length + state.active;
+  const resolved = lane.trim() || CommandLane.Main
+  const state = lanes.get(resolved)
+  if (!state) return 0
+  return state.queue.length + state.activeTaskIds.size
 }
 
 export function getTotalQueueSize() {
-  let total = 0;
+  let total = 0
   for (const s of lanes.values()) {
-    total += s.queue.length + s.active;
+    total += s.queue.length + s.activeTaskIds.size
   }
-  return total;
+  return total
 }
 
 export function clearCommandLane(lane: string = CommandLane.Main) {
-  const cleaned = lane.trim() || CommandLane.Main;
-  const state = lanes.get(cleaned);
-  if (!state) return 0;
-  const removed = state.queue.length;
-  state.queue.length = 0;
-  return removed;
+  const cleaned = lane.trim() || CommandLane.Main
+  const state = lanes.get(cleaned)
+  if (!state) return 0
+  const removed = state.queue.length
+  state.queue.length = 0
+  return removed
+}
+
+/**
+ * Reset all lanes to an idle runtime state.
+ *
+ * Used after in-process restarts where interrupted tasks may leave stale
+ * active task bookkeeping behind, permanently blocking new queue work.
+ * Queued entries are preserved and drained immediately.
+ */
+export function resetAllLanes(): void {
+  const lanesToDrain: string[] = []
+  for (const state of lanes.values()) {
+    state.generation += 1
+    state.activeTaskIds.clear()
+    state.draining = false
+    if (state.queue.length > 0) {
+      lanesToDrain.push(state.lane)
+    }
+  }
+  for (const lane of lanesToDrain) {
+    drainLane(lane)
+  }
+}
+
+export function getActiveTaskCount(): number {
+  let total = 0
+  for (const state of lanes.values()) {
+    total += state.activeTaskIds.size
+  }
+  return total
+}
+
+export function waitForActiveTasks(timeoutMs: number): Promise<{ drained: boolean }> {
+  const POLL_INTERVAL_MS = 50
+  const deadline = Date.now() + timeoutMs
+  const activeAtStart = new Set<number>()
+  for (const state of lanes.values()) {
+    for (const taskId of state.activeTaskIds) {
+      activeAtStart.add(taskId)
+    }
+  }
+
+  return new Promise((resolve) => {
+    const check = () => {
+      if (activeAtStart.size === 0) {
+        resolve({ drained: true })
+        return
+      }
+
+      let hasPending = false
+      for (const state of lanes.values()) {
+        for (const taskId of state.activeTaskIds) {
+          if (activeAtStart.has(taskId)) {
+            hasPending = true
+            break
+          }
+        }
+        if (hasPending) {
+          break
+        }
+      }
+
+      if (!hasPending) {
+        resolve({ drained: true })
+        return
+      }
+      if (Date.now() >= deadline) {
+        resolve({ drained: false })
+        return
+      }
+      setTimeout(check, POLL_INTERVAL_MS)
+    }
+    check()
+  })
 }

--- a/packages/zee/Swabble/src/process/restart-recovery.test.ts
+++ b/packages/zee/Swabble/src/process/restart-recovery.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest"
+import { createRestartIterationHook } from "./restart-recovery.js"
+
+describe("restart-recovery", () => {
+  it("skips recovery on first iteration and runs on subsequent iterations", () => {
+    const onRestart = vi.fn()
+    const onIteration = createRestartIterationHook(onRestart)
+
+    expect(onIteration()).toBe(false)
+    expect(onRestart).not.toHaveBeenCalled()
+
+    expect(onIteration()).toBe(true)
+    expect(onRestart).toHaveBeenCalledTimes(1)
+
+    expect(onIteration()).toBe(true)
+    expect(onRestart).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/zee/Swabble/src/process/restart-recovery.ts
+++ b/packages/zee/Swabble/src/process/restart-recovery.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns an iteration hook for in-process restart loops.
+ * The first call is considered initial startup and does nothing.
+ * Each subsequent call represents a restart iteration and invokes `onRestart`.
+ */
+export function createRestartIterationHook(onRestart: () => void): () => boolean {
+  let isFirstIteration = true
+  return () => {
+    if (isFirstIteration) {
+      isFirstIteration = false
+      return false
+    }
+    onRestart()
+    return true
+  }
+}


### PR DESCRIPTION
## Summary
- harden command-lane bookkeeping with generation-scoped active task IDs so stale completions from pre-restart tasks cannot block queues
- add `resetAllLanes`, `getActiveTaskCount`, and `waitForActiveTasks`, and invoke reset on restart iterations in the gateway run loop
- drain active tasks (with timeout) before SIGUSR1 restarts to reduce dropped in-flight work
- harden heartbeat wake lifecycle with generation-scoped handler disposal, priority reason coalescing, timer preemption rules, and stale state reset on handler replacement
- add focused regression coverage for command-queue restart behavior, heartbeat wake restart behavior, run-loop restart iteration handling, and restart-recovery hook

Closes #334

## Test Plan
- `cd packages/zee/Swabble && bunx vitest run src/infra/heartbeat-wake.test.ts src/process/command-queue.test.ts src/process/restart-recovery.test.ts src/cli/gateway-cli/run-loop.test.ts`
- `cd packages/zee/Swabble && bunx prettier --check src/cli/gateway-cli/run-loop.ts src/infra/heartbeat-runner.ts src/infra/heartbeat-wake.ts src/process/command-queue.ts src/process/command-queue.test.ts src/infra/heartbeat-wake.test.ts src/process/restart-recovery.ts src/process/restart-recovery.test.ts src/cli/gateway-cli/run-loop.test.ts`

## Notes
- In this environment, `src/infra/heartbeat-runner.scheduler.test.ts` still fails before running tests due `TypeError: onExit is not a function` from `proper-lockfile` import initialization.