### PR TITLE
fix(web): respect backend base path in dashboard URL generation

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -119,8 +119,13 @@ export function AppInterface(props: { defaultUrl?: string }) {
     if (props.defaultUrl) return props.defaultUrl
     if (stored) return stored
     if (["zee-bot.com"].some((domain) => location.hostname.includes(domain))) return "http://localhost:4096"
-    if (import.meta.env.DEV)
-      return `http://${import.meta.env.VITE_ZEE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_ZEE_SERVER_PORT ?? "4096"}`
+    if (import.meta.env.DEV) {
+      const basePathRaw = import.meta.env.VITE_ZEE_SERVER_BASE_PATH ?? ""
+      const normalizedBasePath = basePathRaw.trim()
+        ? `/${basePathRaw.replace(/^\/+|\/+$/g, "")}`
+        : ""
+      return `http://${import.meta.env.VITE_ZEE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_ZEE_SERVER_PORT ?? "4096"}${normalizedBasePath}`
+    }
 
     return window.location.origin
   }

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -1,6 +1,7 @@
 interface ImportMetaEnv {
   readonly VITE_ZEE_SERVER_HOST: string
   readonly VITE_ZEE_SERVER_PORT: string
+  readonly VITE_ZEE_SERVER_BASE_PATH: string
   readonly VITE_ZEE_CHANGELOG_URL: string
 }
 

--- a/packages/zee/src/cli/cmd/web.ts
+++ b/packages/zee/src/cli/cmd/web.ts
@@ -24,6 +24,7 @@ type BackendTarget = {
   origin: string
   hostForEnv: string
   port: number
+  basePath: string
 }
 
 export function resolveWebBackendUrl(input: { serverUrl?: unknown; env?: NodeJS.ProcessEnv } = {}): string {
@@ -47,10 +48,13 @@ export function resolveWebBackendTarget(rawUrl: string): BackendTarget {
   const port = url.port ? Number(url.port) : 80
   const normalizedHostname = url.hostname.replace(/^\[(.*)\]$/, "$1")
   const hostForEnv = normalizedHostname.includes(":") ? `[${normalizedHostname}]` : normalizedHostname
+  const pathname = url.pathname.replace(/\/+$/, "")
+  const basePath = pathname && pathname !== "/" ? pathname : ""
   return {
     origin: url.origin,
     hostForEnv,
     port,
+    basePath,
   }
 }
 
@@ -157,6 +161,7 @@ export const WebCommand = cmd({
         ...process.env,
         VITE_ZEE_SERVER_HOST: backend.hostForEnv,
         VITE_ZEE_SERVER_PORT: String(backend.port),
+        VITE_ZEE_SERVER_BASE_PATH: backend.basePath,
       },
       stdin: "inherit",
       stdout: "inherit",

--- a/packages/zee/test/cli/auth-frontmatter.test.ts
+++ b/packages/zee/test/cli/auth-frontmatter.test.ts
@@ -92,4 +92,25 @@ describe("extractAuthFromFrontmatter", () => {
     })
     expect(discovered).toEqual([])
   })
+
+  test("does not send bearer auth when apiKey is local placeholder", async () => {
+    const requests: Array<{ auth?: string }> = []
+    const fetchFn = (async (_input: string | URL | Request, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined
+      requests.push({ auth: headers?.Authorization })
+      return new Response(JSON.stringify({ data: [{ id: "qwen3-coder" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as typeof fetch
+
+    const discovered = await discoverOpenAICompatibleModels({
+      baseURL: "http://localhost:8000/v1",
+      apiKey: "local",
+      fetchFn,
+    })
+
+    expect(discovered).toEqual(["qwen3-coder"])
+    expect(requests[0]).toEqual({ auth: undefined })
+  })
 })

--- a/packages/zee/test/cli/web-command.test.ts
+++ b/packages/zee/test/cli/web-command.test.ts
@@ -35,6 +35,7 @@ describe("zee web command helpers", () => {
       origin: "http://localhost:3210",
       hostForEnv: "localhost",
       port: 3210,
+      basePath: "/api",
     })
   })
 
@@ -42,6 +43,7 @@ describe("zee web command helpers", () => {
     const target = resolveWebBackendTarget("http://[::1]:3210")
     expect(target.hostForEnv).toBe("[::1]")
     expect(target.port).toBe(3210)
+    expect(target.basePath).toBe("")
   })
 
   test("resolveWebBackendTarget rejects https backend URLs", () => {


### PR DESCRIPTION
## Summary
- preserve backend URL pathname when parsing `--server-url` in `zee web`
- pass backend base path to the web app via `VITE_ZEE_SERVER_BASE_PATH`
- include base path when constructing the dev default server URL in the app
- add regression assertions for parsed backend base path

## Testing
- not run (per request)

Fixes #369
