### PR TITLE
Fix #359: add regression coverage for root $schema config key

### DIFF
--- a/packages/zee/Swabble/src/config/config.schema-key.test.ts
+++ b/packages/zee/Swabble/src/config/config.schema-key.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { ZeeSchema } from "./zod-schema.js"
+
+describe("config $schema key", () => {
+  it("accepts config with $schema string", () => {
+    const result = ZeeSchema.safeParse({
+      $schema: "https://schemas.zee.local/config.schema.json",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts config without $schema", () => {
+    const result = ZeeSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects non-string $schema", () => {
+    const result = ZeeSchema.safeParse({
+      $schema: 123,
+    })
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add a focused Swabble config regression suite for root `$schema` handling
- verify root config accepts string `$schema`, accepts missing `$schema`, and rejects non-string `$schema`
- lock parity behavior to prevent future regressions under strict root schema validation

Closes #359

## Test Plan
- `cd packages/zee/Swabble && bunx vitest run src/config/config.schema-key.test.ts`