### PR TITLE
fix(sessions): preserve non-default agent fallback for multi-store paths

### DIFF
--- a/packages/zee/Swabble/src/config/sessions/paths.test.ts
+++ b/packages/zee/Swabble/src/config/sessions/paths.test.ts
@@ -24,6 +24,14 @@ describe("session path helpers", () => {
     expect(opts).toEqual({ agentId: "ops" });
   });
 
+  it("falls back to agentId when storePath is a multi-store marker", () => {
+    const opts = resolveSessionFilePathOptions({
+      storePath: "(multiple)",
+      agentId: "ops",
+    });
+    expect(opts).toEqual({ agentId: "ops" });
+  });
+
   it("uses sessionsDir override for session files", () => {
     const resolved = resolveSessionFilePath("sess-1", undefined, {
       sessionsDir: "/tmp/custom/sessions",

--- a/packages/zee/Swabble/src/config/sessions/paths.ts
+++ b/packages/zee/Swabble/src/config/sessions/paths.ts
@@ -19,7 +19,7 @@ export function resolveSessionFilePathOptions(
   input: ResolveSessionFilePathOptionsInput,
 ): ResolveSessionFilePathOptions {
   const storePath = typeof input.storePath === "string" ? input.storePath.trim() : "";
-  if (storePath.length > 0) {
+  if (storePath.length > 0 && storePath !== "(multiple)") {
     return { sessionsDir: path.resolve(path.dirname(storePath)) };
   }
 


### PR DESCRIPTION
## Summary
- treat "(multiple)" as a non-path marker in session path resolution
- fall back to `agentId` when store path cannot identify a concrete sessions directory
- add regression coverage for multi-store marker fallback

## Issue
Fixes #339

## Notes
- this keeps transcript path resolution stable for non-default agent sessions when store metadata is aggregated.
