### PR TITLE
[OpenClaw #13578] Return explicit error for WhatsApp outbound fallback

### DIFF
--- a/packages/zee/Swabble/src/channels/plugins/outbound/whatsapp.resolve-target.test.ts
+++ b/packages/zee/Swabble/src/channels/plugins/outbound/whatsapp.resolve-target.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { whatsappOutbound } from "./whatsapp.js";
+
+describe("whatsapp outbound target resolution", () => {
+  it("rejects empty target even when allowFrom is configured", () => {
+    const res = whatsappOutbound.resolveTarget({
+      to: "",
+      allowFrom: ["+1555"],
+      mode: "explicit",
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.message).toContain("WhatsApp");
+      expect(res.error.message).toContain("<E.164|group JID>");
+    }
+  });
+
+  it("rejects invalid explicit target instead of falling back to allowFrom", () => {
+    const res = whatsappOutbound.resolveTarget({
+      to: "invalid target",
+      allowFrom: ["+1555"],
+      mode: "explicit",
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects implicit target not present in allowFrom", () => {
+    const res = whatsappOutbound.resolveTarget({
+      to: "+1666",
+      allowFrom: ["+1555"],
+      mode: "implicit",
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("allows implicit target when wildcard allowFrom is set", () => {
+    const res = whatsappOutbound.resolveTarget({
+      to: "+1666",
+      allowFrom: ["*"],
+      mode: "implicit",
+    });
+    expect(res).toEqual({ ok: true, to: "+1666" });
+  });
+
+  it("accepts explicit group jid targets", () => {
+    const res = whatsappOutbound.resolveTarget({
+      to: "120363401234567890@g.us",
+      allowFrom: ["+1555"],
+      mode: "explicit",
+    });
+    expect(res).toEqual({ ok: true, to: "120363401234567890@g.us" });
+  });
+});

--- a/packages/zee/Swabble/src/channels/plugins/outbound/whatsapp.ts
+++ b/packages/zee/Swabble/src/channels/plugins/outbound/whatsapp.ts
@@ -23,15 +23,9 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
     if (trimmed) {
       const normalizedTo = normalizeWhatsAppTarget(trimmed);
       if (!normalizedTo) {
-        if ((mode === "implicit" || mode === "heartbeat") && allowList.length > 0) {
-          return { ok: true, to: allowList[0] };
-        }
         return {
           ok: false,
-          error: missingTargetError(
-            "WhatsApp",
-            "<E.164|group JID> or channels.whatsapp.allowFrom[0]",
-          ),
+          error: missingTargetError("WhatsApp", "<E.164|group JID>"),
         };
       }
       if (isWhatsAppGroupJid(normalizedTo)) {
@@ -44,17 +38,17 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
         if (allowList.includes(normalizedTo)) {
           return { ok: true, to: normalizedTo };
         }
-        return { ok: true, to: allowList[0] };
+        return {
+          ok: false,
+          error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+        };
       }
       return { ok: true, to: normalizedTo };
     }
 
-    if (allowList.length > 0) {
-      return { ok: true, to: allowList[0] };
-    }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID> or channels.whatsapp.allowFrom[0]"),
+      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
     };
   },
   sendText: async ({ to, text, accountId, deps, gifPlayback }) => {


### PR DESCRIPTION
## Summary
- remove WhatsApp outbound resolver fallback to `allowFrom[0]` when `to` is missing/invalid
- return explicit missing-target errors for ambiguous or absent outbound targets
- add resolver regression tests for explicit/implicit modes and wildcard/group-jid behavior

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/channels/plugins/outbound/whatsapp.resolve-target.test.ts`

Fixes #342
