### PR TITLE
Fix #367: relax HEARTBEAT_OK stripping for trailing punctuation

### DIFF
--- a/packages/zee/Swabble/src/auto-reply/heartbeat.test.ts
+++ b/packages/zee/Swabble/src/auto-reply/heartbeat.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest"
 
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   isHeartbeatContentEffectivelyEmpty,
   stripHeartbeatToken,
-} from "./heartbeat.js";
-import { HEARTBEAT_TOKEN } from "./tokens.js";
+} from "./heartbeat.js"
+import { HEARTBEAT_TOKEN } from "./tokens.js"
 
 describe("stripHeartbeatToken", () => {
   it("skips empty or token-only replies", () => {
@@ -13,61 +13,61 @@ describe("stripHeartbeatToken", () => {
       shouldSkip: true,
       text: "",
       didStrip: false,
-    });
+    })
     expect(stripHeartbeatToken("  ", { mode: "heartbeat" })).toEqual({
       shouldSkip: true,
       text: "",
       didStrip: false,
-    });
+    })
     expect(stripHeartbeatToken(HEARTBEAT_TOKEN, { mode: "heartbeat" })).toEqual({
       shouldSkip: true,
       text: "",
       didStrip: true,
-    });
-  });
+    })
+  })
 
   it("drops heartbeats with small junk in heartbeat mode", () => {
     expect(stripHeartbeatToken("HEARTBEAT_OK 🦞", { mode: "heartbeat" })).toEqual({
       shouldSkip: true,
       text: "",
       didStrip: true,
-    });
+    })
     expect(stripHeartbeatToken(`🦞 ${HEARTBEAT_TOKEN}`, { mode: "heartbeat" })).toEqual({
       shouldSkip: true,
       text: "",
       didStrip: true,
-    });
-  });
+    })
+  })
 
   it("drops short remainder in heartbeat mode", () => {
     expect(stripHeartbeatToken(`ALERT ${HEARTBEAT_TOKEN}`, { mode: "heartbeat" })).toEqual({
       shouldSkip: true,
       text: "",
       didStrip: true,
-    });
-  });
+    })
+  })
 
   it("keeps heartbeat replies when remaining content exceeds threshold", () => {
-    const long = "A".repeat(DEFAULT_HEARTBEAT_ACK_MAX_CHARS + 1);
+    const long = "A".repeat(DEFAULT_HEARTBEAT_ACK_MAX_CHARS + 1)
     expect(stripHeartbeatToken(`${long} ${HEARTBEAT_TOKEN}`, { mode: "heartbeat" })).toEqual({
       shouldSkip: false,
       text: long,
       didStrip: true,
-    });
-  });
+    })
+  })
 
   it("strips token at edges for normal messages", () => {
     expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN} hello`, { mode: "message" })).toEqual({
       shouldSkip: false,
       text: "hello",
       didStrip: true,
-    });
+    })
     expect(stripHeartbeatToken(`hello ${HEARTBEAT_TOKEN}`, { mode: "message" })).toEqual({
       shouldSkip: false,
       text: "hello",
       didStrip: true,
-    });
-  });
+    })
+  })
 
   it("does not touch token in the middle", () => {
     expect(
@@ -78,24 +78,24 @@ describe("stripHeartbeatToken", () => {
       shouldSkip: false,
       text: `hello ${HEARTBEAT_TOKEN} there`,
       didStrip: false,
-    });
-  });
+    })
+  })
 
   it("strips HTML-wrapped heartbeat tokens", () => {
     expect(stripHeartbeatToken(`<b>${HEARTBEAT_TOKEN}</b>`, { mode: "heartbeat" })).toEqual({
       shouldSkip: true,
       text: "",
       didStrip: true,
-    });
-  });
+    })
+  })
 
   it("strips markdown-wrapped heartbeat tokens", () => {
     expect(stripHeartbeatToken(`**${HEARTBEAT_TOKEN}**`, { mode: "heartbeat" })).toEqual({
       shouldSkip: true,
       text: "",
       didStrip: true,
-    });
-  });
+    })
+  })
 
   it("removes markup-wrapped token and keeps trailing content", () => {
     expect(
@@ -106,79 +106,129 @@ describe("stripHeartbeatToken", () => {
       shouldSkip: false,
       text: "all good",
       didStrip: true,
-    });
-  });
-});
+    })
+  })
+
+  it("strips trailing punctuation only when directly after the token", () => {
+    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}.`, { mode: "heartbeat" })).toEqual({
+      shouldSkip: true,
+      text: "",
+      didStrip: true,
+    })
+    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}!!!`, { mode: "heartbeat" })).toEqual({
+      shouldSkip: true,
+      text: "",
+      didStrip: true,
+    })
+    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}---`, { mode: "heartbeat" })).toEqual({
+      shouldSkip: true,
+      text: "",
+      didStrip: true,
+    })
+  })
+
+  it("strips a sentence-ending token and keeps trailing punctuation", () => {
+    expect(
+      stripHeartbeatToken(`I should not respond ${HEARTBEAT_TOKEN}.`, {
+        mode: "message",
+      }),
+    ).toEqual({
+      shouldSkip: false,
+      text: "I should not respond.",
+      didStrip: true,
+    })
+  })
+
+  it("strips sentence-ending token with emphasis punctuation in heartbeat mode", () => {
+    expect(
+      stripHeartbeatToken(`There is nothing todo, so i should respond with ${HEARTBEAT_TOKEN} !!!`, {
+        mode: "heartbeat",
+      }),
+    ).toEqual({
+      shouldSkip: true,
+      text: "",
+      didStrip: true,
+    })
+  })
+
+  it("preserves trailing punctuation on text before the token", () => {
+    expect(stripHeartbeatToken(`All clear. ${HEARTBEAT_TOKEN}`, { mode: "message" })).toEqual({
+      shouldSkip: false,
+      text: "All clear.",
+      didStrip: true,
+    })
+  })
+})
 
 describe("isHeartbeatContentEffectivelyEmpty", () => {
   it("returns false for undefined/null (missing file should not skip)", () => {
-    expect(isHeartbeatContentEffectivelyEmpty(undefined)).toBe(false);
-    expect(isHeartbeatContentEffectivelyEmpty(null)).toBe(false);
-  });
+    expect(isHeartbeatContentEffectivelyEmpty(undefined)).toBe(false)
+    expect(isHeartbeatContentEffectivelyEmpty(null)).toBe(false)
+  })
 
   it("returns true for empty string", () => {
-    expect(isHeartbeatContentEffectivelyEmpty("")).toBe(true);
-  });
+    expect(isHeartbeatContentEffectivelyEmpty("")).toBe(true)
+  })
 
   it("returns true for whitespace only", () => {
-    expect(isHeartbeatContentEffectivelyEmpty("   ")).toBe(true);
-    expect(isHeartbeatContentEffectivelyEmpty("\n\n\n")).toBe(true);
-    expect(isHeartbeatContentEffectivelyEmpty("  \n  \n  ")).toBe(true);
-    expect(isHeartbeatContentEffectivelyEmpty("\t\t")).toBe(true);
-  });
+    expect(isHeartbeatContentEffectivelyEmpty("   ")).toBe(true)
+    expect(isHeartbeatContentEffectivelyEmpty("\n\n\n")).toBe(true)
+    expect(isHeartbeatContentEffectivelyEmpty("  \n  \n  ")).toBe(true)
+    expect(isHeartbeatContentEffectivelyEmpty("\t\t")).toBe(true)
+  })
 
   it("returns true for header-only content", () => {
-    expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md")).toBe(true);
-    expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n")).toBe(true);
-    expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n\n")).toBe(true);
-  });
+    expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md")).toBe(true)
+    expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n")).toBe(true)
+    expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n\n")).toBe(true)
+  })
 
   it("returns true for comments only", () => {
-    expect(isHeartbeatContentEffectivelyEmpty("# Header\n# Another comment")).toBe(true);
-    expect(isHeartbeatContentEffectivelyEmpty("## Subheader\n### Another")).toBe(true);
-  });
+    expect(isHeartbeatContentEffectivelyEmpty("# Header\n# Another comment")).toBe(true)
+    expect(isHeartbeatContentEffectivelyEmpty("## Subheader\n### Another")).toBe(true)
+  })
 
   it("returns true for default template content (header + comment)", () => {
     const defaultTemplate = `# HEARTBEAT.md
 
 Keep this file empty unless you want a tiny checklist. Keep it small.
-`;
+`
     // Note: The template has actual text content, so it's NOT effectively empty
-    expect(isHeartbeatContentEffectivelyEmpty(defaultTemplate)).toBe(false);
-  });
+    expect(isHeartbeatContentEffectivelyEmpty(defaultTemplate)).toBe(false)
+  })
 
   it("returns true for header with only empty lines", () => {
-    expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n\n\n")).toBe(true);
-  });
+    expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n\n\n")).toBe(true)
+  })
 
   it("returns false when actionable content exists", () => {
-    expect(isHeartbeatContentEffectivelyEmpty("- Check email")).toBe(false);
-    expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n- Task 1")).toBe(false);
-    expect(isHeartbeatContentEffectivelyEmpty("Remind me to call mom")).toBe(false);
-  });
+    expect(isHeartbeatContentEffectivelyEmpty("- Check email")).toBe(false)
+    expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n- Task 1")).toBe(false)
+    expect(isHeartbeatContentEffectivelyEmpty("Remind me to call mom")).toBe(false)
+  })
 
   it("returns false for content with tasks after header", () => {
     const content = `# HEARTBEAT.md
 
 - Task 1
 - Task 2
-`;
-    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false);
-  });
+`
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false)
+  })
 
   it("returns false for mixed content with non-comment text", () => {
     const content = `# HEARTBEAT.md
 ## Tasks
 Check the server logs
-`;
-    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false);
-  });
+`
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false)
+  })
 
   it("treats markdown headers as comments (effectively empty)", () => {
     const content = `# HEARTBEAT.md
 ## Section 1
 ### Subsection
