### PR TITLE
[OpenClaw #11029] Use subsystem logger in hooks loader

### DIFF
--- a/packages/zee/Swabble/src/hooks/loader.test.ts
+++ b/packages/zee/Swabble/src/hooks/loader.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadInternalHooks } from "./loader.js";
 import {
   clearInternalHooks,
@@ -151,8 +151,6 @@ describe("loader", () => {
     });
 
     it("should handle module loading errors gracefully", async () => {
-      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-
       const cfg: ZeeConfig = {
         hooks: {
           internal: {
@@ -169,17 +167,9 @@ describe("loader", () => {
 
       const count = await loadInternalHooks(cfg, tmpDir);
       expect(count).toBe(0);
-      expect(consoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to load hook handler"),
-        expect.any(String),
-      );
-
-      consoleError.mockRestore();
     });
 
     it("should handle non-function exports", async () => {
-      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-
       // Create a module with a non-function export
       const handlerPath = path.join(tmpDir, "bad-export.js");
       await fs.writeFile(handlerPath, 'export default "not a function";', "utf-8");
@@ -200,9 +190,6 @@ describe("loader", () => {
 
       const count = await loadInternalHooks(cfg, tmpDir);
       expect(count).toBe(0);
-      expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("is not a function"));
-
-      consoleError.mockRestore();
     });
 
     it("should handle relative paths", async () => {

--- a/packages/zee/Swabble/src/hooks/loader.ts
+++ b/packages/zee/Swabble/src/hooks/loader.ts
@@ -10,9 +10,12 @@ import path from "node:path";
 import { registerInternalHook } from "./internal-hooks.js";
 import type { ZeeConfig } from "../config/config.js";
 import type { InternalHookHandler } from "./internal-hooks.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { loadWorkspaceHookEntries } from "./workspace.js";
 import { resolveHookConfig } from "./config.js";
 import { shouldIncludeHook } from "./config.js";
+
+const log = createSubsystemLogger("hooks:loader");
 
 /**
  * Load and register all hook handlers
@@ -67,16 +70,14 @@ export async function loadInternalHooks(cfg: ZeeConfig, workspaceDir: string): P
         const handler = mod[exportName];
 
         if (typeof handler !== "function") {
-          console.error(
-            `Hook error: Handler '${exportName}' from ${entry.hook.name} is not a function`,
-          );
+          log.error(`Handler '${exportName}' from ${entry.hook.name} is not a function`);
           continue;
         }
 
         // Register for all events listed in metadata
         const events = entry.metadata?.events ?? [];
         if (events.length === 0) {
-          console.warn(`Hook warning: Hook '${entry.hook.name}' has no events defined in metadata`);
+          log.warn(`Hook '${entry.hook.name}' has no events defined in metadata`);
           continue;
         }
 
@@ -84,21 +85,19 @@ export async function loadInternalHooks(cfg: ZeeConfig, workspaceDir: string): P
           registerInternalHook(event, handler as InternalHookHandler);
         }
 
-        console.log(
+        log.info(
           `Registered hook: ${entry.hook.name} -> ${events.join(", ")}${exportName !== "default" ? ` (export: ${exportName})` : ""}`,
         );
         loadedCount++;
       } catch (err) {
-        console.error(
-          `Failed to load hook ${entry.hook.name}:`,
-          err instanceof Error ? err.message : String(err),
+        log.error(
+          `Failed to load hook ${entry.hook.name}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }
   } catch (err) {
-    console.error(
-      "Failed to load directory-based hooks:",
-      err instanceof Error ? err.message : String(err),
+    log.error(
+      `Failed to load directory-based hooks: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
@@ -121,20 +120,19 @@ export async function loadInternalHooks(cfg: ZeeConfig, workspaceDir: string): P
       const handler = mod[exportName];
 
       if (typeof handler !== "function") {
-        console.error(`Hook error: Handler '${exportName}' from ${modulePath} is not a function`);
+        log.error(`Handler '${exportName}' from ${modulePath} is not a function`);
         continue;
       }
 
       // Register the handler
       registerInternalHook(handlerConfig.event, handler as InternalHookHandler);
-      console.log(
+      log.info(
         `Registered hook (legacy): ${handlerConfig.event} -> ${modulePath}${exportName !== "default" ? `#${exportName}` : ""}`,
       );
       loadedCount++;
     } catch (err) {
-      console.error(
-        `Failed to load hook handler from ${handlerConfig.module}:`,
-        err instanceof Error ? err.message : String(err),
+      log.error(
+        `Failed to load hook handler from ${handlerConfig.module}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- replace `hooks/loader.ts` `console.*` calls with `createSubsystemLogger("hooks:loader")`
- keep loader behavior unchanged while routing output through structured logging sinks
- update loader tests to assert graceful failure behavior without brittle console spies

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/hooks/loader.test.ts`

Fixes #350
