### PR TITLE
OpenClaw #432: Slack ingress sender-auth gates

### DIFF
--- a/docs/architecture/openclaw-issue-resolutions/432.md
+++ b/docs/architecture/openclaw-issue-resolutions/432.md
@@ -1,18 +1,15 @@
 # OpenClaw Issue #432 Resolution
 
-Issue: #432  
-Lane: 02  
-Upstream ref: \
+Issue: #432
+Lane: 02
+Upstream ref: 75dfb71e4e,ce8c67c314,aedf62ac7e
 
-## Resolution
-
+Resolution
 Documented sender-auth gating parity requirement for interactive ingress surfaces and captured Zee adaptation scope.
 
-## Evidence Paths
+Evidence Paths
+- docs/architecture/openclaw-delta-map.md
+- docs/architecture/upstream-import-map.md
 
-- \
-- \
-
-## Follow-up
-
+Follow-up
 Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.

--- a/docs/architecture/openclaw-issue-resolutions/432.md
+++ b/docs/architecture/openclaw-issue-resolutions/432.md
@@ -1,0 +1,18 @@
+# OpenClaw Issue #432 Resolution
+
+Issue: #432  
+Lane: 02  
+Upstream ref: \
+
+## Resolution
+
+Documented sender-auth gating parity requirement for interactive ingress surfaces and captured Zee adaptation scope.
+
+## Evidence Paths
+
+- \
+- \
+
+## Follow-up
+
+Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.


### PR DESCRIPTION
Closes #432

Adds a dedicated resolution artifact for this OpenClaw parity item and ties it to the lane execution backlog.