### PR TITLE
[OpenClaw #15642] Preserve backslashes in daemon Windows parsing

### DIFF
--- a/packages/zee/Swabble/src/daemon/schtasks.test.ts
+++ b/packages/zee/Swabble/src/daemon/schtasks.test.ts
@@ -247,4 +247,64 @@ describe("readScheduledTaskCommand", () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("parses command with Windows backslash paths", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-schtasks-test-"));
+    try {
+      const scriptPath = path.join(tmpDir, ".zee", "gateway.cmd");
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+      await fs.writeFile(
+        scriptPath,
+        [
+          "@echo off",
+          '"C:\\Program Files\\nodejs\\node.exe" C:\\Users\\test\\AppData\\Roaming\\npm\\node_modules\\zee\\dist\\index.js gateway --port 18789',
+        ].join("\r\n"),
+        "utf8",
+      );
+
+      const env = { USERPROFILE: tmpDir, ZEE_PROFILE: "default" };
+      const result = await readScheduledTaskCommand(env);
+      expect(result).toEqual({
+        programArguments: [
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\Users\\test\\AppData\\Roaming\\npm\\node_modules\\zee\\dist\\index.js",
+          "gateway",
+          "--port",
+          "18789",
+        ],
+      });
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves UNC paths in command arguments", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-schtasks-test-"));
+    try {
+      const scriptPath = path.join(tmpDir, ".zee", "gateway.cmd");
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+      await fs.writeFile(
+        scriptPath,
+        [
+          "@echo off",
+          '"\\\\fileserver\\Zee Share\\node.exe" "\\\\fileserver\\Zee Share\\dist\\index.js" gateway --port 18789',
+        ].join("\r\n"),
+        "utf8",
+      );
+
+      const env = { USERPROFILE: tmpDir, ZEE_PROFILE: "default" };
+      const result = await readScheduledTaskCommand(env);
+      expect(result).toEqual({
+        programArguments: [
+          "\\\\fileserver\\Zee Share\\node.exe",
+          "\\\\fileserver\\Zee Share\\dist\\index.js",
+          "gateway",
+          "--port",
+          "18789",
+        ],
+      });
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/zee/Swabble/src/daemon/schtasks.ts
+++ b/packages/zee/Swabble/src/daemon/schtasks.ts
@@ -48,16 +48,14 @@ function parseCommandLine(value: string): string[] {
   const args: string[] = [];
   let current = "";
   let inQuotes = false;
-  let escapeNext = false;
 
-  for (const char of value) {
-    if (escapeNext) {
-      current += char;
-      escapeNext = false;
-      continue;
-    }
-    if (char === "\\") {
-      escapeNext = true;
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    // buildTaskScript only escapes quotes (\")
+    // keep all other backslashes literal to preserve Windows paths.
+    if (char === "\\" && i + 1 < value.length && value[i + 1] === '"') {
+      current += value[i + 1];
+      i++;
       continue;
     }
     if (char === '"') {


### PR DESCRIPTION
## Summary
- update Windows command-line parsing in `daemon/schtasks.ts` to only unescape `\"`
- preserve literal backslashes for drive-letter and UNC path arguments
- add regression tests for quoted Windows paths and UNC path handling in gateway task scripts

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/daemon/schtasks.test.ts`

Fixes #345
