### PR TITLE
[OpenClaw #14498] Use in-process mutex queue for session-store sync

### DIFF
--- a/packages/zee/Swabble/src/config/sessions/store.lock.test.ts
+++ b/packages/zee/Swabble/src/config/sessions/store.lock.test.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { sleep } from "../../utils.js";
+import type { SessionEntry } from "./types.js";
+import {
+  clearSessionStoreCacheForTest,
+  getSessionStoreLockQueueSizeForTest,
+  loadSessionStore,
+  updateSessionStore,
+  updateSessionStoreEntry,
+  withSessionStoreLockForTest,
+} from "./store.js";
+
+describe("session store lock queue", () => {
+  let tmpDirs: string[] = [];
+
+  async function makeTmpStore(
+    initial: Record<string, unknown> = {},
+  ): Promise<{ dir: string; storePath: string }> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-lock-test-"));
+    tmpDirs.push(dir);
+    const storePath = path.join(dir, "sessions.json");
+    if (Object.keys(initial).length > 0) {
+      await fs.writeFile(storePath, JSON.stringify(initial, null, 2), "utf-8");
+    }
+    return { dir, storePath };
+  }
+
+  afterEach(async () => {
+    clearSessionStoreCacheForTest();
+    for (const dir of tmpDirs) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+    tmpDirs = [];
+  });
+
+  it("serializes concurrent updates without data loss", async () => {
+    const key = "agent:main:test";
+    const { storePath } = await makeTmpStore({
+      [key]: { sessionId: "s1", updatedAt: 100, counter: 0 },
+    });
+
+    const N = 10;
+    await Promise.all(
+      Array.from({ length: N }, () =>
+        updateSessionStore(storePath, async (store) => {
+          const entry = store[key] as Record<string, unknown>;
+          await sleep(Math.random() * 10);
+          entry.counter = (entry.counter as number) + 1;
+        }),
+      ),
+    );
+
+    const store = loadSessionStore(storePath);
+    expect((store[key] as Record<string, unknown>).counter).toBe(N);
+  });
+
+  it("merges concurrent updateSessionStoreEntry patches", async () => {
+    const key = "agent:main:merge";
+    const { storePath } = await makeTmpStore({
+      [key]: { sessionId: "s1", updatedAt: 100 },
+    });
+
+    await Promise.all([
+      updateSessionStoreEntry({
+        storePath,
+        sessionKey: key,
+        update: async () => {
+          await sleep(25);
+          return { modelOverride: "model-a" };
+        },
+      }),
+      updateSessionStoreEntry({
+        storePath,
+        sessionKey: key,
+        update: async () => {
+          await sleep(10);
+          return { thinkingLevel: "high" };
+        },
+      }),
+      updateSessionStoreEntry({
+        storePath,
+        sessionKey: key,
+        update: async () => {
+          await sleep(15);
+          return { systemPromptOverride: "custom" };
+        },
+      }),
+    ]);
+
+    const store = loadSessionStore(storePath);
+    const entry = store[key];
+    expect(entry.modelOverride).toBe("model-a");
+    expect(entry.thinkingLevel).toBe("high");
+    expect(entry.systemPromptOverride).toBe("custom");
+  });
+
+  it("continues queue processing after a task throws", async () => {
+    const key = "agent:main:err";
+    const { storePath } = await makeTmpStore({
+      [key]: { sessionId: "s1", updatedAt: 100 },
+    });
+
+    const errorPromise = updateSessionStore(storePath, async () => {
+      throw new Error("boom");
+    });
+    const successPromise = updateSessionStore(storePath, async (store) => {
+      store[key] = { ...store[key], modelOverride: "after-error" } as SessionEntry;
+    });
+
+    await expect(errorPromise).rejects.toThrow("boom");
+    await successPromise;
+
+    const store = loadSessionStore(storePath);
+    expect(store[key]?.modelOverride).toBe("after-error");
+  });
+
+  it("runs different store paths in parallel", async () => {
+    const { storePath: pathA } = await makeTmpStore({
+      a: { sessionId: "a", updatedAt: 100 },
+    });
+    const { storePath: pathB } = await makeTmpStore({
+      b: { sessionId: "b", updatedAt: 100 },
+    });
+
+    const order: string[] = [];
+    const opA = updateSessionStore(pathA, async (store) => {
+      order.push("a-start");
+      await sleep(50);
+      store.a = { ...store.a, modelOverride: "done-a" } as SessionEntry;
+      order.push("a-end");
+    });
+    const opB = updateSessionStore(pathB, async (store) => {
+      order.push("b-start");
+      await sleep(10);
+      store.b = { ...store.b, modelOverride: "done-b" } as SessionEntry;
+      order.push("b-end");
+    });
+    await Promise.all([opA, opB]);
+
+    expect(order.indexOf("b-end")).toBeLessThan(order.indexOf("a-end"));
+    expect(loadSessionStore(pathA).a?.modelOverride).toBe("done-a");
+    expect(loadSessionStore(pathB).b?.modelOverride).toBe("done-b");
+  });
+
+  it("cleans queue state after completion and after errors", async () => {
+    const { storePath } = await makeTmpStore({
+      x: { sessionId: "x", updatedAt: 100 },
+    });
+
+    await updateSessionStore(storePath, async (store) => {
+      store.x = { ...store.x, modelOverride: "done" } as SessionEntry;
+    });
+    await sleep(0);
+    expect(getSessionStoreLockQueueSizeForTest()).toBe(0);
+
+    await updateSessionStore(storePath, async () => {
+      throw new Error("fail");
+    }).catch(() => undefined);
+    await sleep(0);
+    expect(getSessionStoreLockQueueSizeForTest()).toBe(0);
+  });
+
+  it("enforces FIFO order", async () => {
+    const key = "agent:main:fifo";
+    const { storePath } = await makeTmpStore({
+      [key]: { sessionId: "s1", updatedAt: 100, order: "" },
+    });
+
+    const executionOrder: number[] = [];
+    const promises = Array.from({ length: 5 }, (_, i) =>
+      updateSessionStore(storePath, async (store) => {
+        executionOrder.push(i);
+        const entry = store[key] as Record<string, unknown>;
+        entry.order = `${(entry.order as string) || ""}${i}`;
+      }),
+    );
+    await Promise.all(promises);
+
+    expect(executionOrder).toEqual([0, 1, 2, 3, 4]);
+    const store = loadSessionStore(storePath);
+    expect((store[key] as Record<string, unknown>).order).toBe("01234");
+  });
+
+  it("times out waiting tasks and never runs them later", async () => {
+    const { storePath } = await makeTmpStore({
+      x: { sessionId: "x", updatedAt: 100 },
+    });
+    let timedOutRan = false;
+
+    const lockHolder = withSessionStoreLockForTest(
+      storePath,
+      async () => {
+        await sleep(80);
+      },
+      { timeoutMs: 2_000 },
+    );
+    const timedOut = withSessionStoreLockForTest(
+      storePath,
+      async () => {
+        timedOutRan = true;
+      },
+      { timeoutMs: 20 },
+    );
+
+    await expect(timedOut).rejects.toThrow("timeout waiting for session store lock");
+    await lockHolder;
+    await sleep(30);
+    expect(timedOutRan).toBe(false);
+  });
+});

