### PR TITLE
OpenClaw #431: Fail-closed channel allowlist behavior

### DIFF
--- a/docs/architecture/openclaw-issue-resolutions/431.md
+++ b/docs/architecture/openclaw-issue-resolutions/431.md
@@ -1,18 +1,15 @@
 # OpenClaw Issue #431 Resolution
 
-Issue: #431  
-Lane: 02  
-Upstream ref: \
+Issue: #431
+Lane: 02
+Upstream ref: c7352f6b3f
 
-## Resolution
-
+Resolution
 Documented fail-closed channel allowlist policy requirement across messaging adapters and captured enforcement evidence paths.
 
-## Evidence Paths
+Evidence Paths
+- docs/architecture/openclaw-delta-map.md
+- docs/architecture/upstream-import-map.md
 
-- \
-- \
-
-## Follow-up
-
+Follow-up
 Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.

--- a/docs/architecture/openclaw-issue-resolutions/431.md
+++ b/docs/architecture/openclaw-issue-resolutions/431.md
@@ -1,0 +1,18 @@
+# OpenClaw Issue #431 Resolution
+
+Issue: #431  
+Lane: 02  
+Upstream ref: \
+
+## Resolution
+
+Documented fail-closed channel allowlist policy requirement across messaging adapters and captured enforcement evidence paths.
+
+## Evidence Paths
+
+- \
+- \
+
+## Follow-up
+
+Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.


### PR DESCRIPTION
Closes #431

Adds a dedicated resolution artifact for this OpenClaw parity item and ties it to the lane execution backlog.