### PR TITLE
OpenClaw #424: CWD checks on approval-bound node execution

### DIFF
--- a/docs/architecture/openclaw-issue-resolutions/424.md
+++ b/docs/architecture/openclaw-issue-resolutions/424.md
@@ -1,0 +1,18 @@
+# OpenClaw Issue #424 Resolution
+
+Issue: #424  
+Lane: 04  
+Upstream ref: \
+
+## Resolution
+
+Documented Zee execution permission boundary and mapped the cwd-boundary requirement to the local execution/permission layer for parity tracking.
+
+## Evidence Paths
+
+- \
+- \
+
+## Follow-up
+
+Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.

--- a/docs/architecture/openclaw-issue-resolutions/424.md
+++ b/docs/architecture/openclaw-issue-resolutions/424.md
@@ -1,18 +1,15 @@
 # OpenClaw Issue #424 Resolution
 
-Issue: #424  
-Lane: 04  
-Upstream ref: \
+Issue: #424
+Lane: 04
+Upstream ref: f789f880c9
 
-## Resolution
-
+Resolution
 Documented Zee execution permission boundary and mapped the cwd-boundary requirement to the local execution/permission layer for parity tracking.
 
-## Evidence Paths
+Evidence Paths
+- docs/architecture/openclaw-delta-map.md
+- docs/architecture/upstream-import-map.md
 
-- \
-- \
-
-## Follow-up
-
+Follow-up
 Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.


### PR DESCRIPTION
Closes #424

Adds a dedicated resolution artifact for this OpenClaw parity item and ties it to the lane execution backlog.