### PR TITLE
fix(ci): unblock baseline install/typecheck

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -248,7 +248,6 @@
         "@ai-sdk/xai": "3.0.50",
         "@babel/core": "7.28.0",
         "@clack/prompts": "1.0.0-alpha.1",
-        "@clawhub/registry": "file:../../../claw-registry",
         "@hono/standard-validator": "0.1.5",
         "@hono/zod-validator": "0.4.2",
         "@modelcontextprotocol/sdk": "1.26.0",
@@ -3353,8 +3352,6 @@
     "@zee/web/@shikijs/transformers": ["@shikijs/transformers@3.4.2", "", { "dependencies": { "@shikijs/core": "3.4.2", "@shikijs/types": "3.4.2" } }, "sha512-I5baLVi/ynLEOZoWSAMlACHNnG+yw5HDmse0oe+GW6U1u+ULdEB3UHiVWaHoJSSONV7tlcVxuaMy74sREDkSvg=="],
 
     "@zee/web/ai": ["ai@6.0.35", "", { "dependencies": { "@ai-sdk/gateway": "3.0.14", "@ai-sdk/provider": "3.0.3", "@ai-sdk/provider-utils": "4.0.6", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MxgtU6CjnegH1rhRfomM0gptKxP6r+9sxbLvYq36C1l85+o0LacqbXLdNVYzqab+lHN4q7ZP3QS8wZq4YkZahA=="],
-
-    "@zee/zee/@clawhub/registry": ["@clawhub/registry@file:../claw-registry", {}],
 
     "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.5", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w=="],
 

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,6 +1,6 @@
 {
   "nodeModules": {
-    "x86_64-linux": "sha256-+6KcX/2CAdqNl3eNF3QQ0xSH+gUxRdWK/RLT0aPjY+w=",
-    "aarch64-linux": "sha256-xiAV2tpFYO6CK00vcX3dKADEVcdSwJ9M/6Mk99h655Y="
+    "x86_64-linux": "sha256-3lAOBipeJ0EjiiVLfbDv1tWPoWRWAnkqBze5j4frr1o=",
+    "aarch64-linux": "sha256-U9FtuUcEKgCCvJ0BhjZvUY+m2gTWia9YhGv5nYhErq0="
   }
 }

--- a/packages/zee/package.json
+++ b/packages/zee/package.json
@@ -77,7 +77,6 @@
     "@ai-sdk/xai": "3.0.50",
     "@babel/core": "7.28.0",
     "@clack/prompts": "1.0.0-alpha.1",
-    "@clawhub/registry": "file:../../../claw-registry",
     "@hono/standard-validator": "0.1.5",
     "@hono/zod-validator": "0.4.2",
     "@modelcontextprotocol/sdk": "1.26.0",

--- a/packages/zee/src/cli/cmd/always-on.ts
+++ b/packages/zee/src/cli/cmd/always-on.ts
@@ -28,6 +28,7 @@ import { setHeartbeatRunner } from "../../server/route/heartbeat"
 import { startSkillWatcher, stopSkillWatcher } from "../../skill/watcher"
 import { Config } from "../../config/config"
 import { GlobalBus } from "../../bus/global"
+import type { RuntimeProcessLimits } from "./runtime-process-guard"
 import path from "path"
 
 const log = Log.create({ service: "always-on" })
@@ -41,6 +42,9 @@ export interface AlwaysOnOptions {
   wezterm?: boolean
   weztermLayout?: "horizontal" | "vertical" | "grid"
   restoreSessions?: boolean
+  runtimeGuard?: boolean
+  runtimeGuardIntervalMs?: number
+  runtimeLimits?: Partial<RuntimeProcessLimits>
 }
 
 export interface AlwaysOnProcess {

--- a/packages/zee/src/reliability/helpers.ts
+++ b/packages/zee/src/reliability/helpers.ts
@@ -1,0 +1,233 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import net from "node:net"
+import type { ReliabilityCommandOptions, ReliabilityCommandResult } from "./types"
+
+export async function ensureDir(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true })
+}
+
+export async function writeText(filepath: string, content: string): Promise<void> {
+  await ensureDir(path.dirname(filepath))
+  await fs.writeFile(filepath, content, "utf-8")
+}
+
+export async function appendText(filepath: string, content: string): Promise<void> {
+  await ensureDir(path.dirname(filepath))
+  await fs.appendFile(filepath, content, "utf-8")
+}
+
+export function sanitizeFileName(input: string): string {
+  return input.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "")
+}
+
+export function stringifyCommand(args: string[]): string {
+  return args
+    .map((item) => {
+      if (item === "") return '""'
+      if (/^[a-zA-Z0-9_./:@=-]+$/.test(item)) return item
+      return JSON.stringify(item)
+    })
+    .join(" ")
+}
+
+export async function runCommand(
+  command: string[],
+  options: ReliabilityCommandOptions = {},
+): Promise<ReliabilityCommandResult> {
+  if (command.length === 0) {
+    throw new Error("Cannot run empty command")
+  }
+
+  const cwd = options.cwd ?? process.cwd()
+  const env = { ...process.env, ...(options.env ?? {}) }
+  const startedAt = Date.now()
+  const timeoutMs = options.timeoutMs ?? 60_000
+  const expected = options.expectedExitCodes ?? [0]
+
+  const proc = Bun.spawn({
+    cmd: command,
+    cwd,
+    env,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+  let timedOut = false
+  const timer = setTimeout(() => {
+    timedOut = true
+    try {
+      proc.kill()
+    } catch {
+      // noop
+    }
+  }, timeoutMs)
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  clearTimeout(timer)
+  const result: ReliabilityCommandResult = {
+    command,
+    cwd,
+    exitCode,
+    stdout,
+    stderr,
+    durationMs: Date.now() - startedAt,
+    timedOut,
+  }
+
+  if (!expected.includes(exitCode)) {
+    throw new Error(
+      [
+        `Command failed: ${stringifyCommand(command)}`,
+        `cwd: ${cwd}`,
+        `exitCode: ${exitCode}`,
+        `expected: ${expected.join(", ")}`,
+        timedOut ? `timedOut: true` : "",
+        stdout ? `stdout:\n${stdout}` : "",
+        stderr ? `stderr:\n${stderr}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    )
+  }
+
+  return result
+}
+
+export async function waitForPort(
+  host: string,
+  port: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    const open = await isPortOpen(host, port)
+    if (open) return true
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(200)
+  }
+  return false
+}
+
+export async function isPortOpen(host: string, port: number): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const socket = net.createConnection({ host, port })
+    const timeout = setTimeout(() => {
+      socket.destroy()
+      resolve(false)
+    }, 1_000)
+
+    socket.once("connect", () => {
+      clearTimeout(timeout)
+      socket.end()
+      resolve(true)
+    })
+    socket.once("error", () => {
+      clearTimeout(timeout)
+      resolve(false)
+    })
+  })
+}
+
+export async function waitForHttpJson(
+  url: string,
+  timeoutMs: number,
+  intervalMs = 500,
+): Promise<any> {
+  const deadline = Date.now() + timeoutMs
+  let lastError = "request not attempted"
+
+  while (Date.now() < deadline) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await fetch(url, { signal: AbortSignal.timeout(Math.min(intervalMs, 5_000)) })
+      if (res.ok) {
+        // eslint-disable-next-line no-await-in-loop
+        return await res.json()
+      }
+      lastError = `HTTP ${res.status}`
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(intervalMs)
+  }
+
+  throw new Error(`Timed out waiting for ${url}: ${lastError}`)
+}
+
+export async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export async function listZeeProcesses(): Promise<Array<{ pid: number; command: string }>> {
+  if (process.platform === "win32") {
+    const out = await runCommand(
+      ["powershell", "-NoProfile", "-Command", "Get-CimInstance Win32_Process | Select-Object ProcessId,Name,CommandLine | ConvertTo-Json -Depth 3"],
+      {
+        timeoutMs: 15_000,
+      },
+    )
+    const parsed = JSON.parse(out.stdout || "[]")
+    const rows = Array.isArray(parsed) ? parsed : [parsed]
+    return rows
+      .map((row) => ({
+        pid: Number(row?.ProcessId),
+        command: String(row?.CommandLine || row?.Name || ""),
+      }))
+      .filter((entry) => Number.isFinite(entry.pid) && entry.command.toLowerCase().includes("zee"))
+  }
+
+  const out = await runCommand(["pgrep", "-af", "zee"], {
+    timeoutMs: 10_000,
+    expectedExitCodes: [0, 1],
+  })
+
+  return out.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(.*)$/)
+      if (!match) return undefined
+      return {
+        pid: Number.parseInt(match[1], 10),
+        command: match[2] ?? "",
+      }
+    })
+    .filter((entry): entry is { pid: number; command: string } => Boolean(entry))
+}
+
+export function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false
+  const normalized = value.trim().toLowerCase()
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on"
+}
+
+export async function tryRead(filepath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filepath, "utf-8")
+  } catch {
+    return null
+  }
+}
+
+export async function copyIfExists(source: string, destination: string): Promise<boolean> {
+  try {
+    await fs.access(source)
+  } catch {
+    return false
+  }
+  await ensureDir(path.dirname(destination))
+  await fs.copyFile(source, destination)
+  return true
+}

--- a/packages/zee/src/reliability/index.ts
+++ b/packages/zee/src/reliability/index.ts
@@ -1,0 +1,8 @@
+export { runReliabilitySuite, formatReliabilitySummary } from "./runner"
+export type {
+  ReliabilityProfile,
+  ReliabilityRunOptions,
+  ReliabilityReportV1,
+  ReliabilityStageReport,
+  ReliabilitySummary,
+} from "./types"

--- a/packages/zee/src/reliability/platform.ts
+++ b/packages/zee/src/reliability/platform.ts
@@ -1,0 +1,153 @@
+import type { ReliabilitySnapshotArtifact } from "./types"
+import { runCommand, writeText } from "./helpers"
+
+export type ReliabilityServiceMode = "systemd-user" | "launchctl" | "windows-service" | "local-process"
+
+export interface ReliabilityPlatformInfo {
+  platform: NodeJS.Platform
+  mode: ReliabilityServiceMode
+  notes: string[]
+}
+
+export async function detectPlatformInfo(): Promise<ReliabilityPlatformInfo> {
+  const notes: string[] = []
+
+  if (process.platform === "linux") {
+    const hasSystemctl = await commandExists("systemctl")
+    if (hasSystemctl) {
+      const hasUserUnit = await systemdUserUnitExists("zee.service")
+      if (hasUserUnit) {
+        notes.push("Detected systemd user unit zee.service")
+        return { platform: process.platform, mode: "systemd-user", notes }
+      }
+      notes.push("systemctl exists but zee.service user unit is not installed")
+    } else {
+      notes.push("systemctl not found")
+    }
+    return { platform: process.platform, mode: "local-process", notes }
+  }
+
+  if (process.platform === "darwin") {
+    const hasLaunchctl = await commandExists("launchctl")
+    if (hasLaunchctl) {
+      notes.push("launchctl available; using local-process parity checks")
+      return { platform: process.platform, mode: "launchctl", notes }
+    }
+    notes.push("launchctl not found; using local-process parity checks")
+    return { platform: process.platform, mode: "local-process", notes }
+  }
+
+  if (process.platform === "win32") {
+    const hasSc = await commandExists("sc")
+    if (hasSc) {
+      notes.push("Windows service tooling available; using local-process parity checks")
+      return { platform: process.platform, mode: "windows-service", notes }
+    }
+    notes.push("Service controller unavailable; using local-process parity checks")
+    return { platform: process.platform, mode: "local-process", notes }
+  }
+
+  notes.push("Unsupported platform for service-manager checks; using local-process parity checks")
+  return { platform: process.platform, mode: "local-process", notes }
+}
+
+async function commandExists(command: string): Promise<boolean> {
+  if (process.platform === "win32") {
+    const out = await runCommand(["where", command], {
+      expectedExitCodes: [0, 1],
+      timeoutMs: 5_000,
+    })
+    return out.exitCode === 0
+  }
+
+  const out = await runCommand(["which", command], {
+    expectedExitCodes: [0, 1],
+    timeoutMs: 5_000,
+  })
+  return out.exitCode === 0
+}
+
+export async function systemdUserUnitExists(unit: string): Promise<boolean> {
+  if (process.platform !== "linux") return false
+  const out = await runCommand(
+    [
+      "systemctl",
+      "--user",
+      "list-unit-files",
+      "--type=service",
+      "--no-legend",
+      "--no-pager",
+    ],
+    {
+      expectedExitCodes: [0],
+      timeoutMs: 10_000,
+    },
+  )
+
+  return out.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim().split(/\s+/)[0] ?? "")
+    .includes(unit)
+}
+
+export async function collectPlatformSnapshots(
+  artifactDir: string,
+  prefix: string,
+): Promise<ReliabilitySnapshotArtifact[]> {
+  const artifacts: ReliabilitySnapshotArtifact[] = []
+  const plan: Array<{ name: string; command: string[] }> = []
+
+  if (process.platform === "win32") {
+    plan.push(
+      { name: "tasklist", command: ["tasklist"] },
+      { name: "netstat", command: ["netstat", "-ano"] },
+      { name: "sc-query", command: ["sc", "query", "type=", "service", "state=", "all"] },
+    )
+  } else {
+    plan.push(
+      { name: "ps", command: ["ps", "-ef"] },
+      { name: "netstat", command: ["sh", "-lc", "ss -tulpn || netstat -an"] },
+    )
+    if (process.platform === "linux") {
+      plan.push(
+        { name: "systemd-user-status", command: ["systemctl", "--user", "status", "zee", "--no-pager"] },
+        { name: "systemd-user-orch-status", command: ["systemctl", "--user", "status", "zee-orch", "--no-pager"] },
+        { name: "journal-zee", command: ["journalctl", "--user", "-u", "zee", "--since", "10 min ago", "--no-pager"] },
+      )
+    }
+  }
+
+  for (const item of plan) {
+    // eslint-disable-next-line no-await-in-loop
+    const output = await runCommand(item.command, {
+      expectedExitCodes: [0, 1, 3, 4],
+      timeoutMs: 20_000,
+    }).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error)
+      return {
+        command: item.command,
+        cwd: process.cwd(),
+        exitCode: -1,
+        stdout: "",
+        stderr: message,
+        durationMs: 0,
+        timedOut: false,
+      }
+    })
+
+    const filepath = `${artifactDir}/${prefix}-${item.name}.log`
+    // eslint-disable-next-line no-await-in-loop
+    await writeText(
+      filepath,
+      [`$ ${item.command.join(" ")}`, "", output.stdout, output.stderr].filter(Boolean).join("\n"),
+    )
+    artifacts.push({
+      name: item.name,
+      path: filepath,
+      command: item.command,
+      exitCode: output.exitCode,
+    })
+  }
+
+  return artifacts
+}

--- a/packages/zee/src/reliability/types.ts
+++ b/packages/zee/src/reliability/types.ts
@@ -1,0 +1,103 @@
+export const RELIABILITY_REPORT_VERSION = "1"
+
+export type ReliabilityProfile = "alpha" | "diag"
+
+export type ReliabilityStageStatus = "pass" | "fail" | "skip"
+
+export interface ReliabilityRunOptions {
+  profile: ReliabilityProfile
+  artifactDir?: string
+  failFast?: boolean
+  json?: boolean
+  longSoakDurationMs?: number
+}
+
+export interface ReliabilityCommandResult {
+  command: string[]
+  cwd: string
+  exitCode: number
+  stdout: string
+  stderr: string
+  durationMs: number
+  timedOut: boolean
+}
+
+export interface ReliabilityCommandOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  timeoutMs?: number
+  expectedExitCodes?: number[]
+  stream?: boolean
+}
+
+export interface ReliabilitySnapshotArtifact {
+  name: string
+  path: string
+  command: string[]
+  exitCode: number
+}
+
+export interface ReliabilityStageContext {
+  options: ReliabilityRunOptions
+  repoRoot: string
+  packageRoot: string
+  artifactDir: string
+  stageArtifactDir: string
+  profile: ReliabilityProfile
+  runtimeEnv: NodeJS.ProcessEnv
+  daemonPortBase: number
+  gatewayPortBase: number
+  distBinaryPath: string
+  stageIndex: number
+}
+
+export interface ReliabilityStage<TContext extends ReliabilityStageContext = ReliabilityStageContext> {
+  id: string
+  name: string
+  description: string
+  required: boolean
+  timeoutMs: number
+  run: (ctx: TContext) => Promise<ReliabilityStageRunOutput>
+}
+
+export interface ReliabilityStageRunOutput {
+  summary: string
+  details?: string[]
+  artifacts?: ReliabilitySnapshotArtifact[]
+  metrics?: Record<string, number | string | boolean | null>
+}
+
+export interface ReliabilityStageReport {
+  id: string
+  name: string
+  description: string
+  required: boolean
+  startedAt: string
+  completedAt: string
+  durationMs: number
+  status: ReliabilityStageStatus
+  summary: string
+  details: string[]
+  artifacts: ReliabilitySnapshotArtifact[]
+  metrics: Record<string, number | string | boolean | null>
+  error?: string
+}
+
+export interface ReliabilitySummary {
+  total: number
+  passed: number
+  failed: number
+  skipped: number
+}
+
+export interface ReliabilityReportV1 {
+  version: typeof RELIABILITY_REPORT_VERSION
+  generatedAt: string
+  profile: ReliabilityProfile
+  repoRoot: string
+  artifactDir: string
+  platform: NodeJS.Platform
+  summary: ReliabilitySummary
+  stages: ReliabilityStageReport[]
+  assumptions: string[]
+}

--- a/packages/zee/src/server/route/registry.constants.ts
+++ b/packages/zee/src/server/route/registry.constants.ts
@@ -1,0 +1,38 @@
+// Local copy of registry values used by server routes to avoid external file deps in CI.
+export const LOBSTER_PALETTE = {
+  accent: "#FF5A2D",
+  accentBright: "#FF7A3D",
+  accentDim: "#D14A22",
+  info: "#FF8A5B",
+  success: "#2FBF71",
+  warn: "#FFB020",
+  error: "#E23D2D",
+  muted: "#8B7F77",
+} as const
+
+export const PROVIDERS = {
+  anthropic: { label: "Anthropic", icon: "anthropic" },
+  openai: { label: "OpenAI", icon: "openai" },
+  google: { label: "Google", icon: "google" },
+  "github-copilot": { label: "GitHub Copilot", icon: "github-copilot" },
+  "amazon-bedrock": { label: "Amazon Bedrock", icon: "amazon-bedrock" },
+  openrouter: { label: "OpenRouter", icon: "openrouter" },
+  "openai-compatible": { label: "OpenAI Compatible", icon: "openai" },
+  opencode: { label: "Opencode", icon: "opencode" },
+  "agent-core": { label: "Agent-Core", icon: "opencode" },
+} as const
+
+export const SKILL_FRONTMATTER_REQUIRED_KEYS = ["name", "description"] as const
+
+export const SKILL_FRONTMATTER_COMMON_OPTIONAL_KEYS = [
+  "homepage",
+  "tags",
+  "triggers",
+  "requires",
+  "primaryEnv",
+  "version",
+  "category",
+  "author",
+  "source",
+  "metadata",
+] as const

--- a/packages/zee/src/server/route/registry.ts
+++ b/packages/zee/src/server/route/registry.ts
@@ -1,7 +1,12 @@
 import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
-import { LOBSTER_PALETTE, PROVIDERS, SKILL_FRONTMATTER_COMMON_OPTIONAL_KEYS, SKILL_FRONTMATTER_REQUIRED_KEYS } from "@clawhub/registry"
+import {
+  LOBSTER_PALETTE,
+  PROVIDERS,
+  SKILL_FRONTMATTER_COMMON_OPTIONAL_KEYS,
+  SKILL_FRONTMATTER_REQUIRED_KEYS,
+} from "./registry.constants"
 
 const PaletteSchema = z.record(z.string(), z.string())
 const ProviderSchema = z.record(


### PR DESCRIPTION
## Summary\n- remove the external  file dependency from  and inline the needed registry constants in-tree\n- update root  so CI no longer resolves \n- add missing  modules required by  imports\n- extend  with runtime guard option fields already passed by \n\n## Why\n and downstream PR checks were blocked by baseline CI failures:\n1. bun install v1.3.5 (1e86cebd)

Checked 1533 installs across 1576 packages (no changes) [258.00ms] failed in GitHub Actions due to unresolved \n2. after that blocker,  failed because reliability modules were missing and daemon options typed mismatched\n\n## Validation\n- bun install v1.3.5 (1e86cebd)

Checked 1533 installs across 1576 packages (no changes) [51.00ms] (repo root)\n- \n- bun test v1.3.5 (1e86cebd)
DEBUG RESPONSE BODY: {
  "name": "UnknownError",
  "data": {
    "message": "Simulated unexpected error"
  }
}