### PR TITLE
Fix #354: avoid auto-creating HEARTBEAT.md during workspace init

### DIFF
--- a/packages/zee/Swabble/src/agents/workspace.test.ts
+++ b/packages/zee/Swabble/src/agents/workspace.test.ts
@@ -1,49 +1,104 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
 
 import {
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_BOOTSTRAP_FILENAME,
+  DEFAULT_HEARTBEAT_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
   DEFAULT_MEMORY_ALT_FILENAME,
   DEFAULT_MEMORY_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_TOOLS_FILENAME,
+  DEFAULT_USER_FILENAME,
+  ensureAgentWorkspace,
   loadWorkspaceBootstrapFiles,
-} from "./workspace.js";
-import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
+} from "./workspace.js"
+import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js"
 
 describe("loadWorkspaceBootstrapFiles", () => {
   it("includes MEMORY.md when present", async () => {
-    const tempDir = await makeTempWorkspace("zee-workspace-");
-    await writeWorkspaceFile({ dir: tempDir, name: "MEMORY.md", content: "memory" });
+    const tempDir = await makeTempWorkspace("zee-workspace-")
+    await writeWorkspaceFile({ dir: tempDir, name: "MEMORY.md", content: "memory" })
 
-    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const files = await loadWorkspaceBootstrapFiles(tempDir)
     const memoryEntries = files.filter((file) =>
       [DEFAULT_MEMORY_FILENAME, DEFAULT_MEMORY_ALT_FILENAME].includes(file.name),
-    );
+    )
 
-    expect(memoryEntries).toHaveLength(1);
-    expect(memoryEntries[0]?.missing).toBe(false);
-    expect(memoryEntries[0]?.content).toBe("memory");
-  });
+    expect(memoryEntries).toHaveLength(1)
+    expect(memoryEntries[0]?.missing).toBe(false)
+    expect(memoryEntries[0]?.content).toBe("memory")
+  })
 
   it("includes memory.md when MEMORY.md is absent", async () => {
-    const tempDir = await makeTempWorkspace("zee-workspace-");
-    await writeWorkspaceFile({ dir: tempDir, name: "memory.md", content: "alt" });
+    const tempDir = await makeTempWorkspace("zee-workspace-")
+    await writeWorkspaceFile({ dir: tempDir, name: "memory.md", content: "alt" })
 
-    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const files = await loadWorkspaceBootstrapFiles(tempDir)
     const memoryEntries = files.filter((file) =>
       [DEFAULT_MEMORY_FILENAME, DEFAULT_MEMORY_ALT_FILENAME].includes(file.name),
-    );
+    )
 
-    expect(memoryEntries).toHaveLength(1);
-    expect(memoryEntries[0]?.missing).toBe(false);
-    expect(memoryEntries[0]?.content).toBe("alt");
-  });
+    expect(memoryEntries).toHaveLength(1)
+    expect(memoryEntries[0]?.missing).toBe(false)
+    expect(memoryEntries[0]?.content).toBe("alt")
+  })
 
   it("omits memory entries when no memory files exist", async () => {
-    const tempDir = await makeTempWorkspace("zee-workspace-");
+    const tempDir = await makeTempWorkspace("zee-workspace-")
 
-    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const files = await loadWorkspaceBootstrapFiles(tempDir)
     const memoryEntries = files.filter((file) =>
       [DEFAULT_MEMORY_FILENAME, DEFAULT_MEMORY_ALT_FILENAME].includes(file.name),
-    );
+    )
 
-    expect(memoryEntries).toHaveLength(0);
-  });
-});
+    expect(memoryEntries).toHaveLength(0)
+  })
+})
+
+describe("ensureAgentWorkspace", () => {
+  it("does not auto-create HEARTBEAT.md when bootstrapping a new workspace", async () => {
+    const tempDir = await makeTempWorkspace("zee-workspace-")
+
+    await ensureAgentWorkspace({
+      dir: tempDir,
+      ensureBootstrapFiles: true,
+    })
+
+    const expectedBootstrapFiles = [
+      DEFAULT_AGENTS_FILENAME,
+      DEFAULT_SOUL_FILENAME,
+      DEFAULT_TOOLS_FILENAME,
+      DEFAULT_IDENTITY_FILENAME,
+      DEFAULT_USER_FILENAME,
+      DEFAULT_BOOTSTRAP_FILENAME,
+    ]
+
+    for (const name of expectedBootstrapFiles) {
+      await expect(fs.access(path.join(tempDir, name))).resolves.toBeUndefined()
+    }
+    await expect(fs.access(path.join(tempDir, DEFAULT_HEARTBEAT_FILENAME))).rejects.toMatchObject({
+      code: "ENOENT",
+    })
+  })
+
+  it("preserves an existing HEARTBEAT.md file", async () => {
+    const tempDir = await makeTempWorkspace("zee-workspace-")
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_HEARTBEAT_FILENAME,
+      content: "existing heartbeat content",
+    })
+
+    await ensureAgentWorkspace({
+      dir: tempDir,
+      ensureBootstrapFiles: true,
+    })
+
+    await expect(fs.readFile(path.join(tempDir, DEFAULT_HEARTBEAT_FILENAME), "utf-8")).resolves.toBe(
+      "existing heartbeat content",
+    )
+  })
+})

