### PR TITLE
Support AGENT_CORE_MODELS_URL/PATH aliases for model catalog

### DIFF
--- a/packages/zee/src/flag/flag.ts
+++ b/packages/zee/src/flag/flag.ts
@@ -79,8 +79,9 @@ function computeFlags() {
     ZEE_SESSION_CONTROL: truthy("ZEE_SESSION_CONTROL"),
 
     // Models
-    ZEE_MODELS_URL: env("ZEE_MODELS_URL"),
-    ZEE_MODELS_PATH: env("ZEE_MODELS_PATH"),
+    // AGENT_CORE_* aliases are accepted for upstream config parity.
+    ZEE_MODELS_URL: env("ZEE_MODELS_URL") ?? env("AGENT_CORE_MODELS_URL"),
+    ZEE_MODELS_PATH: env("ZEE_MODELS_PATH") ?? env("AGENT_CORE_MODELS_PATH"),
     ZEE_DISABLE_MODELS_FETCH: truthy("ZEE_DISABLE_MODELS_FETCH"),
 
     // Testing

--- a/packages/zee/src/global/index.ts
+++ b/packages/zee/src/global/index.ts
@@ -69,7 +69,7 @@ export namespace Global {
       return path.join(os.tmpdir(), app)
     },
     get modelsDevUrl() {
-      return process.env.ZEE_MODELS_URL || "https://models.dev"
+      return process.env.ZEE_MODELS_URL || process.env.AGENT_CORE_MODELS_URL || "https://models.dev"
     },
   }
 }

--- a/packages/zee/src/provider/models.ts
+++ b/packages/zee/src/provider/models.ts
@@ -27,11 +27,23 @@ export namespace ModelsDev {
   }
 
   function getUrl() {
-    return process.env.ZEE_MODELS_URL || Flag.ZEE_MODELS_URL || configuredUrl || "https://models.dev"
+    return (
+      process.env.ZEE_MODELS_URL ||
+      process.env.AGENT_CORE_MODELS_URL ||
+      Flag.ZEE_MODELS_URL ||
+      configuredUrl ||
+      "https://models.dev"
+    )
   }
 
   function getPath() {
-    return process.env.ZEE_MODELS_PATH || Flag.ZEE_MODELS_PATH || configuredPath || getFilepath()
+    return (
+      process.env.ZEE_MODELS_PATH ||
+      process.env.AGENT_CORE_MODELS_PATH ||
+      Flag.ZEE_MODELS_PATH ||
+      configuredPath ||
+      getFilepath()
+    )
   }
 
   export const Model = z.object({

--- a/packages/zee/test/provider/models-path.test.ts
+++ b/packages/zee/test/provider/models-path.test.ts
@@ -5,6 +5,7 @@ import { reloadFlags } from "../../src/flag/flag"
 
 const ORIGINAL_ENV = {
   ZEE_MODELS_PATH: process.env.ZEE_MODELS_PATH,
+  AGENT_CORE_MODELS_PATH: process.env.AGENT_CORE_MODELS_PATH,
 }
 
 beforeAll(async () => {
@@ -73,6 +74,45 @@ describe("ModelsDev", () => {
     } finally {
       if (originalPath === undefined) delete process.env.ZEE_MODELS_PATH
       else process.env.ZEE_MODELS_PATH = originalPath
+      reloadFlags()
+      ModelsDev.configure()
+      ModelsDev.Data.reset()
+    }
+  })
+
+  test("reads model catalog from AGENT_CORE_MODELS_PATH alias when Zee path is unset", async () => {
+    const aliasFilepath = path.join(process.env.XDG_CACHE_HOME ?? "/tmp", "zee-test-models-alias-path.json")
+    await Bun.write(
+      aliasFilepath,
+      JSON.stringify({
+        alias: {
+          api: "https://example.invalid",
+          name: "Alias Provider",
+          env: [],
+          id: "alias",
+          models: {},
+        },
+      }),
+    )
+
+    const originalZeePath = process.env.ZEE_MODELS_PATH
+    const originalAliasPath = process.env.AGENT_CORE_MODELS_PATH
+    try {
+      delete process.env.ZEE_MODELS_PATH
+      process.env.AGENT_CORE_MODELS_PATH = aliasFilepath
+      reloadFlags()
+      ModelsDev.configure()
+      ModelsDev.Data.reset()
+
+      const data = await ModelsDev.get()
+      expect(data).toBeDefined()
+      expect(Object.keys(data)).toContain("alias")
+      expect(data.alias?.name).toBe("Alias Provider")
+    } finally {
+      if (originalZeePath === undefined) delete process.env.ZEE_MODELS_PATH
+      else process.env.ZEE_MODELS_PATH = originalZeePath
+      if (originalAliasPath === undefined) delete process.env.AGENT_CORE_MODELS_PATH
+      else process.env.AGENT_CORE_MODELS_PATH = originalAliasPath
       reloadFlags()
       ModelsDev.configure()
       ModelsDev.Data.reset()

--- a/packages/zee/test/provider/models-url.test.ts
+++ b/packages/zee/test/provider/models-url.test.ts
@@ -45,4 +45,50 @@ describe("ModelsDev", () => {
     expect(fetchedUrl).toBe(`${catalogUrl}/api.json`)
     expect(content.custom?.name).toBe("Custom Provider")
   })
+
+  test("refresh uses AGENT_CORE_MODELS_URL alias when Zee URL is unset", async () => {
+    const aliasUrl = "https://alias-catalog.example.invalid"
+    const modelsPath = path.join(process.env.XDG_CACHE_HOME ?? "/tmp", "zee-test-models-url-alias.json")
+    await fs.rm(modelsPath, { force: true }).catch(() => {})
+
+    const originalZeeUrl = process.env.ZEE_MODELS_URL
+    const originalAliasUrl = process.env.AGENT_CORE_MODELS_URL
+
+    let fetchedUrl: string | undefined
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      fetchedUrl = input.toString()
+      return new Response(
+        JSON.stringify({
+          aliascustom: {
+            api: "https://example.invalid",
+            name: "Alias Custom Provider",
+            env: [],
+            id: "aliascustom",
+            models: {},
+          },
+        }),
+        { status: 200 },
+      )
+    }) as typeof fetch
+
+    try {
+      delete process.env.ZEE_MODELS_URL
+      process.env.AGENT_CORE_MODELS_URL = aliasUrl
+      ModelsDev.configure({ path: modelsPath })
+      ModelsDev.Data.reset()
+
+      await ModelsDev.refresh({ timeoutMs: 5000 })
+      const content = JSON.parse(await Bun.file(modelsPath).text()) as Record<string, { name?: string }>
+
+      expect(fetchedUrl).toBe(`${aliasUrl}/api.json`)
+      expect(content.aliascustom?.name).toBe("Alias Custom Provider")
+    } finally {
+      if (originalZeeUrl === undefined) delete process.env.ZEE_MODELS_URL
+      else process.env.ZEE_MODELS_URL = originalZeeUrl
+      if (originalAliasUrl === undefined) delete process.env.AGENT_CORE_MODELS_URL
+      else process.env.AGENT_CORE_MODELS_URL = originalAliasUrl
+      ModelsDev.configure()
+      ModelsDev.Data.reset()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- add compatibility aliases for model catalog config env vars
- allow AGENT_CORE_MODELS_URL as fallback for ZEE_MODELS_URL
- allow AGENT_CORE_MODELS_PATH as fallback for ZEE_MODELS_PATH
- add tests covering alias URL/path behavior

Fixes #219
Fixes #221