### PR TITLE
[OpenClaw #15878] Disable Venice streaming compatibility path

### DIFF
--- a/packages/zee/Swabble/src/agents/venice-models.test.ts
+++ b/packages/zee/Swabble/src/agents/venice-models.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  VENICE_MODEL_CATALOG,
+  buildVeniceModelDefinition,
+  discoverVeniceModels,
+} from "./venice-models.js";
+
+describe("venice model definitions", () => {
+  it("marks static catalog models as not supporting usage in streaming", () => {
+    const first = buildVeniceModelDefinition(VENICE_MODEL_CATALOG[0]);
+    expect(first.compat?.supportsUsageInStreaming).toBe(false);
+  });
+
+  it("applies usage-in-streaming compat flag to discovered test-environment models", async () => {
+    const discovered = await discoverVeniceModels();
+    expect(discovered.length).toBeGreaterThan(0);
+    for (const model of discovered) {
+      expect(model.compat?.supportsUsageInStreaming).toBe(false);
+    }
+  });
+});

--- a/packages/zee/Swabble/src/agents/venice-models.ts
+++ b/packages/zee/Swabble/src/agents/venice-models.ts
@@ -300,6 +300,10 @@ export function buildVeniceModelDefinition(entry: VeniceCatalogEntry): ModelDefi
     cost: VENICE_DEFAULT_COST,
     contextWindow: entry.contextWindow,
     maxTokens: entry.maxTokens,
+    // Avoid usage-only streaming chunks that can break OpenAI-compatible parsers.
+    compat: {
+      supportsUsageInStreaming: false,
+    },
   };
 }
 
@@ -381,6 +385,10 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
           cost: VENICE_DEFAULT_COST,
           contextWindow: apiModel.model_spec.availableContextTokens || 128000,
           maxTokens: 8192,
+          // Avoid usage-only streaming chunks that can break OpenAI-compatible parsers.
+          compat: {
+            supportsUsageInStreaming: false,
+          },
         });
       }
     }

--- a/packages/zee/Swabble/src/config/types.models.ts
+++ b/packages/zee/Swabble/src/config/types.models.ts
@@ -10,6 +10,7 @@ export type ModelCompatConfig = {
   supportsStore?: boolean;
   supportsDeveloperRole?: boolean;
   supportsReasoningEffort?: boolean;
+  supportsUsageInStreaming?: boolean;
   maxTokensField?: "max_completion_tokens" | "max_tokens";
 };
 

--- a/packages/zee/Swabble/src/config/zod-schema.core.ts
+++ b/packages/zee/Swabble/src/config/zod-schema.core.ts
@@ -16,6 +16,7 @@ export const ModelCompatSchema = z
     supportsStore: z.boolean().optional(),
     supportsDeveloperRole: z.boolean().optional(),
     supportsReasoningEffort: z.boolean().optional(),
+    supportsUsageInStreaming: z.boolean().optional(),
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),


### PR DESCRIPTION
## Summary
- mark Venice model definitions as `compat.supportsUsageInStreaming = false`
- apply the same compatibility flag to dynamically discovered Venice models
- extend model compat typing/schema to include `supportsUsageInStreaming`
- add regression tests for static and discovered Venice model definitions

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/agents/venice-models.test.ts`

Fixes #371