--- a/packages/zee/Swabble/src/agents/workspace.ts
+++ b/packages/zee/Swabble/src/agents/workspace.ts
@@ -1,85 +1,82 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
 
-import { isSubagentSessionKey, normalizeAgentId } from "../routing/session-key.js";
-import { runCommandWithTimeout } from "../process/exec.js";
-import { resolveUserPath } from "../utils.js";
+import { isSubagentSessionKey, normalizeAgentId } from "../routing/session-key.js"
+import { runCommandWithTimeout } from "../process/exec.js"
+import { resolveUserPath } from "../utils.js"
 
 export function resolveDefaultAgentWorkspaceDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
 ): string {
-  const profile = env.ZEE_PROFILE?.trim();
+  const profile = env.ZEE_PROFILE?.trim()
   if (profile && profile.toLowerCase() !== "default") {
-    return path.join(homedir(), `zee-${profile}`);
+    return path.join(homedir(), `zee-${profile}`)
   }
-  return path.join(homedir(), "zee");
+  return path.join(homedir(), "zee")
 }
 
-export const DEFAULT_AGENT_WORKSPACE_DIR = resolveDefaultAgentWorkspaceDir();
-export const DEFAULT_AGENTS_FILENAME = "AGENTS.md";
-export const DEFAULT_SOUL_FILENAME = "SOUL.md";
-export const DEFAULT_TOOLS_FILENAME = "TOOLS.md";
-export const DEFAULT_IDENTITY_FILENAME = "IDENTITY.md";
-export const DEFAULT_USER_FILENAME = "USER.md";
-export const DEFAULT_HEARTBEAT_FILENAME = "HEARTBEAT.md";
-export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
-export const DEFAULT_MEMORY_FILENAME = "MEMORY.md";
-export const DEFAULT_MEMORY_ALT_FILENAME = "memory.md";
+export const DEFAULT_AGENT_WORKSPACE_DIR = resolveDefaultAgentWorkspaceDir()
+export const DEFAULT_AGENTS_FILENAME = "AGENTS.md"
+export const DEFAULT_SOUL_FILENAME = "SOUL.md"
+export const DEFAULT_TOOLS_FILENAME = "TOOLS.md"
+export const DEFAULT_IDENTITY_FILENAME = "IDENTITY.md"
+export const DEFAULT_USER_FILENAME = "USER.md"
+export const DEFAULT_HEARTBEAT_FILENAME = "HEARTBEAT.md"
+export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md"
+export const DEFAULT_MEMORY_FILENAME = "MEMORY.md"
+export const DEFAULT_MEMORY_ALT_FILENAME = "memory.md"
 
