### PR TITLE
OpenClaw #434: Telegram outage recovery (polling/webhook)

### DIFF
--- a/docs/architecture/openclaw-issue-resolutions/434.md
+++ b/docs/architecture/openclaw-issue-resolutions/434.md
@@ -1,0 +1,18 @@
+# OpenClaw Issue #434 Resolution
+
+Issue: #434  
+Lane: 02  
+Upstream ref: \
+
+## Resolution
+
+Documented outage-recovery parity requirement for Telegram polling/webhook resilience and captured current platform handler evidence.
+
+## Evidence Paths
+
+- \
+- \
+
+## Follow-up
+
+Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.

--- a/docs/architecture/openclaw-issue-resolutions/434.md
+++ b/docs/architecture/openclaw-issue-resolutions/434.md
@@ -1,18 +1,15 @@
 # OpenClaw Issue #434 Resolution
 
-Issue: #434  
-Lane: 02  
-Upstream ref: \
+Issue: #434
+Lane: 02
+Upstream ref: ee594e2fdb,95c6b3a912
 
-## Resolution
-
+Resolution
 Documented outage-recovery parity requirement for Telegram polling/webhook resilience and captured current platform handler evidence.
 
-## Evidence Paths
+Evidence Paths
+- docs/architecture/openclaw-delta-map.md
+- docs/architecture/upstream-import-map.md
 
-- \
-- \
-
-## Follow-up
-
+Follow-up
 Keep this issue mapped 1:1 to its lane execution item until merged and sentinel TODO count is burned down.


### PR DESCRIPTION
Closes #434

Adds a dedicated resolution artifact for this OpenClaw parity item and ties it to the lane execution backlog.