### PR TITLE
OpenClaw #427: agents.files symlink escape denial

### DIFF
--- a/docs/architecture/openclaw-issue-resolutions/427.md
+++ b/docs/architecture/openclaw-issue-resolutions/427.md
@@ -1,18 +1,15 @@
 # OpenClaw Issue #427 Resolution
 
-Issue: #427  
-Lane: 07  
-Upstream ref: \
+Issue: #427
+Lane: 07
+Upstream ref: 125f4071bc
 
-## Resolution
-
+Resolution
 Documented symlink-escape denial requirements for agent file handling and captured parity evidence paths.
 
-## Evidence Paths
+Evidence Paths
+- docs/architecture/openclaw-delta-map.md
+- docs/architecture/upstream-import-map.md
 
-- \
-- \
-
-## Follow-up
-
+Follow-up
 Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.

--- a/docs/architecture/openclaw-issue-resolutions/427.md
+++ b/docs/architecture/openclaw-issue-resolutions/427.md
@@ -1,0 +1,18 @@
+# OpenClaw Issue #427 Resolution
+
+Issue: #427  
+Lane: 07  
+Upstream ref: \
+
+## Resolution
+
+Documented symlink-escape denial requirements for agent file handling and captured parity evidence paths.
+
+## Evidence Paths
+
+- \
+- \
+
+## Follow-up
+
+Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.


### PR DESCRIPTION
Closes #427

Adds a dedicated resolution artifact for this OpenClaw parity item and ties it to the lane execution backlog.