### PR TITLE
[OpenClaw #4702] Harden Windows binary detection and command execution

### DIFF
--- a/packages/zee/Swabble/src/agents/skills/config.ts
+++ b/packages/zee/Swabble/src/agents/skills/config.ts
@@ -75,13 +75,21 @@ export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): 
 export function hasBinary(bin: string): boolean {
   const pathEnv = process.env.PATH ?? "";
   const parts = pathEnv.split(path.delimiter).filter(Boolean);
+  const winPathExt = process.env.PATHEXT;
+  const winExtensions =
+    winPathExt !== undefined
+      ? winPathExt.split(";").filter(Boolean)
+      : [".EXE", ".CMD", ".BAT", ".COM"];
+  const extensions = process.platform === "win32" ? ["", ...winExtensions] : [""];
   for (const part of parts) {
-    const candidate = path.join(part, bin);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return true;
-    } catch {
-      // keep scanning
+    for (const ext of extensions) {
+      const candidate = path.join(part, bin + ext);
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return true;
+      } catch {
+        // keep scanning
+      }
     }
   }
   return false;

--- a/packages/zee/Swabble/src/hooks/config.ts
+++ b/packages/zee/Swabble/src/hooks/config.ts
@@ -54,13 +54,24 @@ export function resolveRuntimePlatform(): string {
 export function hasBinary(bin: string): boolean {
   const pathEnv = process.env.PATH ?? "";
   const parts = pathEnv.split(path.delimiter).filter(Boolean);
+  const extensions =
+    process.platform === "win32"
+      ? [
+          "",
+          ...(process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+            .split(";")
+            .filter(Boolean),
+        ]
+      : [""];
   for (const part of parts) {
-    const candidate = path.join(part, bin);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return true;
-    } catch {
-      // keep scanning
+    for (const ext of extensions) {
+      const candidate = path.join(part, bin + ext);
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return true;
+      } catch {
+        // keep scanning
+      }
     }
   }
   return false;

--- a/packages/zee/Swabble/src/process/exec.test.ts
+++ b/packages/zee/Swabble/src/process/exec.test.ts
@@ -42,4 +42,24 @@ describe("runCommandWithTimeout", () => {
       }
     }
   });
+
+  it("coerces env values to strings and omits undefined values", async () => {
+    const result = await runCommandWithTimeout(
+      [
+        process.execPath,
+        "-e",
+        'process.stdout.write((process.env.ZEE_NUM ?? "") + "|" + String(Object.prototype.hasOwnProperty.call(process.env, "ZEE_UNDEF")))',
+      ],
+      {
+        timeoutMs: 5_000,
+        env: {
+          ZEE_NUM: 42 as unknown as string,
+          ZEE_UNDEF: undefined,
+        } as unknown as NodeJS.ProcessEnv,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("42|false");
+  });
 });

--- a/packages/zee/Swabble/src/process/exec.ts
+++ b/packages/zee/Swabble/src/process/exec.ts
@@ -73,7 +73,12 @@ export async function runCommandWithTimeout(
     return false;
   })();
 
-  const resolvedEnv = env ? { ...process.env, ...env } : { ...process.env };
+  const mergedEnv = env ? { ...process.env, ...env } : { ...process.env };
+  const resolvedEnv = Object.fromEntries(
+    Object.entries(mergedEnv)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => [key, String(value)]),
+  );
   if (shouldSuppressNpmFund) {
     if (resolvedEnv.NPM_CONFIG_FUND == null) resolvedEnv.NPM_CONFIG_FUND = "false";
     if (resolvedEnv.npm_config_fund == null) resolvedEnv.npm_config_fund = "false";
@@ -85,6 +90,7 @@ export async function runCommandWithTimeout(
     cwd,
     env: resolvedEnv,
     windowsVerbatimArguments,
+    shell: process.platform === "win32",
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- update `hasBinary` checks in skills/hooks config to respect Windows `PATHEXT` candidates
- normalize command env values in `runCommandWithTimeout` by stringifying values and dropping `undefined`
- enable `shell` spawning on Windows in `runCommandWithTimeout` for command execution parity
- add regression coverage for env coercion/undefined filtering in process exec tests

## Testing
- `cd packages/zee/Swabble && bunx vitest run src/process/exec.test.ts`

Fixes #344
