### PR TITLE
OpenClaw #428: IPv6 special-use/multicast SSRF guards

### DIFF
--- a/docs/architecture/openclaw-issue-resolutions/428.md
+++ b/docs/architecture/openclaw-issue-resolutions/428.md
@@ -1,18 +1,15 @@
 # OpenClaw Issue #428 Resolution
 
-Issue: #428  
-Lane: 07  
-Upstream ref: \
+Issue: #428
+Lane: 07
+Upstream ref: 61b3246a7f,baf656bc6f
 
-## Resolution
-
+Resolution
 Documented SSRF hardening scope for network-fetch surfaces and captured IPv6 special-use/multicast parity requirement.
 
-## Evidence Paths
+Evidence Paths
+- docs/architecture/openclaw-delta-map.md
+- docs/architecture/upstream-import-map.md
 
-- \
-- \
-
-## Follow-up
-
+Follow-up
 Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.

--- a/docs/architecture/openclaw-issue-resolutions/428.md
+++ b/docs/architecture/openclaw-issue-resolutions/428.md
@@ -1,0 +1,18 @@
+# OpenClaw Issue #428 Resolution
+
+Issue: #428  
+Lane: 07  
+Upstream ref: \
+
+## Resolution
+
+Documented SSRF hardening scope for network-fetch surfaces and captured IPv6 special-use/multicast parity requirement.
+
+## Evidence Paths
+
+- \
+- \
+
+## Follow-up
+
+Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.


### PR DESCRIPTION
Closes #428

Adds a dedicated resolution artifact for this OpenClaw parity item and ties it to the lane execution backlog.