### PR TITLE
fix(cli): keep completion stdout clean by routing logs to stderr

### DIFF
--- a/packages/zee/src/logging/transports/console.ts
+++ b/packages/zee/src/logging/transports/console.ts
@@ -37,12 +37,9 @@ export class ConsoleTransport implements ITransport {
 
     const output = this.formatter.format(entry)
 
-    // Use stderr for errors, stdout for everything else
-    if (entry.level === "error" || entry.level === "fatal") {
-      console.error(output)
-    } else {
-      console.log(output)
-    }
+    // Route all logger output to stderr so stdout stays machine-readable
+    // (for example: shell completion script generation and JSON outputs).
+    console.error(output)
   }
 
   async flush(): Promise<void> {


### PR DESCRIPTION
## Summary\n- route all logger console transport output to stderr\n- prevent log lines from polluting command stdout payloads (for example shell completion scripts)\n\n## Why\n###-begin-zee-completions-###
#
# yargs command completion script
#
# Installation: zee completion >> ~/.bashrc
#    or zee completion >> ~/.bash_profile on OSX.
#
_zee_yargs_completions()
{
    local cur_word args type_list

    cur_word="${COMP_WORDS[COMP_CWORD]}"
    args=("${COMP_WORDS[@]}")

    # ask yargs to generate completions.
    # see https://stackoverflow.com/a/40944195/7080036 for the spaces-handling awk
    mapfile -t type_list < <(zee --get-yargs-completions "${args[@]}")
    mapfile -t COMPREPLY < <(compgen -W "$( printf '%q ' "${type_list[@]}" )" -- "${cur_word}" |
        awk '/ / { print "\""$0"\"" } /^[^ ]+$/ { print $0 }')

    # if no match was found, fall back to filename completion
    if [ ${#COMPREPLY[@]} -eq 0 ]; then
      COMPREPLY=()
    fi

    return 0
}
complete -o bashdefault -o default -F _zee_yargs_completions zee
###-end-zee-completions-### currently emits startup info logs to stdout before the completion script, which corrupts shell completion installation output.\n\n## Issue\nFixes #364\n\n## Notes\n- This change preserves log visibility while keeping stdout machine-readable for command output flows.