-`;
-    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
-  });
-});
+`
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true)
+  })
+})

--- a/packages/zee/Swabble/src/auto-reply/heartbeat.ts
+++ b/packages/zee/Swabble/src/auto-reply/heartbeat.ts
@@ -1,11 +1,11 @@
-import { HEARTBEAT_TOKEN } from "./tokens.js";
+import { HEARTBEAT_TOKEN } from "./tokens.js"
 
 // Default heartbeat prompt (used when config.agents.defaults.heartbeat.prompt is unset).
 // Keep it tight and avoid encouraging the model to invent/rehash "open loops" from prior chat context.
 export const HEARTBEAT_PROMPT =
-  "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.";
-export const DEFAULT_HEARTBEAT_EVERY = "30m";
-export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
+  "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."
+export const DEFAULT_HEARTBEAT_EVERY = "30m"
+export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300
 
 /**
  * Check if HEARTBEAT.md content is "effectively empty" - meaning it has no actionable tasks.
@@ -20,83 +20,90 @@ export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
  * decide what to do. This function is only for when the file exists but has no content.
  */
 export function isHeartbeatContentEffectivelyEmpty(content: string | undefined | null): boolean {
-  if (content === undefined || content === null) return false;
-  if (typeof content !== "string") return false;
+  if (content === undefined || content === null) return false
+  if (typeof content !== "string") return false
 
-  const lines = content.split("\n");
+  const lines = content.split("\n")
   for (const line of lines) {
-    const trimmed = line.trim();
+    const trimmed = line.trim()
     // Skip empty lines
-    if (!trimmed) continue;
+    if (!trimmed) continue
     // Skip markdown header lines (# followed by space or EOL, ## etc)
     // This intentionally does NOT skip lines like "#TODO" or "#hashtag" which might be content
     // (Those aren't valid markdown headers - ATX headers require space after #)
-    if (/^#+(\s|$)/.test(trimmed)) continue;
+    if (/^#+(\s|$)/.test(trimmed)) continue
     // Skip empty markdown list items like "- [ ]" or "* [ ]" or just "- "
-    if (/^[-*+]\s*(\[[\sXx]?\]\s*)?$/.test(trimmed)) continue;
+    if (/^[-*+]\s*(\[[\sXx]?\]\s*)?$/.test(trimmed)) continue
     // Found a non-empty, non-comment line - there's actionable content
-    return false;
+    return false
   }
   // All lines were either empty or comments
-  return true;
+  return true
 }
 
 export function resolveHeartbeatPrompt(raw?: string): string {
-  const trimmed = typeof raw === "string" ? raw.trim() : "";
-  return trimmed || HEARTBEAT_PROMPT;
+  const trimmed = typeof raw === "string" ? raw.trim() : ""
+  return trimmed || HEARTBEAT_PROMPT
 }
 
-export type StripHeartbeatMode = "heartbeat" | "message";
+export type StripHeartbeatMode = "heartbeat" | "message"
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
 
 function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
-  let text = raw.trim();
-  if (!text) return { text: "", didStrip: false };
+  let text = raw.trim()
+  if (!text) return { text: "", didStrip: false }
 
-  const token = HEARTBEAT_TOKEN;
-  if (!text.includes(token)) return { text, didStrip: false };
+  const token = HEARTBEAT_TOKEN
+  const tokenAtEndWithOptionalTrailingPunctuation = new RegExp(`${escapeRegExp(token)}[^\\w]{0,4}$`)
+  if (!text.includes(token)) return { text, didStrip: false }
 
-  let didStrip = false;
-  let changed = true;
+  let didStrip = false
+  let changed = true
   while (changed) {
-    changed = false;
-    const next = text.trim();
+    changed = false
+    const next = text.trim()
     if (next.startsWith(token)) {
-      const after = next.slice(token.length).trimStart();
-      text = after;
-      didStrip = true;
-      changed = true;
-      continue;
+      const after = next.slice(token.length).trimStart()
+      text = after
+      didStrip = true
+      changed = true
+      continue
     }
-    if (next.endsWith(token)) {
-      const before = next.slice(0, Math.max(0, next.length - token.length));
-      text = before.trimEnd();
-      didStrip = true;
-      changed = true;
+    if (tokenAtEndWithOptionalTrailingPunctuation.test(next)) {
+      const idx = next.lastIndexOf(token)
+      const before = next.slice(0, idx).trimEnd()
+      if (!before) {
+        text = ""
+      } else {
+        const after = next.slice(idx + token.length).trimStart()
+        text = `${before}${after}`.trimEnd()
+      }
+      didStrip = true
+      changed = true
     }
   }
 
-  const collapsed = text.replace(/\s+/g, " ").trim();
-  return { text: collapsed, didStrip };
+  const collapsed = text.replace(/\s+/g, " ").trim()
+  return { text: collapsed, didStrip }
 }
 
-export function stripHeartbeatToken(
-  raw?: string,
-  opts: { mode?: StripHeartbeatMode; maxAckChars?: number } = {},
-) {
-  if (!raw) return { shouldSkip: true, text: "", didStrip: false };
-  const trimmed = raw.trim();
-  if (!trimmed) return { shouldSkip: true, text: "", didStrip: false };
+export function stripHeartbeatToken(raw?: string, opts: { mode?: StripHeartbeatMode; maxAckChars?: number } = {}) {
+  if (!raw) return { shouldSkip: true, text: "", didStrip: false }
+  const trimmed = raw.trim()
+  if (!trimmed) return { shouldSkip: true, text: "", didStrip: false }
 
-  const mode: StripHeartbeatMode = opts.mode ?? "message";
-  const maxAckCharsRaw = opts.maxAckChars;
-  const parsedAckChars =
-    typeof maxAckCharsRaw === "string" ? Number(maxAckCharsRaw) : maxAckCharsRaw;
+  const mode: StripHeartbeatMode = opts.mode ?? "message"
+  const maxAckCharsRaw = opts.maxAckChars
+  const parsedAckChars = typeof maxAckCharsRaw === "string" ? Number(maxAckCharsRaw) : maxAckCharsRaw
   const maxAckChars = Math.max(
     0,
     typeof parsedAckChars === "number" && Number.isFinite(parsedAckChars)
       ? parsedAckChars
       : DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
-  );
+  )
 
   // Normalize lightweight markup so HEARTBEAT_OK wrapped in HTML/Markdown
   // (e.g., <b>HEARTBEAT_OK</b> or **HEARTBEAT_OK**) still strips.
@@ -108,32 +115,31 @@ export function stripHeartbeatToken(
       .replace(/&nbsp;/gi, " ")
       // Remove markdown-ish wrappers at the edges.
       .replace(/^[*`~_]+/, "")
-      .replace(/[*`~_]+$/, "");
+      .replace(/[*`~_]+$/, "")
 
-  const trimmedNormalized = stripMarkup(trimmed);
-  const hasToken = trimmed.includes(HEARTBEAT_TOKEN) || trimmedNormalized.includes(HEARTBEAT_TOKEN);
+  const trimmedNormalized = stripMarkup(trimmed)
+  const hasToken = trimmed.includes(HEARTBEAT_TOKEN) || trimmedNormalized.includes(HEARTBEAT_TOKEN)
   if (!hasToken) {
-    return { shouldSkip: false, text: trimmed, didStrip: false };
+    return { shouldSkip: false, text: trimmed, didStrip: false }
   }
 
-  const strippedOriginal = stripTokenAtEdges(trimmed);
-  const strippedNormalized = stripTokenAtEdges(trimmedNormalized);
-  const picked =
-    strippedOriginal.didStrip && strippedOriginal.text ? strippedOriginal : strippedNormalized;
+  const strippedOriginal = stripTokenAtEdges(trimmed)
+  const strippedNormalized = stripTokenAtEdges(trimmedNormalized)
+  const picked = strippedOriginal.didStrip && strippedOriginal.text ? strippedOriginal : strippedNormalized
   if (!picked.didStrip) {
-    return { shouldSkip: false, text: trimmed, didStrip: false };
+    return { shouldSkip: false, text: trimmed, didStrip: false }
   }
 
   if (!picked.text) {
-    return { shouldSkip: true, text: "", didStrip: true };
+    return { shouldSkip: true, text: "", didStrip: true }
   }
 
-  const rest = picked.text.trim();
+  const rest = picked.text.trim()
   if (mode === "heartbeat") {
     if (rest.length <= maxAckChars) {
-      return { shouldSkip: true, text: "", didStrip: true };
+      return { shouldSkip: true, text: "", didStrip: true }
     }
   }
 
-  return { shouldSkip: false, text: rest, didStrip: true };
+  return { shouldSkip: false, text: rest, didStrip: true }
 }


### PR DESCRIPTION
## Summary
- update heartbeat token edge-stripping to tolerate up to 4 trailing non-word characters after `HEARTBEAT_OK` at the end of a message
- preserve punctuation in the surrounding sentence text while stripping only the token and its synthetic suffix noise
- add regression tests for token+punctionuation endings, sentence-ending token stripping, and punctuation preservation

Closes #367

## Test Plan
- `cd packages/zee/Swabble && bunx vitest run src/auto-reply/heartbeat.test.ts`