### PR TITLE
[OpenClaw #11560] Preserve ${VAR} env references on config writeback

### DIFF
--- a/packages/zee/Swabble/src/config/config.env-preserve-writeback.test.ts
+++ b/packages/zee/Swabble/src/config/config.env-preserve-writeback.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+import type { ZeeConfig } from "./types.js";
+import { withEnvOverride, withTempHome } from "./test-helpers.js";
+
+const CONFIG_WITH_ENV_REF = `{
+  models: {
+    providers: {
+      anthropic: {
+        baseUrl: "https://api.anthropic.com/v1",
+        api: "anthropic-messages",
+        apiKey: "\${ANTHROPIC_API_KEY}",
+        models: []
+      }
+    }
+  }
+}
+`;
+
+describe("config writeback env reference preservation", () => {
+  it("keeps ${VAR} reference when caller writes back unchanged resolved value", async () => {
+    await withTempHome(async () => {
+      await withEnvOverride({ ANTHROPIC_API_KEY: "sk-ant-secret" }, async () => {
+        const { resolveConfigPath, loadConfig, writeConfigFile } = await import("./config.js");
+        const configPath = resolveConfigPath();
+        await fs.writeFile(configPath, CONFIG_WITH_ENV_REF, "utf-8");
+
+        const loaded = loadConfig();
+        await writeConfigFile(loaded);
+
+        const persisted = await fs.readFile(configPath, "utf-8");
+        expect(persisted).toContain('"${ANTHROPIC_API_KEY}"');
+        expect(persisted).not.toContain("sk-ant-secret");
+      });
+    });
+  });
+
+  it("keeps explicit caller override instead of restoring old placeholder", async () => {
+    await withTempHome(async () => {
+      await withEnvOverride({ ANTHROPIC_API_KEY: "sk-ant-secret" }, async () => {
+        const { resolveConfigPath, loadConfig, writeConfigFile } = await import("./config.js");
+        const configPath = resolveConfigPath();
+        await fs.writeFile(configPath, CONFIG_WITH_ENV_REF, "utf-8");
+
+        const loaded = loadConfig() as ZeeConfig & {
+          models?: {
+            providers?: Record<string, { apiKey?: string }>;
+          };
+        };
+        loaded.models ??= {};
+        loaded.models.providers ??= {};
+        loaded.models.providers.anthropic ??= {};
+        loaded.models.providers.anthropic.apiKey = "manual-override";
+
+        await writeConfigFile(loaded);
+
+        const persisted = await fs.readFile(configPath, "utf-8");
+        expect(persisted).toContain('"manual-override"');
+        expect(persisted).not.toContain('"${ANTHROPIC_API_KEY}"');
+      });
+    });
+  });
+});

--- a/packages/zee/Swabble/src/config/env-preserve.test.ts
+++ b/packages/zee/Swabble/src/config/env-preserve.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { restoreEnvVarRefs } from "./env-preserve.js";
+
+describe("restoreEnvVarRefs", () => {
+  it("restores full ${VAR} placeholders when value matches env-resolved value", () => {
+    const next = { models: { providers: { anthropic: { apiKey: "sk-ant-secret" } } } };
+    const original = { models: { providers: { anthropic: { apiKey: "${ANTHROPIC_API_KEY}" } } } };
+    const restored = restoreEnvVarRefs(next, original, { ANTHROPIC_API_KEY: "sk-ant-secret" }) as {
+      models: { providers: { anthropic: { apiKey: string } } };
+    };
+
+    expect(restored.models.providers.anthropic.apiKey).toBe("${ANTHROPIC_API_KEY}");
+  });
+
+  it("keeps changed values when caller intentionally modified them", () => {
+    const next = { key: "override" };
+    const original = { key: "${MY_KEY}" };
+    const restored = restoreEnvVarRefs(next, original, { MY_KEY: "original" }) as { key: string };
+    expect(restored.key).toBe("override");
+  });
+
+  it("only restores full-string references", () => {
+    const next = { key: "prefix-secret-suffix" };
+    const original = { key: "prefix-${MY_KEY}-suffix" };
+    const restored = restoreEnvVarRefs(next, original, { MY_KEY: "secret" }) as { key: string };
+    expect(restored.key).toBe("prefix-secret-suffix");
+  });
+});

--- a/packages/zee/Swabble/src/config/env-preserve.ts
+++ b/packages/zee/Swabble/src/config/env-preserve.ts
@@ -1,0 +1,51 @@
+const FULL_ENV_REF_RE = /^\$\{([A-Z_][A-Z0-9_]*)\}$/;
+
+function restoreAtPath(
+  nextValue: unknown,
+  originalValue: unknown,
+  env: Record<string, string | undefined>,
+): unknown {
+  if (typeof nextValue === "string") {
+    if (typeof originalValue !== "string") return nextValue;
+    const match = FULL_ENV_REF_RE.exec(originalValue.trim());
+    if (!match) return nextValue;
+    const varName = match[1];
+    const resolved = env[varName];
+    if (resolved && nextValue === resolved) {
+      return originalValue;
+    }
+    return nextValue;
+  }
+
+  if (Array.isArray(nextValue)) {
+    const originalArray = Array.isArray(originalValue) ? originalValue : [];
+    return nextValue.map((entry, index) => restoreAtPath(entry, originalArray[index], env));
+  }
+
+  if (nextValue && typeof nextValue === "object") {
+    const nextObj = nextValue as Record<string, unknown>;
+    const originalObj =
+      originalValue && typeof originalValue === "object" && !Array.isArray(originalValue)
+        ? (originalValue as Record<string, unknown>)
+        : {};
+    const output: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(nextObj)) {
+      output[key] = restoreAtPath(value, originalObj[key], env);
+    }
+    return output;
+  }
+
+  return nextValue;
+}
+
+/**
+ * Restores `${VAR}` references from the current on-disk config when the caller
+ * writes back the same resolved value.
+ */
+export function restoreEnvVarRefs(
+  nextConfig: unknown,
+  originalConfig: unknown,
+  env: Record<string, string | undefined>,
+): unknown {
+  return restoreAtPath(nextConfig, originalConfig, env);
+}