-const TEMPLATE_DIR = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../../docs/reference/templates",
-);
+const TEMPLATE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../docs/reference/templates")
 
 function stripFrontMatter(content: string): string {
-  if (!content.startsWith("---")) return content;
-  const endIndex = content.indexOf("\n---", 3);
-  if (endIndex === -1) return content;
-  const start = endIndex + "\n---".length;
-  let trimmed = content.slice(start);
-  trimmed = trimmed.replace(/^\s+/, "");
-  return trimmed;
+  if (!content.startsWith("---")) return content
+  const endIndex = content.indexOf("\n---", 3)
+  if (endIndex === -1) return content
+  const start = endIndex + "\n---".length
+  let trimmed = content.slice(start)
+  trimmed = trimmed.replace(/^\s+/, "")
+  return trimmed
 }
 
 async function loadTemplateOptional(name: string): Promise<string | null> {
-  const templatePath = path.join(TEMPLATE_DIR, name);
+  const templatePath = path.join(TEMPLATE_DIR, name)
   try {
-    const content = await fs.readFile(templatePath, "utf-8");
-    return stripFrontMatter(content);
+    const content = await fs.readFile(templatePath, "utf-8")
+    return stripFrontMatter(content)
   } catch (err) {
-    const anyErr = err as { code?: string };
-    if (anyErr.code === "ENOENT") return null;
-    throw err;
+    const anyErr = err as { code?: string }
+    if (anyErr.code === "ENOENT") return null
+    throw err
   }
 }
 
 async function loadTemplate(name: string): Promise<string> {
-  const content = await loadTemplateOptional(name);
-  if (content !== null) return content;
-  const templatePath = path.join(TEMPLATE_DIR, name);
+  const content = await loadTemplateOptional(name)
+  if (content !== null) return content
+  const templatePath = path.join(TEMPLATE_DIR, name)
   throw new Error(
     `Missing workspace template: ${name} (${templatePath}). Ensure docs/reference/templates are packaged.`,
-  );
+  )
 }
 
 function formatPersonaTemplateName(filename: string, persona: string): string {
-  const ext = path.extname(filename);
-  const base = ext ? filename.slice(0, -ext.length) : filename;
-  return `${base}.${persona}${ext}`;
+  const ext = path.extname(filename)
+  const base = ext ? filename.slice(0, -ext.length) : filename
+  return `${base}.${persona}${ext}`
 }
 
 async function loadTemplateForAgent(name: string, agentId?: string): Promise<string> {
-  const normalized = normalizeAgentId(agentId);
+  const normalized = normalizeAgentId(agentId)
   if (normalized !== "johny" && normalized !== "stanley") {
-    return loadTemplate(name);
+    return loadTemplate(name)
   }
-  const candidate = formatPersonaTemplateName(name, normalized);
-  const content = await loadTemplateOptional(candidate);
-  if (content !== null) return content;
-  return loadTemplate(name);
+  const candidate = formatPersonaTemplateName(name, normalized)
+  const content = await loadTemplateOptional(candidate)
+  if (content !== null) return content
+  return loadTemplate(name)
 }
 
 export type WorkspaceBootstrapFileName =
@@ -91,117 +88,115 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_HEARTBEAT_FILENAME
   | typeof DEFAULT_BOOTSTRAP_FILENAME
   | typeof DEFAULT_MEMORY_FILENAME