--- a/packages/zee/Swabble/src/config/sessions/store.ts
+++ b/packages/zee/Swabble/src/config/sessions/store.ts
@@ -12,6 +12,7 @@ import {
   type DeliveryContext,
 } from "../../utils/delivery-context.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
+import { acquireSessionWriteLock } from "../../agents/session-write-lock.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
 import { mergeSessionEntry, type SessionEntry } from "./types.js";
 
@@ -90,6 +91,27 @@ function normalizeSessionStore(store: Record<string, SessionEntry>): void {
 
 export function clearSessionStoreCacheForTest(): void {
   SESSION_STORE_CACHE.clear();
+  for (const queue of LOCK_QUEUES.values()) {
+    for (const task of queue.pending) {
+      task.timedOut = true;
+      if (task.timer) {
+        clearTimeout(task.timer);
+      }
+    }
+  }
+  LOCK_QUEUES.clear();
+}
+
+export function getSessionStoreLockQueueSizeForTest(): number {
+  return LOCK_QUEUES.size;
+}
+
+export async function withSessionStoreLockForTest<T>(
+  storePath: string,
+  fn: () => Promise<T>,
+  opts: SessionStoreLockOptions = {},
+): Promise<T> {
+  return await withSessionStoreLock(storePath, fn, opts);
 }
 
 type LoadSessionStoreOptions = {
@@ -266,74 +288,149 @@ type SessionStoreLockOptions = {
   staleMs?: number;
 };
 
+type SessionStoreLockTask = {
+  fn: () => Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  timeoutAt?: number;
+  staleMs: number;
+  timer?: ReturnType<typeof setTimeout>;
+  started: boolean;
+  timedOut: boolean;
+};
+
+type SessionStoreLockQueue = {
+  running: boolean;
+  pending: SessionStoreLockTask[];
+};
+
+const LOCK_QUEUES = new Map<string, SessionStoreLockQueue>();
+
+function lockTimeoutError(storePath: string): Error {
+  return new Error(`timeout waiting for session store lock: ${storePath}`);
+}
+
+function getOrCreateLockQueue(storePath: string): SessionStoreLockQueue {
+  const existing = LOCK_QUEUES.get(storePath);
+  if (existing) {
+    return existing;
+  }
+  const created: SessionStoreLockQueue = { running: false, pending: [] };
+  LOCK_QUEUES.set(storePath, created);
+  return created;
+}
+
+function removePendingTask(queue: SessionStoreLockQueue, task: SessionStoreLockTask): void {
+  const idx = queue.pending.indexOf(task);
+  if (idx >= 0) {
+    queue.pending.splice(idx, 1);
+  }
+}
+
+async function drainSessionStoreLockQueue(storePath: string): Promise<void> {
+  const queue = LOCK_QUEUES.get(storePath);
+  if (!queue || queue.running) {
+    return;
+  }
+  queue.running = true;
+  try {
+    while (queue.pending.length > 0) {
+      const task = queue.pending.shift();
+      if (!task || task.timedOut) {
+        continue;
+      }
+
+      if (task.timer) {
+        clearTimeout(task.timer);
+      }
+      task.started = true;
+
+      const remainingTimeoutMs =
+        task.timeoutAt != null
+          ? Math.max(0, task.timeoutAt - Date.now())
+          : Number.POSITIVE_INFINITY;
+      if (task.timeoutAt != null && remainingTimeoutMs <= 0) {
+        task.timedOut = true;
+        task.reject(lockTimeoutError(storePath));
+        continue;
+      }
+
+      let lock: { release: () => Promise<void> } | undefined;
+      let result: unknown;
+      let failed: unknown;
+      let hasFailure = false;
+      try {
+        lock = await acquireSessionWriteLock({
+          sessionFile: storePath,
+          timeoutMs: remainingTimeoutMs,
+          staleMs: task.staleMs,
+        });
+        result = await task.fn();
+      } catch (err) {
+        hasFailure = true;
+        failed = err;
+      } finally {
+        await lock?.release().catch(() => undefined);
+      }
+      if (hasFailure) {
+        task.reject(failed);
+        continue;
+      }
+      task.resolve(result);
+    }
+  } finally {
+    queue.running = false;
+    if (queue.pending.length === 0) {
+      LOCK_QUEUES.delete(storePath);
+    } else {
+      queueMicrotask(() => {
+        void drainSessionStoreLockQueue(storePath);
+      });
+    }
+  }
+}
+
 async function withSessionStoreLock<T>(
   storePath: string,
   fn: () => Promise<T>,
   opts: SessionStoreLockOptions = {},
 ): Promise<T> {
   const timeoutMs = opts.timeoutMs ?? 10_000;
-  const pollIntervalMs = opts.pollIntervalMs ?? 25;
   const staleMs = opts.staleMs ?? 30_000;
-  const lockPath = `${storePath}.lock`;
-  const startedAt = Date.now();
+  // Kept for API compatibility with older lock options.
+  void opts.pollIntervalMs;
 
-  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
+  const hasTimeout = timeoutMs > 0 && Number.isFinite(timeoutMs);
+  const timeoutAt = hasTimeout ? Date.now() + timeoutMs : undefined;
+  const queue = getOrCreateLockQueue(storePath);
 
-  while (true) {
-    try {
-      const handle = await fs.promises.open(lockPath, "wx");
-      try {
-        await handle.writeFile(
-          JSON.stringify({ pid: process.pid, startedAt: Date.now() }),
-          "utf-8",
-        );
-      } catch {
-        // best-effort
-      }
-      await handle.close();
-      break;
-    } catch (err) {
-      const code =
-        err && typeof err === "object" && "code" in err
-          ? String((err as { code?: unknown }).code)
-          : null;
-      if (code === "ENOENT") {
-        // Store directory may be deleted/recreated in tests while writes are in-flight.
-        // Best-effort: recreate the parent dir and retry until timeout.
-        await fs.promises
-          .mkdir(path.dirname(storePath), { recursive: true })
-          .catch(() => undefined);
-        await new Promise((r) => setTimeout(r, pollIntervalMs));
-        continue;
-      }
-      if (code !== "EEXIST") throw err;
+  const promise = new Promise<T>((resolve, reject) => {
+    const task: SessionStoreLockTask = {
+      fn: async () => await fn(),
+      resolve: (value) => resolve(value as T),
+      reject,
+      timeoutAt,
+      staleMs,
+      started: false,
+      timedOut: false,
+    };
 
-      const now = Date.now();
-      if (now - startedAt > timeoutMs) {
-        throw new Error(`timeout acquiring session store lock: ${lockPath}`);
-      }
-
-      // Best-effort stale lock eviction (e.g. crashed process).
-      try {
-        const st = await fs.promises.stat(lockPath);
-        const ageMs = now - st.mtimeMs;
-        if (ageMs > staleMs) {
-          await fs.promises.unlink(lockPath);
-          continue;
+    if (hasTimeout) {
+      task.timer = setTimeout(() => {
+        if (task.started || task.timedOut) {
+          return;
         }
-      } catch {
-        // ignore
-      }
-
-      await new Promise((r) => setTimeout(r, pollIntervalMs));
+        task.timedOut = true;
+        removePendingTask(queue, task);
+        reject(lockTimeoutError(storePath));
+      }, timeoutMs);
     }
-  }
 
-  try {
-    return await fn();
-  } finally {
-    await fs.promises.unlink(lockPath).catch(() => undefined);
-  }
+    queue.pending.push(task);
+    void drainSessionStoreLockQueue(storePath);
+  });
+
+  return await promise;
 }
 
 export async function updateSessionStoreEntry(params: {


### PR DESCRIPTION
## Summary
- replace session-store lock polling with an in-process per-store promise queue
- keep the underlying file lock (`acquireSessionWriteLock`) for cross-process coordination
- add test helpers for lock queue visibility and direct lock invocation
- add regression tests covering concurrency safety, FIFO ordering, timeout handling, and queue cleanup

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/config/sessions/store.lock.test.ts`

Fixes #341
