### PR TITLE
[OpenClaw #15867] Add GLM-5 model support in catalog

### DIFF
--- a/packages/zee/Swabble/src/agents/synthetic-models.test.ts
+++ b/packages/zee/Swabble/src/agents/synthetic-models.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { SYNTHETIC_MODEL_CATALOG, buildSyntheticModelDefinition } from "./synthetic-models.js";
+
+describe("synthetic model catalog", () => {
+  it("includes GLM-5 with reasoning and vision support", () => {
+    const glm5 = SYNTHETIC_MODEL_CATALOG.find((entry) => entry.id === "hf:zai-org/GLM-5");
+    expect(glm5).toBeTruthy();
+    expect(glm5).toMatchObject({
+      name: "GLM-5",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 256000,
+      maxTokens: 128000,
+    });
+  });
+
+  it("builds a usable model definition for GLM-5", () => {
+    const glm5 = SYNTHETIC_MODEL_CATALOG.find((entry) => entry.id === "hf:zai-org/GLM-5");
+    expect(glm5).toBeTruthy();
+    const built = buildSyntheticModelDefinition(glm5!);
+    expect(built).toMatchObject({
+      id: "hf:zai-org/GLM-5",
+      name: "GLM-5",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 256000,
+      maxTokens: 128000,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    });
+  });
+});

--- a/packages/zee/Swabble/src/agents/synthetic-models.ts
+++ b/packages/zee/Swabble/src/agents/synthetic-models.ts
@@ -148,6 +148,14 @@ export const SYNTHETIC_MODEL_CATALOG = [
     maxTokens: 128000,
   },
   {
+    id: "hf:zai-org/GLM-5",
+    name: "GLM-5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 256000,
+    maxTokens: 128000,
+  },
+  {
     id: "hf:deepseek-ai/DeepSeek-V3",
     name: "DeepSeek V3",
     reasoning: false,


### PR DESCRIPTION
## Summary
- add synthetic catalog support for `hf:zai-org/GLM-5`
- mark GLM-5 as reasoning-capable with text+image inputs
- include regression tests for catalog presence and model definition output

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/agents/synthetic-models.test.ts`

Fixes #370
