### PR TITLE
[OpenClaw #11063] Expose full model-compat fields in schema

### DIFF
--- a/packages/zee/Swabble/src/config/config.model-compat-schema.test.ts
+++ b/packages/zee/Swabble/src/config/config.model-compat-schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { validateConfigObject } from "./validation.js";
+
+describe("model compat config schema", () => {
+  it("accepts full openai-completions compat fields", () => {
+    const res = validateConfigObject({
+      models: {
+        providers: {
+          local: {
+            baseUrl: "http://127.0.0.1:1234/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "qwen3-32b",
+                name: "Qwen3 32B",
+                compat: {
+                  supportsUsageInStreaming: true,
+                  supportsStrictMode: false,
+                  thinkingFormat: "qwen",
+                  requiresToolResultName: true,
+                  requiresAssistantAfterToolResult: false,
+                  requiresThinkingAsText: false,
+                  requiresMistralToolIds: false,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+});

--- a/packages/zee/Swabble/src/config/types.models.ts
+++ b/packages/zee/Swabble/src/config/types.models.ts
@@ -10,7 +10,14 @@ export type ModelCompatConfig = {
   supportsStore?: boolean;
   supportsDeveloperRole?: boolean;
   supportsReasoningEffort?: boolean;
+  supportsUsageInStreaming?: boolean;
+  supportsStrictMode?: boolean;
   maxTokensField?: "max_completion_tokens" | "max_tokens";
+  thinkingFormat?: "openai" | "zai" | "qwen";
+  requiresToolResultName?: boolean;
+  requiresAssistantAfterToolResult?: boolean;
+  requiresThinkingAsText?: boolean;
+  requiresMistralToolIds?: boolean;
 };
 
 export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";

--- a/packages/zee/Swabble/src/config/zod-schema.core.ts
+++ b/packages/zee/Swabble/src/config/zod-schema.core.ts
@@ -16,9 +16,16 @@ export const ModelCompatSchema = z
     supportsStore: z.boolean().optional(),
     supportsDeveloperRole: z.boolean().optional(),
     supportsReasoningEffort: z.boolean().optional(),
+    supportsUsageInStreaming: z.boolean().optional(),
+    supportsStrictMode: z.boolean().optional(),
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),
+    thinkingFormat: z.union([z.literal("openai"), z.literal("zai"), z.literal("qwen")]).optional(),
+    requiresToolResultName: z.boolean().optional(),
+    requiresAssistantAfterToolResult: z.boolean().optional(),
+    requiresThinkingAsText: z.boolean().optional(),
+    requiresMistralToolIds: z.boolean().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary
- expand `ModelCompatSchema` to include the full pi-ai compat surface:
  - `supportsUsageInStreaming`, `supportsStrictMode`, `thinkingFormat`
  - `requiresToolResultName`, `requiresAssistantAfterToolResult`
  - `requiresThinkingAsText`, `requiresMistralToolIds`
- mirror these fields in `ModelCompatConfig` typing
- add regression coverage validating full compat payload acceptance

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/config/config.model-compat-schema.test.ts src/config/io.compat.test.ts`

Fixes #351