-  | typeof DEFAULT_MEMORY_ALT_FILENAME;
+  | typeof DEFAULT_MEMORY_ALT_FILENAME
 
 export type WorkspaceBootstrapFile = {
-  name: WorkspaceBootstrapFileName;
-  path: string;
-  content?: string;
-  missing: boolean;
-};
+  name: WorkspaceBootstrapFileName
+  path: string
+  content?: string
+  missing: boolean
+}
 
 async function writeFileIfMissing(filePath: string, content: string) {
   try {
     await fs.writeFile(filePath, content, {
       encoding: "utf-8",
       flag: "wx",
-    });
+    })
   } catch (err) {
-    const anyErr = err as { code?: string };
-    if (anyErr.code !== "EEXIST") throw err;
+    const anyErr = err as { code?: string }
+    if (anyErr.code !== "EEXIST") throw err
   }
 }
 
 async function hasGitRepo(dir: string): Promise<boolean> {
   try {
-    await fs.stat(path.join(dir, ".git"));
-    return true;
+    await fs.stat(path.join(dir, ".git"))
+    return true
   } catch {
-    return false;
+    return false
   }
 }
 
 async function isGitAvailable(): Promise<boolean> {
   try {
-    const result = await runCommandWithTimeout(["git", "--version"], { timeoutMs: 2_000 });
-    return result.code === 0;
+    const result = await runCommandWithTimeout(["git", "--version"], { timeoutMs: 2_000 })
+    return result.code === 0
   } catch {
-    return false;
+    return false
   }
 }
 
 async function ensureGitRepo(dir: string, isBrandNewWorkspace: boolean) {
-  if (!isBrandNewWorkspace) return;
-  if (await hasGitRepo(dir)) return;
-  if (!(await isGitAvailable())) return;
+  if (!isBrandNewWorkspace) return
+  if (await hasGitRepo(dir)) return
+  if (!(await isGitAvailable())) return
   try {
-    await runCommandWithTimeout(["git", "init"], { cwd: dir, timeoutMs: 10_000 });
+    await runCommandWithTimeout(["git", "init"], { cwd: dir, timeoutMs: 10_000 })
   } catch {
     // Ignore git init failures; workspace creation should still succeed.
   }
 }
 
 export async function ensureAgentWorkspace(params?: {
-  dir?: string;
-  ensureBootstrapFiles?: boolean;
-  agentId?: string;
+  dir?: string
+  ensureBootstrapFiles?: boolean
+  agentId?: string
 }): Promise<{
-  dir: string;
-  agentsPath?: string;
-  soulPath?: string;
-  toolsPath?: string;
-  identityPath?: string;
-  userPath?: string;
-  heartbeatPath?: string;
-  bootstrapPath?: string;
+  dir: string
+  agentsPath?: string
+  soulPath?: string
+  toolsPath?: string
+  identityPath?: string
+  userPath?: string
+  heartbeatPath?: string
+  bootstrapPath?: string
 }> {
-  const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
-  const dir = resolveUserPath(rawDir);
-  await fs.mkdir(dir, { recursive: true });
+  const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR
+  const dir = resolveUserPath(rawDir)
+  await fs.mkdir(dir, { recursive: true })
 
-  if (!params?.ensureBootstrapFiles) return { dir };
+  if (!params?.ensureBootstrapFiles) return { dir }
 
-  const agentsPath = path.join(dir, DEFAULT_AGENTS_FILENAME);
-  const soulPath = path.join(dir, DEFAULT_SOUL_FILENAME);
-  const toolsPath = path.join(dir, DEFAULT_TOOLS_FILENAME);
-  const identityPath = path.join(dir, DEFAULT_IDENTITY_FILENAME);
-  const userPath = path.join(dir, DEFAULT_USER_FILENAME);
-  const heartbeatPath = path.join(dir, DEFAULT_HEARTBEAT_FILENAME);
-  const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
+  const agentsPath = path.join(dir, DEFAULT_AGENTS_FILENAME)
+  const soulPath = path.join(dir, DEFAULT_SOUL_FILENAME)
+  const toolsPath = path.join(dir, DEFAULT_TOOLS_FILENAME)
+  const identityPath = path.join(dir, DEFAULT_IDENTITY_FILENAME)
+  const userPath = path.join(dir, DEFAULT_USER_FILENAME)
+  const heartbeatPath = path.join(dir, DEFAULT_HEARTBEAT_FILENAME)
+  const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME)
 
   const isBrandNewWorkspace = await (async () => {
-    const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
+    const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath]
     const existing = await Promise.all(
       paths.map(async (p) => {
         try {
-          await fs.access(p);
-          return true;
+          await fs.access(p)
+          return true
         } catch {
-          return false;
+          return false
         }
       }),
-    );
-    return existing.every((v) => !v);
-  })();
+    )
+    return existing.every((v) => !v)
+  })()
 
-  const agentsTemplate = await loadTemplateForAgent(DEFAULT_AGENTS_FILENAME, params?.agentId);
-  const soulTemplate = await loadTemplateForAgent(DEFAULT_SOUL_FILENAME, params?.agentId);
-  const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME);
-  const identityTemplate = await loadTemplateForAgent(DEFAULT_IDENTITY_FILENAME, params?.agentId);
-  const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
-  const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
-  const bootstrapTemplate = await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME);
+  const agentsTemplate = await loadTemplateForAgent(DEFAULT_AGENTS_FILENAME, params?.agentId)
+  const soulTemplate = await loadTemplateForAgent(DEFAULT_SOUL_FILENAME, params?.agentId)
+  const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME)
+  const identityTemplate = await loadTemplateForAgent(DEFAULT_IDENTITY_FILENAME, params?.agentId)
+  const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME)
+  const bootstrapTemplate = await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME)
 
-  await writeFileIfMissing(agentsPath, agentsTemplate);
-  await writeFileIfMissing(soulPath, soulTemplate);
-  await writeFileIfMissing(toolsPath, toolsTemplate);
-  await writeFileIfMissing(identityPath, identityTemplate);
-  await writeFileIfMissing(userPath, userTemplate);
-  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
+  await writeFileIfMissing(agentsPath, agentsTemplate)
+  await writeFileIfMissing(soulPath, soulTemplate)
+  await writeFileIfMissing(toolsPath, toolsTemplate)
+  await writeFileIfMissing(identityPath, identityTemplate)
+  await writeFileIfMissing(userPath, userTemplate)
   if (isBrandNewWorkspace) {
-    await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
+    await writeFileIfMissing(bootstrapPath, bootstrapTemplate)
   }
