### PR TITLE
[OpenClaw #15573] Preserve streamed text when final payload regresses

### DIFF
--- a/packages/zee/Swabble/src/tui/tui-stream-assembler.test.ts
+++ b/packages/zee/Swabble/src/tui/tui-stream-assembler.test.ts
@@ -1,4 +1,65 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./tui-formatters.js", () => ({
+  composeThinkingAndContent: ({
+    thinkingText,
+    contentText,
+    showThinking,
+  }: {
+    thinkingText?: string;
+    contentText?: string;
+    showThinking?: boolean;
+  }) => {
+    const parts: string[] = [];
+    if (showThinking && thinkingText?.trim()) {
+      parts.push(`[thinking]\n${thinkingText.trim()}`);
+    }
+    if (contentText?.trim()) {
+      parts.push(contentText.trim());
+    }
+    return parts.join("\n\n").trim();
+  },
+  extractThinkingFromMessage: (message: unknown) => {
+    if (!message || typeof message !== "object") return "";
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) return "";
+    return content
+      .map((block) =>
+        block && typeof block === "object" && (block as { type?: unknown }).type === "thinking"
+          ? (block as { thinking?: string }).thinking
+          : undefined,
+      )
+      .filter((v): v is string => typeof v === "string" && v.trim().length > 0)
+      .join("\n")
+      .trim();
+  },
+  extractContentFromMessage: (message: unknown) => {
+    if (!message || typeof message !== "object") return "";
+    const content = (message as { content?: unknown }).content;
+    if (typeof content === "string") return content.trim();
+    if (!Array.isArray(content)) return "";
+    return content
+      .map((block) =>
+        block && typeof block === "object" && (block as { type?: unknown }).type === "text"
+          ? (block as { text?: string }).text
+          : undefined,
+      )
+      .filter((v): v is string => typeof v === "string" && v.trim().length > 0)
+      .join("\n")
+      .trim();
+  },
+  resolveFinalAssistantText: ({
+    finalText,
+    streamedText,
+  }: {
+    finalText?: string | null;
+    streamedText?: string | null;
+  }) => {
+    if (finalText?.trim()) return finalText;
+    if (streamedText?.trim()) return streamedText;
+    return "(no output)";
+  },
+}));
 
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 
@@ -89,5 +150,110 @@ describe("TuiStreamAssembler", () => {
     );
 
     expect(second).toBeNull();
+  });
+
+  it("keeps richer streamed text when final payload drops earlier blocks", () => {
+    const assembler = new TuiStreamAssembler();
+    assembler.ingestDelta(
+      "run-5",
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Before tool call" },
+          { type: "tool_use", name: "search" },
+          { type: "text", text: "After tool call" },
+        ],
+      },
+      false,
+    );
+
+    const finalText = assembler.finalize(
+      "run-5",
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", name: "search" },
+          { type: "text", text: "After tool call" },
+        ],
+      },
+      false,
+    );
+
+    expect(finalText).toBe("Before tool call\nAfter tool call");
+  });
+
+  it("keeps non-empty final text for plain text prefix/suffix updates", () => {
+    const assembler = new TuiStreamAssembler();
+    assembler.ingestDelta(
+      "run-5b",
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Draft line 1" },
+          { type: "text", text: "Draft line 2" },
+        ],
+      },
+      false,
+    );
+
+    const finalText = assembler.finalize(
+      "run-5b",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Draft line 1" }],
+      },
+      false,
+    );
+
+    expect(finalText).toBe("Draft line 1");
+  });
+
+  it("accepts richer final payload when it extends streamed text", () => {
+    const assembler = new TuiStreamAssembler();
+    assembler.ingestDelta(
+      "run-6",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Before tool call" }],
+      },
+      false,
+    );
+
+    const finalText = assembler.finalize(
+      "run-6",
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Before tool call" },
+          { type: "text", text: "After tool call" },
+        ],
+      },
+      false,
+    );
+
+    expect(finalText).toBe("Before tool call\nAfter tool call");
+  });
+
+  it("prefers non-empty final payload when it is not a dropped block regression", () => {
+    const assembler = new TuiStreamAssembler();
+    assembler.ingestDelta(
+      "run-7",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NOT OK" }],
+      },
+      false,
+    );
+
+    const finalText = assembler.finalize(
+      "run-7",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "OK" }],
+      },
+      false,
+    );
+
+    expect(finalText).toBe("OK");
   });
 });

