### PR TITLE
[OpenClaw #12341] Classify text/* MIME types as documents

### DIFF
--- a/packages/zee/Swabble/src/media/constants.test.ts
+++ b/packages/zee/Swabble/src/media/constants.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { mediaKindFromMime } from "./constants.js";
+
+describe("mediaKindFromMime", () => {
+  it("classifies text mimes as document", () => {
+    expect(mediaKindFromMime("text/plain")).toBe("document");
+    expect(mediaKindFromMime("text/csv")).toBe("document");
+    expect(mediaKindFromMime("text/html; charset=utf-8")).toBe("document");
+  });
+
+  it("keeps unknown mimes as unknown", () => {
+    expect(mediaKindFromMime("model/gltf+json")).toBe("unknown");
+  });
+});

--- a/packages/zee/Swabble/src/media/constants.ts
+++ b/packages/zee/Swabble/src/media/constants.ts
@@ -11,6 +11,7 @@ export function mediaKindFromMime(mime?: string | null): MediaKind {
   if (mime.startsWith("audio/")) return "audio";
   if (mime.startsWith("video/")) return "video";
   if (mime === "application/pdf") return "document";
+  if (mime.startsWith("text/")) return "document";
   if (mime.startsWith("application/")) return "document";
   return "unknown";
 }


### PR DESCRIPTION
## Summary
- classify all `text/*` MIME types as `document` in media kind resolution
- keep existing `application/*` and media family behavior unchanged
- add regression coverage for `text/plain`, `text/csv`, and `text/html` MIME values

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/media/constants.test.ts src/media/mime.test.ts`

Fixes #355
