### PR TITLE
feat(provider): native ollama /api/chat parity wiring

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -119,8 +119,13 @@ export function AppInterface(props: { defaultUrl?: string }) {
     if (props.defaultUrl) return props.defaultUrl
     if (stored) return stored
     if (["zee-bot.com"].some((domain) => location.hostname.includes(domain))) return "http://localhost:4096"
-    if (import.meta.env.DEV)
-      return `http://${import.meta.env.VITE_ZEE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_ZEE_SERVER_PORT ?? "4096"}`
+    if (import.meta.env.DEV) {
+      const basePathRaw = import.meta.env.VITE_ZEE_SERVER_BASE_PATH ?? ""
+      const normalizedBasePath = basePathRaw.trim()
+        ? `/${basePathRaw.replace(/^\/+|\/+$/g, "")}`
+        : ""
+      return `http://${import.meta.env.VITE_ZEE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_ZEE_SERVER_PORT ?? "4096"}${normalizedBasePath}`
+    }
 
     return window.location.origin
   }

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -1,6 +1,7 @@
 interface ImportMetaEnv {
   readonly VITE_ZEE_SERVER_HOST: string
   readonly VITE_ZEE_SERVER_PORT: string
+  readonly VITE_ZEE_SERVER_BASE_PATH: string
   readonly VITE_ZEE_CHANGELOG_URL: string
 }
 

--- a/packages/zee/src/cli/cmd/auth.ts
+++ b/packages/zee/src/cli/cmd/auth.ts
@@ -299,6 +299,11 @@ export function resolveLocalProviderBaseUrl(host: string, port: number): string 
   return `http://${safeHost}:${port}/v1`
 }
 
