### PR TITLE
[OpenClaw #11547] Preserve literal \n in inbound text normalization

### DIFF
--- a/packages/zee/Swabble/src/auto-reply/reply/inbound-text.test.ts
+++ b/packages/zee/Swabble/src/auto-reply/reply/inbound-text.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeInboundTextNewlines } from "./inbound-text.js";
+
+describe("normalizeInboundTextNewlines", () => {
+  it("converts CRLF to LF", () => {
+    expect(normalizeInboundTextNewlines("hello\r\nworld")).toBe("hello\nworld");
+  });
+
+  it("converts CR to LF", () => {
+    expect(normalizeInboundTextNewlines("hello\rworld")).toBe("hello\nworld");
+  });
+
+  it("preserves literal backslash-n sequences in Windows paths", () => {
+    const windowsPath = "C:\\Work\\nxxx\\README.md";
+    expect(normalizeInboundTextNewlines(windowsPath)).toBe("C:\\Work\\nxxx\\README.md");
+  });
+
+  it("preserves backslash-n in messages containing Windows paths", () => {
+    const message = "Please read C:\\Work\\nxxx\\README.md";
+    expect(normalizeInboundTextNewlines(message)).toBe("Please read C:\\Work\\nxxx\\README.md");
+  });
+
+  it("still normalizes actual CRLF while preserving backslash-n", () => {
+    const message = "Line 1\r\nC:\\Work\\nxxx";
+    expect(normalizeInboundTextNewlines(message)).toBe("Line 1\nC:\\Work\\nxxx");
+  });
+});

--- a/packages/zee/Swabble/src/auto-reply/reply/inbound-text.ts
+++ b/packages/zee/Swabble/src/auto-reply/reply/inbound-text.ts
@@ -1,3 +1,5 @@
 export function normalizeInboundTextNewlines(input: string): string {
-  return input.replaceAll("\r\n", "\n").replaceAll("\r", "\n").replaceAll("\\n", "\n");
+  // Normalize actual newline characters while preserving literal "\n" sequences.
+  // Literal backslash-n values are common in Windows paths and user text.
+  return input.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
 }


### PR DESCRIPTION
## Summary
- stop converting literal `\\n` sequences in inbound text normalization
- keep CRLF/CR normalization to LF intact
- add regression tests for Windows path and mixed-newline inputs

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/auto-reply/reply/inbound-text.test.ts`

Fixes #346
