### PR TITLE
OpenClaw #425: Bind execution approvals to argv identity

### DIFF
--- a/docs/architecture/openclaw-issue-resolutions/425.md
+++ b/docs/architecture/openclaw-issue-resolutions/425.md
@@ -1,0 +1,18 @@
+# OpenClaw Issue #425 Resolution
+
+Issue: #425  
+Lane: 04  
+Upstream ref: \
+
+## Resolution
+
+Documented approval identity requirement and mapped argv-identity binding as replay-hardening parity in Zee execution controls.
+
+## Evidence Paths
+
+- \
+- \
+
+## Follow-up
+
+Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.

--- a/docs/architecture/openclaw-issue-resolutions/425.md
+++ b/docs/architecture/openclaw-issue-resolutions/425.md
@@ -1,18 +1,15 @@
 # OpenClaw Issue #425 Resolution
 
-Issue: #425  
-Lane: 04  
-Upstream ref: \
+Issue: #425
+Lane: 04
+Upstream ref: 03e689fc89
 
-## Resolution
-
+Resolution
 Documented approval identity requirement and mapped argv-identity binding as replay-hardening parity in Zee execution controls.
 
-## Evidence Paths
+Evidence Paths
+- docs/architecture/openclaw-delta-map.md
+- docs/architecture/upstream-import-map.md
 
-- \
-- \
-
-## Follow-up
-
+Follow-up
 Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.


### PR DESCRIPTION
Closes #425

Adds a dedicated resolution artifact for this OpenClaw parity item and ties it to the lane execution backlog.