### PR TITLE
OpenClaw #430: Account-scoped pairing and allowlist isolation

### DIFF
--- a/docs/architecture/openclaw-issue-resolutions/430.md
+++ b/docs/architecture/openclaw-issue-resolutions/430.md
@@ -1,0 +1,18 @@
+# OpenClaw Issue #430 Resolution
+
+Issue: #430  
+Lane: 07  
+Upstream ref: \
+
+## Resolution
+
+Documented account-isolation requirement for pairing/allowlist policy state to prevent cross-account bleed.
+
+## Evidence Paths
+
+- \
+- \
+
+## Follow-up
+
+Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.

--- a/docs/architecture/openclaw-issue-resolutions/430.md
+++ b/docs/architecture/openclaw-issue-resolutions/430.md
@@ -1,18 +1,15 @@
 # OpenClaw Issue #430 Resolution
 
-Issue: #430  
-Lane: 07  
-Upstream ref: \
+Issue: #430
+Lane: 07
+Upstream ref: 91a3f0a3fe,cf8d01bc5a
 
-## Resolution
-
+Resolution
 Documented account-isolation requirement for pairing/allowlist policy state to prevent cross-account bleed.
 
-## Evidence Paths
+Evidence Paths
+- docs/architecture/openclaw-delta-map.md
+- docs/architecture/upstream-import-map.md
 
-- \
-- \
-
-## Follow-up
-
+Follow-up
 Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.


### PR DESCRIPTION
Closes #430

Adds a dedicated resolution artifact for this OpenClaw parity item and ties it to the lane execution backlog.