+export function resolveOllamaProviderBaseUrl(host: string, port: number): string {
+  const safeHost = host.trim() || "localhost"
+  return `http://${safeHost}:${port}/api`
+}
+
 export function normalizeLocalProviderBaseUrl(input: string, fallbackPort: number): string {
   const trimmed = input.trim()
   if (!trimmed) return `http://localhost:${fallbackPort}/v1`
@@ -1174,7 +1179,8 @@ export const AuthLoginCommand = cmd({
             if (prompts.isCancel(portStr)) throw new UI.CancelledError()
 
             const port = parseInt(portStr, 10)
-            baseURL = resolveLocalProviderBaseUrl(host, port)
+            baseURL =
+              provider === "ollama" ? resolveOllamaProviderBaseUrl(host, port) : resolveLocalProviderBaseUrl(host, port)
           }
 
           // Add provider to config

--- a/packages/zee/src/cli/cmd/web.ts
+++ b/packages/zee/src/cli/cmd/web.ts
@@ -24,6 +24,7 @@ type BackendTarget = {
   origin: string
   hostForEnv: string
   port: number
+  basePath: string
 }
 
 export function resolveWebBackendUrl(input: { serverUrl?: unknown; env?: NodeJS.ProcessEnv } = {}): string {
@@ -47,10 +48,13 @@ export function resolveWebBackendTarget(rawUrl: string): BackendTarget {
   const port = url.port ? Number(url.port) : 80
   const normalizedHostname = url.hostname.replace(/^\[(.*)\]$/, "$1")
   const hostForEnv = normalizedHostname.includes(":") ? `[${normalizedHostname}]` : normalizedHostname
+  const pathname = url.pathname.replace(/\/+$/, "")
+  const basePath = pathname && pathname !== "/" ? pathname : ""
   return {
     origin: url.origin,
     hostForEnv,
     port,
+    basePath,
   }
 }
 
@@ -157,6 +161,7 @@ export const WebCommand = cmd({
         ...process.env,
         VITE_ZEE_SERVER_HOST: backend.hostForEnv,
         VITE_ZEE_SERVER_PORT: String(backend.port),
+        VITE_ZEE_SERVER_BASE_PATH: backend.basePath,
       },
       stdin: "inherit",
       stdout: "inherit",

--- a/packages/zee/src/provider/blacklist.json
+++ b/packages/zee/src/provider/blacklist.json
@@ -75,7 +75,6 @@
     { "id": "alibaba", "reason": "Removed per request" },
     { "id": "cerebras", "reason": "Removed per request" },
     { "id": "synthetic", "reason": "Redundant HuggingFace proxy" },
-    { "id": "ollama", "reason": "Local provider -- use vLLM instead" },
     { "id": "github-copilot", "reason": "Subscription-based, limited models" },
     { "id": "amazon-bedrock", "reason": "Enterprise AWS only" },
     { "id": "qwen-portal", "reason": "OAuth complexity, limited models" },

--- a/packages/zee/src/provider/provider.ts
+++ b/packages/zee/src/provider/provider.ts
@@ -129,6 +129,11 @@ export namespace Provider {
     return Number(match[1]) >= 5
   }
 
+  function resolveProviderNpm(providerID: string, npm: string): string {
+    if (providerID === "ollama") return "@ai-sdk/ollama"
+    return npm
+  }
+
   const BUNDLED_PROVIDERS: Record<string, (options: any) => ProviderSDK> = {
     "@ai-sdk/anthropic": createAnthropic,
     "@ai-sdk/azure": createAzure,
@@ -296,12 +301,15 @@ export namespace Provider {
       api: {
         id: model.id,
         url: provider.api ?? "",
-        npm: iife(() => {
-          // Fix: Kimi For Coding uses OpenAI-compatible API format, not Anthropic
-          // The models-api.json incorrectly specifies @ai-sdk/anthropic
-          if (provider.id === "kimi-for-coding") return "@ai-sdk/openai-compatible"
-          return model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible"
-        }),
+        npm: resolveProviderNpm(
+          provider.id,
+          iife(() => {
+            // Fix: Kimi For Coding uses OpenAI-compatible API format, not Anthropic
+            // The models-api.json incorrectly specifies @ai-sdk/anthropic
+            if (provider.id === "kimi-for-coding") return "@ai-sdk/openai-compatible"
+            return model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible"
+          }),
+        ),
       },
       status: model.status ?? "active",
       headers: model.headers ?? {},
@@ -460,17 +468,20 @@ export namespace Provider {
           id: modelID,
           api: {
             id: model.id ?? existingModel?.api.id ?? modelID,
-            npm: iife(() => {
-              // Fix: Kimi For Coding uses OpenAI-compatible API format, not Anthropic
-              if (providerID === "kimi-for-coding") return "@ai-sdk/openai-compatible"
-              return (
-                model.provider?.npm ??
-                provider.npm ??
-                existingModel?.api.npm ??
-                modelsDev[providerID]?.npm ??
-                "@ai-sdk/openai-compatible"
-              )
-            }),
+            npm: resolveProviderNpm(
+              providerID,
+              iife(() => {
+                // Fix: Kimi For Coding uses OpenAI-compatible API format, not Anthropic
+                if (providerID === "kimi-for-coding") return "@ai-sdk/openai-compatible"
+                return (
+                  model.provider?.npm ??
+                  provider.npm ??
+                  existingModel?.api.npm ??
+                  modelsDev[providerID]?.npm ??
+                  "@ai-sdk/openai-compatible"
+                )
+              }),
+            ),
             url: provider?.api ?? existingModel?.api.url ?? modelsDev[providerID]?.api,
           },
           status: model.status ?? existingModel?.status ?? "active",
@@ -842,7 +853,6 @@ export namespace Provider {
       if (blocked.has(providerID)) continue
 
       try {
-        const baseURL = (configProvider.options.baseURL as string).replace(/\/v1\/?$/, "")
         const key = providers[providerID]?.key
         const headers =
           key && key !== "local"
@@ -850,6 +860,87 @@ export namespace Provider {
                 Authorization: `Bearer ${key}`,
               }
             : undefined
+        const configuredBaseURL = String(configProvider.options.baseURL).replace(/\/+$/, "")
+
+        if (providerID === "ollama") {
+          const baseURL = configuredBaseURL.replace(/\/v1\/?$/, "").replace(/\/api\/?$/, "")
+          const response = await fetch(`${baseURL}/api/tags`, {
+            headers,
+            signal: AbortSignal.timeout(3000),
+          })
+          if (!response.ok) continue
+          const data = (await response.json()) as {
+            models?: Array<{
+              name?: string
+              details?: { context_length?: number }
+            }>
+          }
+
+          // Ensure provider exists
+          if (!providers[providerID]) {
+            providers[providerID] = {
+              id: providerID,
+              name: providerID.charAt(0).toUpperCase() + providerID.slice(1),
+              models: {},
+              source: "config",
+              env: configProvider.env ?? [],
+              options: configProvider.options,
+            }
+          }
+
+          for (const apiModel of data.models ?? []) {
+            const modelID = (apiModel.name ?? "").trim()
+            if (!modelID) continue
+            if (providers[providerID].models[modelID]) continue // Don't overwrite existing
+
+            const contextLength =
+              typeof apiModel.details?.context_length === "number" && apiModel.details.context_length > 0
+                ? apiModel.details.context_length
+                : 8192
+
+            providers[providerID].models[modelID] = {
+              id: modelID,
+              name: modelID.split("/").pop() ?? modelID,
+              providerID,
+              api: {
+                id: modelID,
+                url: `${baseURL}/api`,
+                npm: "@ai-sdk/ollama",
+              },
+              status: "active",
+              headers: {},
+              cost: {
+                input: 0,
+                output: 0,
+                cache: { read: 0, write: 0 },
+              },
+              capabilities: {
+                temperature: true,
+                attachment: false,
+                reasoning: modelID.toLowerCase().includes("qwen3"),
+                toolcall: true,
+                streaming: true,
+                input: { text: true, audio: false, image: false, video: false, pdf: false },
+                output: { text: true, audio: false, image: false, video: false, pdf: false },
+                interleaved: false,
+              },
+              limit: {
+                context: contextLength,
+                output: Math.min(contextLength, 4096),
+              },
+              options: {},
+              release_date: "1970-01-01",
+            }
+          }
+
+          log.info("auto-discovered models from local provider", {
+            provider: providerID,
+            count: Object.keys(providers[providerID].models).length,
+          })
+          continue
+        }
+
+        const baseURL = configuredBaseURL.replace(/\/v1\/?$/, "")
         const response = await fetch(`${baseURL}/v1/models`, {
           headers,
           signal: AbortSignal.timeout(3000),

--- a/packages/zee/test/cli/auth-frontmatter.test.ts
+++ b/packages/zee/test/cli/auth-frontmatter.test.ts
@@ -4,6 +4,7 @@ import {
   extractAuthFromFrontmatter,
   normalizeLocalProviderBaseUrl,
   parseOpenAICompatibleModelIds,
+  resolveOllamaProviderBaseUrl,
   resolveLocalProviderBaseUrl,
 } from "../../src/cli/cmd/auth"
 
@@ -44,6 +45,7 @@ describe("extractAuthFromFrontmatter", () => {
 
   test("builds and normalizes local provider URLs", () => {
     expect(resolveLocalProviderBaseUrl("localhost", 8000)).toBe("http://localhost:8000/v1")
+    expect(resolveOllamaProviderBaseUrl("localhost", 11434)).toBe("http://localhost:11434/api")
     expect(normalizeLocalProviderBaseUrl("localhost:8000", 8000)).toBe("http://localhost:8000/v1")
     expect(normalizeLocalProviderBaseUrl("http://127.0.0.1", 8000)).toBe("http://127.0.0.1:8000/v1")
     expect(normalizeLocalProviderBaseUrl("https://host.example/v1/", 8000)).toBe("https://host.example/v1")

--- a/packages/zee/test/cli/auth-frontmatter.test.ts
+++ b/packages/zee/test/cli/auth-frontmatter.test.ts
@@ -92,4 +92,25 @@ describe("extractAuthFromFrontmatter", () => {
     })
     expect(discovered).toEqual([])
   })
+
+  test("does not send bearer auth when apiKey is local placeholder", async () => {
+    const requests: Array<{ auth?: string }> = []
+    const fetchFn = (async (_input: string | URL | Request, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined
+      requests.push({ auth: headers?.Authorization })
+      return new Response(JSON.stringify({ data: [{ id: "qwen3-coder" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as typeof fetch
+
+    const discovered = await discoverOpenAICompatibleModels({
+      baseURL: "http://localhost:8000/v1",
+      apiKey: "local",
+      fetchFn,
+    })
+
+    expect(discovered).toEqual(["qwen3-coder"])
+    expect(requests[0]).toEqual({ auth: undefined })
+  })
 })

--- a/packages/zee/test/cli/web-command.test.ts
+++ b/packages/zee/test/cli/web-command.test.ts
@@ -35,6 +35,7 @@ describe("zee web command helpers", () => {
       origin: "http://localhost:3210",
       hostForEnv: "localhost",
       port: 3210,
+      basePath: "/api",
     })
   })
 
@@ -42,6 +43,7 @@ describe("zee web command helpers", () => {
     const target = resolveWebBackendTarget("http://[::1]:3210")
     expect(target.hostForEnv).toBe("[::1]")
     expect(target.port).toBe(3210)
+    expect(target.basePath).toBe("")
   })
 
   test("resolveWebBackendTarget rejects https backend URLs", () => {

--- a/packages/zee/test/provider/provider.test.ts
+++ b/packages/zee/test/provider/provider.test.ts
@@ -1364,6 +1364,43 @@ test("provider with custom npm package", async () => {
   })
 })
 
+test("ollama provider defaults configured models to native ollama SDK", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "zee.jsonc"),
+        JSON.stringify({
+          $schema: "zee",
+          provider: {
+            ollama: {
+              name: "Ollama",
+              env: [],
+              models: {
+                "llama3.2": {
+                  name: "Llama 3.2",
+                  tool_call: true,
+                  limit: { context: 8192, output: 2048 },
+                },
+              },
+              options: {
+                baseURL: "http://localhost:11434/api",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["ollama"]).toBeDefined()
+      expect(providers["ollama"].models["llama3.2"].api.npm).toBe("@ai-sdk/ollama")
+    },
+  })
+})
+
 // Edge cases for model configuration
 
 test("model alias name defaults to alias key when id differs", async () => {


### PR DESCRIPTION
## Summary
- unblocks the `ollama` provider and maps Ollama models to native `@ai-sdk/ollama`
- adds provider-specific local model discovery for Ollama via `/api/tags` (instead of OpenAI `/v1/models`)
- normalizes `zee auth login ollama` onboarding to store `/api` base URLs
- adds regression coverage for ollama URL/auth helpers and native SDK mapping

## Testing
- not run (per request)

Fixes #353