--- a/packages/zee/Swabble/src/tui/tui-stream-assembler.ts
+++ b/packages/zee/Swabble/src/tui/tui-stream-assembler.ts
@@ -8,8 +8,72 @@ import {
 type RunStreamState = {
   thinkingText: string;
   contentText: string;
+  contentBlocks: string[];
+  sawNonTextContentBlocks: boolean;
   displayText: string;
 };
+
+function extractTextBlocksAndSignals(message: unknown): {
+  textBlocks: string[];
+  sawNonTextContentBlocks: boolean;
+} {
+  if (!message || typeof message !== "object") {
+    return { textBlocks: [], sawNonTextContentBlocks: false };
+  }
+  const record = message as Record<string, unknown>;
+  const content = record.content;
+
+  if (typeof content === "string") {
+    const text = content.trim();
+    return {
+      textBlocks: text ? [text] : [],
+      sawNonTextContentBlocks: false,
+    };
+  }
+  if (!Array.isArray(content)) {
+    return { textBlocks: [], sawNonTextContentBlocks: false };
+  }
+
+  const textBlocks: string[] = [];
+  let sawNonTextContentBlocks = false;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const rec = block as Record<string, unknown>;
+    if (rec.type === "text" && typeof rec.text === "string") {
+      const text = rec.text.trim();
+      if (text) {
+        textBlocks.push(text);
+      }
+      continue;
+    }
+    if (typeof rec.type === "string" && rec.type !== "thinking") {
+      sawNonTextContentBlocks = true;
+    }
+  }
+  return { textBlocks, sawNonTextContentBlocks };
+}
+
+function isDroppedBoundaryTextBlockSubset(params: {
+  streamedTextBlocks: string[];
+  finalTextBlocks: string[];
+}): boolean {
+  const { streamedTextBlocks, finalTextBlocks } = params;
+  if (finalTextBlocks.length === 0 || finalTextBlocks.length >= streamedTextBlocks.length) {
+    return false;
+  }
+
+  const prefixMatches = finalTextBlocks.every(
+    (block, index) => streamedTextBlocks[index] === block,
+  );
+  if (prefixMatches) {
+    return true;
+  }
+
+  const suffixStart = streamedTextBlocks.length - finalTextBlocks.length;
+  return finalTextBlocks.every((block, index) => streamedTextBlocks[suffixStart + index] === block);
+}
 
 export class TuiStreamAssembler {
   private runs = new Map<string, RunStreamState>();
@@ -20,6 +84,8 @@ export class TuiStreamAssembler {
       state = {
         thinkingText: "",
         contentText: "",
+        contentBlocks: [],
+        sawNonTextContentBlocks: false,
         displayText: "",
       };
       this.runs.set(runId, state);
@@ -30,12 +96,17 @@ export class TuiStreamAssembler {
   private updateRunState(state: RunStreamState, message: unknown, showThinking: boolean) {
     const thinkingText = extractThinkingFromMessage(message);
     const contentText = extractContentFromMessage(message);
+    const { textBlocks, sawNonTextContentBlocks } = extractTextBlocksAndSignals(message);
 
     if (thinkingText) {
       state.thinkingText = thinkingText;
     }
     if (contentText) {
       state.contentText = contentText;
+      state.contentBlocks = textBlocks.length > 0 ? textBlocks : [contentText];
+    }
+    if (sawNonTextContentBlocks) {
+      state.sawNonTextContentBlocks = true;
     }
 
     const displayText = composeThinkingAndContent({
@@ -59,11 +130,20 @@ export class TuiStreamAssembler {
 
   finalize(runId: string, message: unknown, showThinking: boolean): string {
     const state = this.getOrCreateRun(runId);
+    const streamedDisplayText = state.displayText;
+    const streamedTextBlocks = [...state.contentBlocks];
+    const streamedSawNonTextContentBlocks = state.sawNonTextContentBlocks;
     this.updateRunState(state, message, showThinking);
     const finalComposed = state.displayText;
+    const shouldKeepStreamedText =
+      streamedSawNonTextContentBlocks &&
+      isDroppedBoundaryTextBlockSubset({
+        streamedTextBlocks,
+        finalTextBlocks: state.contentBlocks,
+      });
     const finalText = resolveFinalAssistantText({
-      finalText: finalComposed,
-      streamedText: state.displayText,
+      finalText: shouldKeepStreamedText ? streamedDisplayText : finalComposed,
+      streamedText: streamedDisplayText,
     });
 
     this.runs.delete(runId);


### PR DESCRIPTION
## Summary
- preserve richer streamed TUI text when final payload regresses by dropping boundary text blocks around tool blocks
- keep non-empty final text when no tool-block regression shape is detected
- add regression coverage for dropped-prefix/suffix blocks and non-regression scenarios

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/tui/tui-stream-assembler.test.ts`

Fixes #340
