### PR TITLE
[OpenClaw #12352] Allow media-only auto-reply messages into agent pipeline

### DIFF
--- a/packages/zee/Swabble/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/packages/zee/Swabble/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ZeeConfig } from "../../config/config.js";
+import { runPreparedReply } from "./get-reply-run.js";
+
+vi.mock("../../agents/auth-profiles/session-override.js", () => ({
+  resolveSessionAuthProfileOverride: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+  resolveEmbeddedSessionLane: vi.fn().mockReturnValue("session:session-key"),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  resolveGroupSessionKey: vi.fn().mockReturnValue(undefined),
+  resolveSessionFilePath: vi.fn().mockReturnValue("/tmp/session.jsonl"),
+  updateSessionStore: vi.fn(),
+}));
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+vi.mock("../../process/command-queue.js", () => ({
+  clearCommandLane: vi.fn().mockReturnValue(0),
+  getQueueSize: vi.fn().mockReturnValue(0),
+}));
+
+vi.mock("../../routing/session-key.js", () => ({
+  normalizeMainKey: vi.fn().mockReturnValue("main"),
+}));
+
+vi.mock("../../utils/provider-utils.js", () => ({
+  isReasoningTagProvider: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../command-detection.js", () => ({
+  hasControlCommand: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("./agent-runner.js", () => ({
+  runReplyAgent: vi.fn().mockResolvedValue({ text: "ok" }),
+}));
+
+vi.mock("./body.js", () => ({
+  applySessionHints: vi.fn().mockImplementation(async ({ baseBody }) => baseBody),
+}));
+
+vi.mock("./groups.js", () => ({
+  buildGroupIntro: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("./queue.js", () => ({
+  resolveQueueSettings: vi.fn().mockReturnValue({ mode: "followup" }),
+}));
+
+vi.mock("./route-reply.js", () => ({
+  routeReply: vi.fn(),
+}));
+
+vi.mock("./session-updates.js", () => ({
+  ensureSkillSnapshot: vi.fn().mockImplementation(async ({ sessionEntry, systemSent }) => ({
+    sessionEntry,
+    systemSent,
+    skillsSnapshot: undefined,
+  })),
+  prependSystemEvents: vi.fn().mockImplementation(async ({ prefixedBodyBase }) => prefixedBodyBase),
+}));
+
+vi.mock("./typing-mode.js", () => ({
+  resolveTypingMode: vi.fn().mockReturnValue("off"),
+}));
+
+import { runReplyAgent } from "./agent-runner.js";
+
+function buildParams(
+  overrides: Partial<Parameters<typeof runPreparedReply>[0]> = {},
+): Parameters<typeof runPreparedReply>[0] {
+  return {
+    ctx: {
+      Body: "",
+      RawBody: "",
+      CommandBody: "",
+      ThreadStarterBody: "Earlier message in this thread",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: "+15550001111",
+      ChatType: "direct",
+      MediaPath: "/tmp/input.png",
+    },
+    sessionCtx: {
+      Body: "",
+      BodyStripped: "",
+      ThreadStarterBody: "Earlier message in this thread",
+      MediaPath: "/tmp/input.png",
+      Provider: "whatsapp",
+      ChatType: "direct",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: "+15550001111",
+    },
+    cfg: {
+      session: {},
+      channels: {},
+      agents: { defaults: {} },
+    } as ZeeConfig,
+    agentId: "default",
+    agentDir: "/tmp/agent",
+    agentCfg: {},
+    sessionCfg: {},
+    commandAuthorized: true,
+    command: {
+      isAuthorizedSender: true,
+      abortKey: "session-key",
+      ownerList: [],
+      senderIsOwner: false,
+      channel: "whatsapp",
+      from: "+15550001111",
+      to: "+15550002222",
+    } as never,
+    commandSource: "",
+    allowTextCommands: true,
+    directives: {
+      hasThinkDirective: false,
+      thinkLevel: undefined,
+    } as never,
+    defaultActivation: "always",
+    resolvedThinkLevel: "high",
+    resolvedVerboseLevel: "off",
+    resolvedReasoningLevel: "off",
+    resolvedElevatedLevel: "off",
+    elevatedEnabled: false,
+    elevatedAllowed: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    modelState: {
+      resolveDefaultThinkingLevel: async () => "medium",
+    } as never,
+    provider: "openai",
+    model: "gpt-4.1",
+    typing: {
+      onReplyStart: vi.fn().mockResolvedValue(undefined),
+      cleanup: vi.fn(),
+    } as never,
+    defaultProvider: "openai",
+    defaultModel: "gpt-4.1",
+    timeoutMs: 30_000,
+    isNewSession: true,
+    resetTriggered: false,
+    systemSent: true,
+    sessionKey: "session-key",
+    workspaceDir: "/tmp/workspace",
+    abortedLastRun: false,
+    ...overrides,
+  };
+}
+
+describe("runPreparedReply media-only handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows media-only prompts and keeps thread context in queued followups", async () => {
+    const result = await runPreparedReply(buildParams());
+    expect(result).toEqual({ text: "ok" });
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call).toBeTruthy();
+    expect(call?.followupRun.prompt).toContain("[Thread starter - for context]");
+    expect(call?.followupRun.prompt).toContain("Earlier message in this thread");
+    expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
+    expect(call?.commandBody).toContain("[User sent media without caption]");
+  });
+
+  it("returns the empty-body reply when there is no text and no media", async () => {
+    const result = await runPreparedReply(
+      buildParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "whatsapp",
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      text: "I didn't receive any text in your message. Please resend or add a caption.",
+    });
+    expect(vi.mocked(runReplyAgent)).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zee/Swabble/src/auto-reply/reply/get-reply-run.ts
+++ b/packages/zee/Swabble/src/auto-reply/reply/get-reply-run.ts
@@ -199,7 +199,17 @@ export async function runPreparedReply(
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
   const baseBodyFinal = isBareSessionReset ? BARE_SESSION_RESET_PROMPT : baseBody;
   const baseBodyTrimmed = baseBodyFinal.trim();
-  if (!baseBodyTrimmed) {
+  const hasMediaAttachment = Boolean(
+    ctx.MediaPath?.trim() ||
+      ctx.MediaUrl?.trim() ||
+      (ctx.MediaPaths?.length ?? 0) > 0 ||
+      (ctx.MediaUrls?.length ?? 0) > 0 ||
+      sessionCtx.MediaPath?.trim() ||
+      sessionCtx.MediaUrl?.trim() ||
+      (sessionCtx.MediaPaths?.length ?? 0) > 0 ||
+      (sessionCtx.MediaUrls?.length ?? 0) > 0,
+  );
+  if (!baseBodyTrimmed && !hasMediaAttachment) {
     await typing.onReplyStart();
     logVerbose("Inbound body empty after normalization; skipping agent run");
     typing.cleanup();
@@ -207,8 +217,11 @@ export async function runPreparedReply(
       text: "I didn't receive any text in your message. Please resend or add a caption.",
     };
   }
+  const effectiveBaseBody = baseBodyTrimmed
+    ? baseBodyFinal
+    : "[User sent media without caption]";
   let prefixedBodyBase = await applySessionHints({
-    baseBody: baseBodyFinal,
+    baseBody: effectiveBaseBody,
     abortedLastRun,
     sessionEntry,
     sessionStore,
@@ -307,7 +320,7 @@ export async function runPreparedReply(
   }
   const sessionIdFinal = sessionId ?? crypto.randomUUID();
   const sessionFile = resolveSessionFilePath(sessionIdFinal, sessionEntry);
-  const queueBodyBase = [threadStarterNote, baseBodyFinal].filter(Boolean).join("\n\n");
+  const queueBodyBase = [threadStarterNote, effectiveBaseBody].filter(Boolean).join("\n\n");
   const queueMessageId = sessionCtx.MessageSid?.trim();
   const queueMessageIdHint = queueMessageId ? `[message_id: ${queueMessageId}]` : "";
   const queueBodyWithId = queueMessageIdHint


### PR DESCRIPTION
## Summary
- allow media-only inbound messages to proceed through `runPreparedReply`
- only return the empty-text rejection when both text and media are absent
- use a media-only placeholder body for session hints and queued followups
- add regression tests for media-only and truly-empty inbound messages

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/auto-reply/reply/get-reply-run.media-only.test.ts`

Fixes #356
