### PR TITLE
[OpenClaw #15833] Preserve per-agent exec defaults after compaction

### DIFF
--- a/packages/zee/Swabble/src/agents/pi-embedded-runner/compact.ts
+++ b/packages/zee/Swabble/src/agents/pi-embedded-runner/compact.ts
@@ -64,7 +64,7 @@ import { buildEmbeddedSystemPrompt } from "./system-prompt.js";
 import { splitSdkTools } from "./tool-split.js";
 import type { EmbeddedPiCompactResult } from "./types.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
-import { describeUnknownError, mapThinkingLevel, resolveExecToolDefaults } from "./utils.js";
+import { describeUnknownError, mapThinkingLevel } from "./utils.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 
 export type CompactEmbeddedPiSessionParams = {
@@ -210,7 +210,6 @@ export async function compactEmbeddedPiSessionDirect(
     const runAbortController = new AbortController();
     const toolsRaw = createZeeCodingTools({
       exec: {
-        ...resolveExecToolDefaults(params.config),
         elevated: params.bashElevated,
       },
       sandbox,

--- a/packages/zee/Swabble/src/agents/pi-embedded-runner/utils.ts
+++ b/packages/zee/Swabble/src/agents/pi-embedded-runner/utils.ts
@@ -1,18 +1,10 @@
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
-import type { ZeeConfig } from "../../config/config.js";
-import type { ExecToolDefaults } from "../bash-tools.js";
 
 export function mapThinkingLevel(level?: ThinkLevel): ThinkingLevel {
   // pi-agent-core supports "xhigh"; Zee enables it for specific models.
   if (!level) return "off";
   return level;
-}
-
-export function resolveExecToolDefaults(config?: ZeeConfig): ExecToolDefaults | undefined {
-  const tools = config?.tools;
-  if (!tools?.exec) return undefined;
-  return tools.exec;
 }
 
 export function describeUnknownError(error: unknown): string {

--- a/packages/zee/Swabble/src/agents/pi-tools.safe-bins.test.ts
+++ b/packages/zee/Swabble/src/agents/pi-tools.safe-bins.test.ts
@@ -75,4 +75,62 @@ describe("createZeeCodingTools safeBins", () => {
     expect(result.details.status).toBe("completed");
     expect(text).toContain(marker);
   });
+
+  it("applies agent-specific exec host defaults over global defaults", async () => {
+    if (process.platform === "win32") return;
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zee-agent-exec-host-"));
+    const cfg: ZeeConfig = {
+      tools: {
+        exec: {
+          host: "sandbox",
+          security: "full",
+          ask: "off",
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            tools: {
+              exec: {
+                host: "gateway",
+              },
+            },
+          },
+          { id: "helper" },
+        ],
+      },
+    };
+
+    const mainTools = createZeeCodingTools({
+      config: cfg,
+      sessionKey: "agent:main:main",
+      workspaceDir: tmpDir,
+      agentDir: path.join(tmpDir, "agent-main"),
+    });
+    const mainExecTool = mainTools.find((tool) => tool.name === "exec");
+    expect(mainExecTool).toBeDefined();
+    await expect(
+      mainExecTool!.execute("call-main", {
+        command: "echo done",
+        host: "sandbox",
+      }),
+    ).rejects.toThrow("exec host not allowed");
+
+    const helperTools = createZeeCodingTools({
+      config: cfg,
+      sessionKey: "agent:helper:main",
+      workspaceDir: tmpDir,
+      agentDir: path.join(tmpDir, "agent-helper"),
+    });
+    const helperExecTool = helperTools.find((tool) => tool.name === "exec");
+    expect(helperExecTool).toBeDefined();
+    const helperResult = await helperExecTool!.execute("call-helper", {
+      command: "echo done",
+      host: "sandbox",
+      yieldMs: 10,
+    });
+    expect(helperResult.details.status).toBe("completed");
+  });
 });

--- a/packages/zee/Swabble/src/agents/pi-tools.ts
+++ b/packages/zee/Swabble/src/agents/pi-tools.ts
@@ -6,6 +6,7 @@ import {
   readTool,
 } from "@mariozechner/pi-coding-agent";
 import type { ZeeConfig } from "../config/config.js";
+import { resolveAgentConfig } from "./agent-scope.js";
 import { isSubagentSessionKey } from "../routing/session-key.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
 import { createApplyPatchTool } from "./apply-patch.js";
@@ -78,21 +79,25 @@ function isApplyPatchAllowedForModel(params: {
   });
 }
 
-function resolveExecConfig(cfg: ZeeConfig | undefined) {
+function resolveExecConfig(params: { cfg?: ZeeConfig; agentId?: string }) {
+  const cfg = params.cfg;
   const globalExec = cfg?.tools?.exec;
+  const agentExec =
+    cfg && params.agentId ? resolveAgentConfig(cfg, params.agentId)?.tools?.exec : undefined;
   return {
-    host: globalExec?.host,
-    security: globalExec?.security,
-    ask: globalExec?.ask,
-    node: globalExec?.node,
-    pathPrepend: globalExec?.pathPrepend,
-    safeBins: globalExec?.safeBins,
-    backgroundMs: globalExec?.backgroundMs,
-    timeoutSec: globalExec?.timeoutSec,
-    approvalRunningNoticeMs: globalExec?.approvalRunningNoticeMs,
-    cleanupMs: globalExec?.cleanupMs,
-    notifyOnExit: globalExec?.notifyOnExit,
-    applyPatch: globalExec?.applyPatch,
+    host: agentExec?.host ?? globalExec?.host,
+    security: agentExec?.security ?? globalExec?.security,
+    ask: agentExec?.ask ?? globalExec?.ask,
+    node: agentExec?.node ?? globalExec?.node,
+    pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
+    safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
+    backgroundMs: agentExec?.backgroundMs ?? globalExec?.backgroundMs,
+    timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
+    approvalRunningNoticeMs:
+      agentExec?.approvalRunningNoticeMs ?? globalExec?.approvalRunningNoticeMs,
+    cleanupMs: agentExec?.cleanupMs ?? globalExec?.cleanupMs,
+    notifyOnExit: agentExec?.notifyOnExit ?? globalExec?.notifyOnExit,
+    applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
   };
 }
 
@@ -212,7 +217,7 @@ export function createZeeCodingTools(options?: {
     sandbox?.tools,
     subagentPolicy,
   ]);
-  const execConfig = resolveExecConfig(options?.config);
+  const execConfig = resolveExecConfig({ cfg: options?.config, agentId });
   const sandboxRoot = sandbox?.workspaceDir;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = options?.workspaceDir ?? process.cwd();


### PR DESCRIPTION
## Summary
- resolve exec defaults with agent-specific precedence in `createZeeCodingTools`
- stop forcing global `tools.exec` defaults in compaction tool creation
- remove now-redundant `resolveExecToolDefaults` helper from compact utils
- add regression coverage ensuring per-agent `tools.exec.host` overrides take precedence over global defaults

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/agents/pi-tools.safe-bins.test.ts`

Fixes #366
