### PR TITLE
fix(cron): honor per-job deleteAfterRun cleanup

### DIFF
--- a/packages/zee/src/cron/service/timer.ts
+++ b/packages/zee/src/cron/service/timer.ts
@@ -102,9 +102,11 @@ export async function executeJob(state: CronServiceState, job: CronJob, nowMs: n
       state.activeRuns.set(job.id, prev - 1)
     }
 
-    const shouldDelete = job.schedule.kind === "at" && status === "ok" && job.deleteAfterRun === true
+    const shouldDelete = status === "ok" && job.deleteAfterRun === true
 
-    if (!shouldDelete) {
+    if (shouldDelete) {
+      job.state.nextRunAtMs = undefined
+    } else {
       if (job.schedule.kind === "at" && status === "ok") {
         // One-shot job completed successfully; disable it.
         job.enabled = false

--- a/packages/zee/test/cron/concurrency-throttle.test.ts
+++ b/packages/zee/test/cron/concurrency-throttle.test.ts
@@ -425,4 +425,22 @@ describe("bug fixes", () => {
     })
     expect(result).toBeUndefined()
   })
+
+  test("bug 6: executeJob respects deleteAfterRun for recurring jobs", async () => {
+    const state = makeState({
+      nowMs: () => 1000,
+      runIsolatedAgentJob: async () => ({ status: "ok", summary: "done" }),
+    })
+    const job = makeJob({
+      schedule: { kind: "every", everyMs: 60_000 },
+      deleteAfterRun: true,
+    })
+    state.store = { version: 1, jobs: [job] } as CronStoreFile
+
+    await executeJob(state, job, 1000, { forced: false })
+
+    expect(job.state.lastStatus).toBe("ok")
+    expect(job.state.nextRunAtMs).toBeUndefined()
+    expect(state.store.jobs).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
## Summary
- make cron cleanup honor per-job `deleteAfterRun` on any successful run
- stop scheduling a next run when a job is marked for deletion
- add regression coverage for recurring jobs with `deleteAfterRun: true`

## Testing
- not run (per request)

Fixes #361
