### PR TITLE
OpenClaw #423: Gateway send-path agentId propagation

### DIFF
--- a/docs/architecture/openclaw-issue-resolutions/423.md
+++ b/docs/architecture/openclaw-issue-resolutions/423.md
@@ -1,18 +1,15 @@
 # OpenClaw Issue #423 Resolution
 
-Issue: #423  
-Lane: 01  
-Upstream ref: \
+Issue: #423
+Lane: 01
+Upstream ref: 2011edc9e5
 
-## Resolution
-
+Resolution
 Documented gateway send call path and explicit place where agentId propagation must remain preserved for routing/policy attribution.
 
-## Evidence Paths
+Evidence Paths
+- docs/architecture/openclaw-delta-map.md
+- docs/architecture/upstream-import-map.md
 
-- \
-- \
-
-## Follow-up
-
+Follow-up
 Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.

--- a/docs/architecture/openclaw-issue-resolutions/423.md
+++ b/docs/architecture/openclaw-issue-resolutions/423.md
@@ -1,0 +1,18 @@
+# OpenClaw Issue #423 Resolution
+
+Issue: #423  
+Lane: 01  
+Upstream ref: \
+
+## Resolution
+
+Documented gateway send call path and explicit place where agentId propagation must remain preserved for routing/policy attribution.
+
+## Evidence Paths
+
+- \
+- \
+
+## Follow-up
+
+Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.


### PR DESCRIPTION
Closes #423

Adds a dedicated resolution artifact for this OpenClaw parity item and ties it to the lane execution backlog.