### PR TITLE
[OpenClaw #14976] Auto-inject replyToCurrent in reply-mode flows

### DIFF
--- a/packages/zee/Swabble/src/auto-reply/reply/agent-runner-execution.ts
+++ b/packages/zee/Swabble/src/auto-reply/reply/agent-runner-execution.ts
@@ -332,7 +332,9 @@ export async function runAgentTurnWithFallback(params: {
                       text,
                       mediaUrls: payload.mediaUrls,
                       mediaUrl: payload.mediaUrls?.[0],
-                      replyToId: payload.replyToId,
+                      replyToId:
+                        payload.replyToId ??
+                        (payload.replyToCurrent === false ? undefined : currentMessageId),
                       replyToTag: payload.replyToTag,
                       replyToCurrent: payload.replyToCurrent,
                     },

--- a/packages/zee/Swabble/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/packages/zee/Swabble/src/auto-reply/reply/block-reply-coalescer.ts
@@ -76,10 +76,12 @@ export function createBlockReplyCoalescer(params: {
     }
     if (!hasText) return;
 
-    if (
+    const replyToConflict = Boolean(
       bufferText &&
-      (bufferReplyToId !== payload.replyToId || bufferAudioAsVoice !== payload.audioAsVoice)
-    ) {
+      payload.replyToId &&
+      (!bufferReplyToId || bufferReplyToId !== payload.replyToId),
+    );
+    if (bufferText && (replyToConflict || bufferAudioAsVoice !== payload.audioAsVoice)) {
       void flush({ force: true });
     }
 

--- a/packages/zee/Swabble/src/auto-reply/reply/reply-payloads.auto-threading.test.ts
+++ b/packages/zee/Swabble/src/auto-reply/reply/reply-payloads.auto-threading.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { applyReplyThreading } from "./reply-payloads.js";
+
+describe("applyReplyThreading auto-threading", () => {
+  it("sets replyToId to currentMessageId even without [[reply_to_current]] tag", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "Hello" }],
+      replyToMode: "first",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBe("42");
+  });
+
+  it("threads only first payload when mode is 'first'", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "A" }, { text: "B" }],
+      replyToMode: "first",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].replyToId).toBe("42");
+    expect(result[1].replyToId).toBeUndefined();
+  });
+
+  it("threads all payloads when mode is 'all'", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "A" }, { text: "B" }],
+      replyToMode: "all",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].replyToId).toBe("42");
+    expect(result[1].replyToId).toBe("42");
+  });
+
+  it("strips replyToId when mode is 'off'", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "A" }],
+      replyToMode: "off",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBeUndefined();
+  });
+
+  it("does not bypass off mode for Slack when reply is implicit", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "A" }],
+      replyToMode: "off",
+      replyToChannel: "slack",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBeUndefined();
+  });
+
+});

--- a/packages/zee/Swabble/src/auto-reply/reply/reply-payloads.ts
+++ b/packages/zee/Swabble/src/auto-reply/reply/reply-payloads.ts
@@ -58,8 +58,15 @@ export function applyReplyThreading(params: {
 }): ReplyPayload[] {
   const { payloads, replyToMode, replyToChannel, currentMessageId } = params;
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
+  const implicitReplyToId = currentMessageId?.trim() || undefined;
   return payloads
-    .map((payload) => applyReplyTagsToPayload(payload, currentMessageId))
+    .map((payload) => {
+      const autoThreaded =
+        payload.replyToId || payload.replyToCurrent === false || !implicitReplyToId
+          ? payload
+          : { ...payload, replyToId: implicitReplyToId };
+      return applyReplyTagsToPayload(autoThreaded, currentMessageId);
+    })
     .filter(isRenderablePayload)
     .map(applyReplyToMode);
 }


### PR DESCRIPTION
## Summary
- auto-inject `replyToId` from the current inbound message before reply-mode filtering when payloads are implicit
- ensure direct block-reply forwarding path preserves inferred threading metadata
- prevent coalescer flushes on replyTo mismatch unless incoming payload explicitly sets `replyToId`
- add regression tests for auto-threading behavior across `first`/`all`/`off` modes

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/auto-reply/reply/reply-payloads.auto-threading.test.ts`

Fixes #343
