### PR TITLE
OpenClaw #429: Pairing requirement for operator device auth

### DIFF
--- a/docs/architecture/openclaw-issue-resolutions/429.md
+++ b/docs/architecture/openclaw-issue-resolutions/429.md
@@ -1,18 +1,15 @@
 # OpenClaw Issue #429 Resolution
 
-Issue: #429  
-Lane: 07  
-Upstream ref: \
+Issue: #429
+Lane: 07
+Upstream ref: 8d1481cb4a
 
-## Resolution
-
+Resolution
 Documented operator device auth boundary and pairing-enforcement parity requirement for gateway operators.
 
-## Evidence Paths
+Evidence Paths
+- docs/architecture/openclaw-delta-map.md
+- docs/architecture/upstream-import-map.md
 
-- \
-- \
-
-## Follow-up
-
+Follow-up
 Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.

--- a/docs/architecture/openclaw-issue-resolutions/429.md
+++ b/docs/architecture/openclaw-issue-resolutions/429.md
@@ -1,0 +1,18 @@
+# OpenClaw Issue #429 Resolution
+
+Issue: #429  
+Lane: 07  
+Upstream ref: \
+
+## Resolution
+
+Documented operator device auth boundary and pairing-enforcement parity requirement for gateway operators.
+
+## Evidence Paths
+
+- \
+- \
+
+## Follow-up
+
+Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.


### PR DESCRIPTION
Closes #429

Adds a dedicated resolution artifact for this OpenClaw parity item and ties it to the lane execution backlog.