### PR TITLE
fix(config): expose full model-compat schema fields

### DIFF
--- a/packages/zee/Swabble/src/config/config.model-compat-schema.test.ts
+++ b/packages/zee/Swabble/src/config/config.model-compat-schema.test.ts
@@ -15,8 +15,12 @@ describe("model compat config schema", () => {
                 id: "qwen3-32b",
                 name: "Qwen3 32B",
                 compat: {
+                  supportsStore: true,
+                  supportsDeveloperRole: true,
+                  supportsReasoningEffort: true,
                   supportsUsageInStreaming: true,
                   supportsStrictMode: false,
+                  maxTokensField: "max_completion_tokens",
                   thinkingFormat: "qwen",
                   requiresToolResultName: true,
                   requiresAssistantAfterToolResult: false,
@@ -31,5 +35,36 @@ describe("model compat config schema", () => {
     });
 
     expect(res.ok).toBe(true);
+  });
+
+  it("rejects invalid enum values for full compat fields", () => {
+    const res = validateConfigObject({
+      models: {
+        providers: {
+          local: {
+            baseUrl: "http://127.0.0.1:1234/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "qwen3-32b",
+                name: "Qwen3 32B",
+                compat: {
+                  maxTokensField: "bad",
+                  thinkingFormat: "bad",
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.errors).toContain(
+      "models.providers.local.models[0].compat.maxTokensField must be one of: max_completion_tokens, max_tokens",
+    );
+    expect(res.errors).toContain(
+      "models.providers.local.models[0].compat.thinkingFormat must be one of: openai, zai, qwen",
+    );
   });
 });

--- a/packages/zee/Swabble/src/config/validation.ts
+++ b/packages/zee/Swabble/src/config/validation.ts
@@ -1,7 +1,11 @@
 type CompatConfig = {
+  supportsStore?: boolean;
+  supportsDeveloperRole?: boolean;
+  supportsReasoningEffort?: boolean;
   supportsUsageInStreaming?: boolean;
   supportsStrictMode?: boolean;
-  thinkingFormat?: string;
+  maxTokensField?: "max_completion_tokens" | "max_tokens";
+  thinkingFormat?: "openai" | "zai" | "qwen";
   requiresToolResultName?: boolean;
   requiresAssistantAfterToolResult?: boolean;
   requiresThinkingAsText?: boolean;
@@ -24,6 +28,9 @@ function validateCompat(compat: unknown, path: string, errors: string[]): void {
   }
 
   const booleanKeys: Array<keyof CompatConfig> = [
+    "supportsStore",
+    "supportsDeveloperRole",
+    "supportsReasoningEffort",
     "supportsUsageInStreaming",
     "supportsStrictMode",
     "requiresToolResultName",
@@ -39,8 +46,21 @@ function validateCompat(compat: unknown, path: string, errors: string[]): void {
     }
   }
 
-  if (compat.thinkingFormat !== undefined && typeof compat.thinkingFormat !== "string") {
-    errors.push(`${path}.thinkingFormat must be a string`);
+  if (
+    compat.maxTokensField !== undefined &&
+    compat.maxTokensField !== "max_completion_tokens" &&
+    compat.maxTokensField !== "max_tokens"
+  ) {
+    errors.push(`${path}.maxTokensField must be one of: max_completion_tokens, max_tokens`);
+  }
+
+  if (
+    compat.thinkingFormat !== undefined &&
+    compat.thinkingFormat !== "openai" &&
+    compat.thinkingFormat !== "zai" &&
+    compat.thinkingFormat !== "qwen"
+  ) {
+    errors.push(`${path}.thinkingFormat must be one of: openai, zai, qwen`);
   }
 }
 
@@ -70,4 +90,3 @@ export function validateConfigObject(config: unknown): ValidationResult {
 
   return errors.length === 0 ? { ok: true } : { ok: false, errors };
 }
-


### PR DESCRIPTION
## Summary
- add missing model compat boolean fields to Swabble config validation
- add enum validation for `maxTokensField` and `thinkingFormat`
- extend schema regression coverage for accepted and rejected full-compat payloads

## Issue
Fixes #351

## Notes
- this aligns the compat schema surface with upstream expectations while preserving Zee's current config architecture.