--- a/packages/zee/Swabble/src/config/io.ts
+++ b/packages/zee/Swabble/src/config/io.ts
@@ -23,6 +23,7 @@ import {
   applySessionDefaults,
   applyTalkApiKey,
 } from "./defaults.js";
+import { restoreEnvVarRefs } from "./env-preserve.js";
 import { VERSION } from "../version.js";
 import { MissingEnvVarError, resolveConfigEnvVars } from "./env-substitution.js";
 import { collectConfigEnvVars } from "./env-vars.js";
@@ -483,9 +484,29 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         .join("\n");
       deps.logger.warn(`Config warnings:\n${details}`);
     }
+
+    let configToWrite: ZeeConfig = validated.config;
+    // Preserve ${VAR} placeholders already present in the on-disk config when
+    // the caller writes back the same resolved value.
+    try {
+      if (deps.fs.existsSync(configPath)) {
+        const currentRaw = await deps.fs.promises.readFile(configPath, "utf-8");
+        const parsedRes = parseConfigJson5(currentRaw, deps.json5);
+        if (parsedRes.ok) {
+          configToWrite = restoreEnvVarRefs(
+            configToWrite,
+            parsedRes.parsed,
+            deps.env as Record<string, string | undefined>,
+          ) as ZeeConfig;
+        }
+      }
+    } catch {
+      // Fall back to writing the validated config as-is.
+    }
+
     const dir = path.dirname(configPath);
     await deps.fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
-    const json = JSON.stringify(applyModelDefaults(stampConfigVersion(cfg)), null, 2)
+    const json = JSON.stringify(applyModelDefaults(stampConfigVersion(configToWrite)), null, 2)
       .trimEnd()
       .concat("\n");
 


### PR DESCRIPTION
## Summary
- add `restoreEnvVarRefs` to preserve existing `${VAR}` placeholders during config writeback
- wire write path to read current config content and restore placeholders only when resolved values are unchanged
- keep explicit caller overrides untouched (no forced placeholder restoration)
- add unit + integration coverage for env-ref restoration behavior

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/config/env-preserve.test.ts src/config/config.env-preserve-writeback.test.ts`

Fixes #352
