### PR TITLE
perf(abort): harden abort binding patterns across long-lived runtime paths

### DIFF
--- a/packages/zee/src/diagnostics/checks/providers.ts
+++ b/packages/zee/src/diagnostics/checks/providers.ts
@@ -49,7 +49,7 @@ async function checkInternetConnectivity(): Promise<CheckResult> {
   for (const url of testUrls) {
     try {
       const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 5000)
+      const timeout = setTimeout(controller.abort.bind(controller), 5000)
       const response = await fetch(url, { method: "HEAD", signal: controller.signal })
       clearTimeout(timeout)
 
@@ -121,7 +121,7 @@ async function checkProvider(provider: ProviderConfig): Promise<CheckResult> {
 
   try {
     const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), provider.timeout)
+    const timeout = setTimeout(controller.abort.bind(controller), provider.timeout)
     const response = await fetch(provider.endpoint, { method: "HEAD", signal: controller.signal })
     clearTimeout(timeout)
     const latency = Date.now() - start
@@ -161,7 +161,7 @@ async function checkOllama(): Promise<CheckResult> {
 
   try {
     const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 3000)
+    const timeout = setTimeout(controller.abort.bind(controller), 3000)
     const response = await fetch(ollamaUrl, { signal: controller.signal })
     clearTimeout(timeout)
     const latency = Date.now() - start

--- a/packages/zee/src/server/route/global.ts
+++ b/packages/zee/src/server/route/global.ts
@@ -172,7 +172,7 @@ export const GlobalRoute = new Hono()
       let internet: "ok" | "fail" | "checking" = "checking"
       try {
         const controller = new AbortController()
-        const timeout = setTimeout(() => controller.abort(), 3000)
+        const timeout = setTimeout(controller.abort.bind(controller), 3000)
         const response = await fetch("https://cloudflare.com/cdn-cgi/trace", {
           method: "HEAD",
           signal: controller.signal,

--- a/packages/zee/src/server/route/llm.ts
+++ b/packages/zee/src/server/route/llm.ts
@@ -8,6 +8,7 @@ import { Log } from "../../util/log"
 import { Fallback } from "../../provider/fallback"
 import { FluxRecorder } from "@/flux"
 import { RequestMeta } from "../request-meta"
+import { bindAbortRelay } from "../../util/net"
 
 const log = Log.create({ service: "server:llm" })
 
@@ -379,7 +380,7 @@ export const LlmRoute = new Hono().post(
     const abortController = new AbortController()
     const requestAbort = c.req.raw.signal
     if (requestAbort?.aborted) abortController.abort()
-    requestAbort?.addEventListener("abort", () => abortController.abort(), { once: true })
+    requestAbort?.addEventListener("abort", bindAbortRelay(abortController), { once: true })
 
     return streamSSE(c, async (stream) => {
       FluxRecorder.record({

--- a/packages/zee/src/surface/platforms/telegram.ts
+++ b/packages/zee/src/surface/platforms/telegram.ts
@@ -704,7 +704,7 @@ export class TelegramPlatformHandler implements MessagingPlatformHandler {
   ): Promise<T> {
     const url = `${this.apiBaseUrl}/bot${this.token}/${method}`
     const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), options?.timeoutMs ?? 30_000)
+    const timeout = setTimeout(controller.abort.bind(controller), options?.timeoutMs ?? 30_000)
     const signal = options?.signal
       ? AbortSignal.any([controller.signal, options.signal])
       : controller.signal

--- a/packages/zee/src/util/net.ts
+++ b/packages/zee/src/util/net.ts
@@ -10,6 +10,14 @@ import { parseHttpTarget } from "@/security"
 
 const log = Log.create({ service: "net-util" })
 
+function relayAbort(this: AbortController): void {
+  this.abort()
+}
+
+export function bindAbortRelay(controller: AbortController): () => void {
+  return relayAbort.bind(controller)
+}
+
 /**
  * Fetch with timeout using AbortController
  *
@@ -24,7 +32,7 @@ export async function fetchWithTimeout(
   timeoutMs: number = 10000,
 ): Promise<Response | null> {
   const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  const timeoutId = setTimeout(controller.abort.bind(controller), timeoutMs)
 
   try {
     const response = await fetch(url, {

--- a/src/domain/zee/cron.ts
+++ b/src/domain/zee/cron.ts
@@ -142,7 +142,7 @@ async function callGatewayRpc<T = unknown>(
   const url = `${baseUrl}/rpc`;
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  const timeoutId = setTimeout(controller.abort.bind(controller), timeout);
 
   try {
     const response = await fetch(url, {

--- a/src/domain/zee/pty-sessions.ts
+++ b/src/domain/zee/pty-sessions.ts
@@ -47,7 +47,7 @@ async function callGatewayRpc<T = unknown>(
   const url = `${baseUrl}/rpc`;
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  const timeoutId = setTimeout(controller.abort.bind(controller), timeout);
 
   try {
     const response = await fetch(url, {

--- a/src/domain/zee/splitwise.ts
+++ b/src/domain/zee/splitwise.ts
@@ -248,7 +248,7 @@ export async function callSplitwiseApi(
 
   const timeoutMs = request.timeoutMs ?? config.timeoutMs ?? 15000;
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const timeoutId = setTimeout(controller.abort.bind(controller), timeoutMs);
 
   let response: Response;
   try {

--- a/src/mcp/builtin/webfetch.ts
+++ b/src/mcp/builtin/webfetch.ts
@@ -48,7 +48,7 @@ Usage:
       const timeout = Math.min((params.timeout ?? DEFAULT_TIMEOUT / 1000) * 1000, MAX_TIMEOUT);
 
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), timeout);
+      const timeoutId = setTimeout(controller.abort.bind(controller), timeout);
 
       // Build Accept header based on format
       let acceptHeader = '*/*';

--- a/src/memory/qdrant.ts
+++ b/src/memory/qdrant.ts
@@ -171,7 +171,7 @@ export class QdrantVectorStorage implements VectorStorage {
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+      const timeoutId = setTimeout(controller.abort.bind(controller), this.timeoutMs);
       let response: Response;
       try {
         response = await fetch(url, {


### PR DESCRIPTION
## Summary
- replace `setTimeout(() => controller.abort(), ...)` with `setTimeout(controller.abort.bind(controller), ...)` across runtime call-sites
- replace request abort relay closure with a bound relay helper in LLM route wiring
- add reusable `bindAbortRelay` utility in net helpers for event-listener abort relays

## Issue
Fixes #347

## Notes
- this follows the upstream leak-prevention pattern and reduces closure retention risk in long-running sessions.