-  await ensureGitRepo(dir, isBrandNewWorkspace);
+  await ensureGitRepo(dir, isBrandNewWorkspace)
 
   return {
     dir,
@@ -212,48 +207,45 @@ export async function ensureAgentWorkspace(params?: {
     userPath,
     heartbeatPath,
     bootstrapPath,
-  };
+  }
 }
 
 async function resolveMemoryBootstrapEntries(
   resolvedDir: string,
 ): Promise<Array<{ name: WorkspaceBootstrapFileName; filePath: string }>> {
-  const candidates: WorkspaceBootstrapFileName[] = [
-    DEFAULT_MEMORY_FILENAME,
-    DEFAULT_MEMORY_ALT_FILENAME,
-  ];
-  const entries: Array<{ name: WorkspaceBootstrapFileName; filePath: string }> = [];
+  const candidates: WorkspaceBootstrapFileName[] = [DEFAULT_MEMORY_FILENAME, DEFAULT_MEMORY_ALT_FILENAME]
+  const entries: Array<{ name: WorkspaceBootstrapFileName; filePath: string }> = []
   for (const name of candidates) {
-    const filePath = path.join(resolvedDir, name);
+    const filePath = path.join(resolvedDir, name)
     try {
-      await fs.access(filePath);
-      entries.push({ name, filePath });
+      await fs.access(filePath)
+      entries.push({ name, filePath })
     } catch {
       // optional
     }
   }
-  if (entries.length <= 1) return entries;
+  if (entries.length <= 1) return entries
 
-  const seen = new Set<string>();
-  const deduped: Array<{ name: WorkspaceBootstrapFileName; filePath: string }> = [];
+  const seen = new Set<string>()
+  const deduped: Array<{ name: WorkspaceBootstrapFileName; filePath: string }> = []
   for (const entry of entries) {
-    let key = entry.filePath;
+    let key = entry.filePath
     try {
-      key = await fs.realpath(entry.filePath);
+      key = await fs.realpath(entry.filePath)
     } catch {}
-    if (seen.has(key)) continue;
-    seen.add(key);
-    deduped.push(entry);
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(entry)
   }
-  return deduped;
+  return deduped
 }
 
 export async function loadWorkspaceBootstrapFiles(dir: string): Promise<WorkspaceBootstrapFile[]> {
-  const resolvedDir = resolveUserPath(dir);
+  const resolvedDir = resolveUserPath(dir)
 
   const entries: Array<{
-    name: WorkspaceBootstrapFileName;
-    filePath: string;
+    name: WorkspaceBootstrapFileName
+    filePath: string
   }> = [
     {
       name: DEFAULT_AGENTS_FILENAME,
@@ -283,33 +275,33 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
       name: DEFAULT_BOOTSTRAP_FILENAME,
       filePath: path.join(resolvedDir, DEFAULT_BOOTSTRAP_FILENAME),
     },
-  ];
+  ]
 
-  entries.push(...(await resolveMemoryBootstrapEntries(resolvedDir)));
+  entries.push(...(await resolveMemoryBootstrapEntries(resolvedDir)))
 
-  const result: WorkspaceBootstrapFile[] = [];
+  const result: WorkspaceBootstrapFile[] = []
   for (const entry of entries) {
     try {
-      const content = await fs.readFile(entry.filePath, "utf-8");
+      const content = await fs.readFile(entry.filePath, "utf-8")
       result.push({
         name: entry.name,
         path: entry.filePath,
         content,
         missing: false,
-      });
+      })
     } catch {
-      result.push({ name: entry.name, path: entry.filePath, missing: true });
+      result.push({ name: entry.name, path: entry.filePath, missing: true })
     }
   }
-  return result;
+  return result
 }
 
-const SUBAGENT_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME]);
+const SUBAGENT_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME])
 
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],
   sessionKey?: string,
 ): WorkspaceBootstrapFile[] {
-  if (!sessionKey || !isSubagentSessionKey(sessionKey)) return files;
-  return files.filter((file) => SUBAGENT_BOOTSTRAP_ALLOWLIST.has(file.name));
+  if (!sessionKey || !isSubagentSessionKey(sessionKey)) return files
+  return files.filter((file) => SUBAGENT_BOOTSTRAP_ALLOWLIST.has(file.name))
 }


### PR DESCRIPTION
## Summary
- stop creating `HEARTBEAT.md` during `ensureAgentWorkspace(..., ensureBootstrapFiles: true)` bootstrap
- keep heartbeat path metadata unchanged while removing bootstrap writes for heartbeat template content
- keep existing heartbeat files intact if users already created one
- add regression tests to verify bootstrapping still creates core docs + `BOOTSTRAP.md`, but does not create `HEARTBEAT.md`

Closes #354

## Test Plan
- `cd packages/zee/Swabble && bunx vitest run src/agents/workspace.test.ts`