### PR TITLE
[OpenClaw #15154] Fix transcript path resolution for non-default agents

### DIFF
--- a/packages/zee/Swabble/src/agents/tools/session-status-tool.ts
+++ b/packages/zee/Swabble/src/agents/tools/session-status-tool.ts
@@ -418,6 +418,7 @@ export function createSessionStatusTool(opts?: {
         },
         sessionEntry: resolved.entry,
         sessionKey: resolved.key,
+        sessionStorePath: storePath,
         groupActivation,
         modelAuth: resolveModelAuthLabel({
           provider: providerForCard,

--- a/packages/zee/Swabble/src/auto-reply/reply/get-reply-run.ts
+++ b/packages/zee/Swabble/src/auto-reply/reply/get-reply-run.ts
@@ -11,6 +11,7 @@ import type { ZeeConfig } from "../../config/config.js";
 import {
   resolveGroupSessionKey,
   resolveSessionFilePath,
+  resolveSessionFilePathOptions,
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
@@ -306,7 +307,11 @@ export async function runPreparedReply(
     }
   }
   const sessionIdFinal = sessionId ?? crypto.randomUUID();
-  const sessionFile = resolveSessionFilePath(sessionIdFinal, sessionEntry);
+  const sessionFile = resolveSessionFilePath(
+    sessionIdFinal,
+    sessionEntry,
+    resolveSessionFilePathOptions({ agentId, storePath }),
+  );
   const queueBodyBase = [threadStarterNote, baseBodyFinal].filter(Boolean).join("\n\n");
   const queueMessageId = sessionCtx.MessageSid?.trim();
   const queueMessageIdHint = queueMessageId ? `[message_id: ${queueMessageId}]` : "";

--- a/packages/zee/Swabble/src/auto-reply/status.ts
+++ b/packages/zee/Swabble/src/auto-reply/status.ts
@@ -10,6 +10,7 @@ import type { ZeeConfig } from "../config/config.js";
 import {
   resolveMainSessionKey,
   resolveSessionFilePath,
+  resolveSessionFilePathOptions,
   type SessionEntry,
   type SessionScope,
 } from "../config/sessions.js";
@@ -35,6 +36,7 @@ import {
   type ChatCommandDefinition,
 } from "./commands-registry.js";
 import { listPluginCommands } from "../plugins/commands.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { SkillCommandSpec } from "../agents/skills.js";
 import type { CommandCategory } from "./commands-registry.types.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
@@ -58,6 +60,7 @@ type StatusArgs = {
   agent: AgentConfig;
   sessionEntry?: SessionEntry;
   sessionKey?: string;
+  sessionStorePath?: string;
   sessionScope?: SessionScope;
   groupActivation?: "mention" | "always";
   resolvedThink?: ThinkLevel;
@@ -160,6 +163,8 @@ const formatQueueDetails = (queue?: QueueStatus) => {
 const readUsageFromSessionLog = (
   sessionId?: string,
   sessionEntry?: SessionEntry,
+  sessionKey?: string,
+  storePath?: string,
 ):
   | {
       input: number;
@@ -171,7 +176,17 @@ const readUsageFromSessionLog = (
   | undefined => {
   // Transcripts are stored at the session file path (fallback: ~/.zee/sessions/<SessionId>.jsonl)
   if (!sessionId) return undefined;
-  const logPath = resolveSessionFilePath(sessionId, sessionEntry);
+  let logPath: string;
+  try {
+    const agentId = sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined;
+    logPath = resolveSessionFilePath(
+      sessionId,
+      sessionEntry,
+      resolveSessionFilePathOptions({ agentId, storePath }),
+    );
+  } catch {
+    return undefined;
+  }
   if (!fs.existsSync(logPath)) return undefined;
 
   try {
@@ -304,7 +319,12 @@ export function buildStatusMessage(args: StatusArgs): string {
   // Prefer prompt-size tokens from the session transcript when it looks larger
   // (cached prompt tokens are often missing from agent meta/store).
   if (args.includeTranscriptUsage) {
-    const logUsage = readUsageFromSessionLog(entry?.sessionId, entry);
+    const logUsage = readUsageFromSessionLog(
+      entry?.sessionId,
+      entry,
+      args.sessionKey,
+      args.sessionStorePath,
+    );
     if (logUsage) {
       const candidate = logUsage.promptTokens || logUsage.total;
       if (!totalTokens || totalTokens === 0 || candidate > totalTokens) {

--- a/packages/zee/Swabble/src/config/sessions/paths.test.ts
+++ b/packages/zee/Swabble/src/config/sessions/paths.test.ts
@@ -1,0 +1,38 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  resolveSessionTranscriptPath,
+} from "./paths.js";
+
+describe("session path helpers", () => {
+  it("prefers storePath when resolving session file options", () => {
+    const opts = resolveSessionFilePathOptions({
+      storePath: "/tmp/custom/agent-store/sessions.json",
+      agentId: "ops",
+    });
+    expect(opts).toEqual({
+      sessionsDir: path.resolve("/tmp/custom/agent-store"),
+    });
+  });
+
+  it("falls back to agentId when storePath is absent", () => {
+    const opts = resolveSessionFilePathOptions({ agentId: "ops" });
+    expect(opts).toEqual({ agentId: "ops" });
+  });
+
+  it("uses sessionsDir override for session files", () => {
+    const resolved = resolveSessionFilePath("sess-1", undefined, {
+      sessionsDir: "/tmp/custom/sessions",
+    });
+    expect(resolved).toBe(path.resolve("/tmp/custom/sessions/sess-1.jsonl"));
+  });
+
+  it("still resolves transcript paths under agent directories", () => {
+    const resolved = resolveSessionTranscriptPath("sess-1", "main");
+    expect(resolved.endsWith(path.join("agents", "main", "sessions", "sess-1.jsonl"))).toBe(true);
+  });
+});

--- a/packages/zee/Swabble/src/config/sessions/paths.ts
+++ b/packages/zee/Swabble/src/config/sessions/paths.ts
@@ -33,6 +33,26 @@ export function resolveDefaultSessionStorePath(agentId?: string): string {
   return path.join(resolveAgentSessionsDir(agentId), "sessions.json");
 }
 
+export type SessionFilePathOptions = {
+  agentId?: string;
+  sessionsDir?: string;
+};
+
+export function resolveSessionFilePathOptions(params: {
+  agentId?: string;
+  storePath?: string;
+}): SessionFilePathOptions | undefined {
+  const storePath = params.storePath?.trim();
+  if (storePath) {
+    return { sessionsDir: path.dirname(path.resolve(storePath)) };
+  }
+  const agentId = params.agentId?.trim();
+  if (agentId) {
+    return { agentId };
+  }
+  return undefined;
+}
+
 export function resolveSessionTranscriptPath(
   sessionId: string,
   agentId?: string,
@@ -52,10 +72,15 @@ export function resolveSessionTranscriptPath(
 export function resolveSessionFilePath(
   sessionId: string,
   entry?: SessionEntry,
-  opts?: { agentId?: string },
+  opts?: SessionFilePathOptions,
 ): string {
   const candidate = entry?.sessionFile?.trim();
-  return candidate ? candidate : resolveSessionTranscriptPath(sessionId, opts?.agentId);
+  if (candidate) return candidate;
+  const sessionsDir = opts?.sessionsDir?.trim();
+  if (sessionsDir) {
+    return path.join(path.resolve(sessionsDir), `${sessionId}.jsonl`);
+  }
+  return resolveSessionTranscriptPath(sessionId, opts?.agentId);
 }
 
 export function resolveStorePath(store?: string, opts?: { agentId?: string }) {


### PR DESCRIPTION
## Summary
- add `resolveSessionFilePathOptions({ agentId, storePath })` so transcript lookups can resolve from the active session store directory
- update auto-reply run/status session file resolution to use the new options helper
- pass session store path through `session_status` so transcript usage reads from the correct non-default agent store
- add regression tests for session path option resolution

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/config/sessions/paths.test.ts`
- `cd packages/zee/Swabble && bunx tsc --noEmit` (fails due pre-existing unrelated error in `src/wizard/clack-prompter.ts`)

Fixes #339
