### PR TITLE
Add Control UI auth downgrade guardrails and security audits

### DIFF
--- a/docs/architecture/gateway-control-plane.md
+++ b/docs/architecture/gateway-control-plane.md
@@ -44,3 +44,44 @@ The CLI never prints the token unless you pass `--print`:
 zee gateway token --print
 ```
 
+## Control UI Auth Guardrails
+
+Control UI auth defaults should remain strict:
+
+- `gateway.controlUi.auth.required: true`
+- `gateway.controlUi.auth.mode: "token"`
+- `gateway.controlUi.auth.allowPasswordOnly: false`
+- `gateway.controlUi.auth.allowInsecureHttp: false`
+
+Recommended config baseline:
+
+```jsonc
+{
+  "gateway": {
+    "controlUi": {
+      "auth": {
+        "required": true,
+        "mode": "token",
+        "allowPasswordOnly": false,
+        "allowInsecureHttp": false
+      },
+      "trustedOrigins": ["https://control.example.com"]
+    }
+  }
+}
+```
+
+Dangerous downgrade settings (`mode: "none"`, `allowPasswordOnly`, `allowInsecureHttp`) require explicit break-glass acknowledgement:
+
+- config: `gateway.controlUi.auth.breakGlassAck`
+- env: `ZEE_CONTROL_UI_BREAK_GLASS_ACK`
+- required value: `I_UNDERSTAND_CONTROL_UI_AUTH_IS_INSECURE`
+
+Audit commands:
+
+```bash
+zee security audit
+zee doctor security
+```
+
+For non-loopback deployments, terminate TLS at a reverse proxy and keep `trustedOrigins` explicit.

--- a/packages/zee/Swabble/src/config/types.gateway.ts
+++ b/packages/zee/Swabble/src/config/types.gateway.ts
@@ -6,3 +6,22 @@ export type GatewayAuthRateLimitConfig = {
   lockoutMs?: number;
 };
 
+export type GatewayControlUiAuthMode = "token" | "password" | "none";
+
+export type GatewayControlUiAuthConfig = {
+  required?: boolean;
+  mode?: GatewayControlUiAuthMode;
+  allowPasswordOnly?: boolean;
+  allowInsecureHttp?: boolean;
+  breakGlassAck?: string;
+};
+
+export type GatewayControlUiConfig = {
+  auth?: GatewayControlUiAuthConfig;
+  trustedOrigins?: string[];
+};
+
+export type GatewayConfig = {
+  controlUi?: GatewayControlUiConfig;
+  authRateLimit?: GatewayAuthRateLimitConfig;
+};

--- a/packages/zee/src/cli/cmd/debug/index.ts
+++ b/packages/zee/src/cli/cmd/debug/index.ts
@@ -75,6 +75,10 @@ const FlagsCommand = cmd({
       "CLIENT",
       "EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS",
       "EXPERIMENTAL_OUTPUT_TOKEN_MAX",
+      "CONTROL_UI_DISABLE_AUTH",
+      "CONTROL_UI_ALLOW_PASSWORD_ONLY",
+      "CONTROL_UI_ALLOW_INSECURE_HTTP",
+      "CONTROL_UI_BREAK_GLASS_ACK",
     ]
 
     const flags = flagNames.map((name) => {

--- a/packages/zee/src/cli/cmd/doctor.ts
+++ b/packages/zee/src/cli/cmd/doctor.ts
@@ -1,5 +1,7 @@
 import type { Argv } from "yargs"
 import { cmd } from "./cmd"
+import { Config } from "../../config/config"
+import { CONTROL_UI_BREAK_GLASS_ACK, auditControlUiSecurity } from "@/security"
 import {
   type RuntimeProcessLimits,
   resolveRuntimeProcessLimits,
@@ -14,6 +16,11 @@ type DoctorRuntimeArgs = {
   maxMcpTotal?: number
   maxMcpPerServer?: number
   maxClients?: number
+}
+
+type DoctorSecurityArgs = {
+  json?: boolean
+  strict?: boolean
 }
 
 function parseLimits(args: DoctorRuntimeArgs): Partial<RuntimeProcessLimits> {
@@ -114,9 +121,61 @@ const DoctorRuntimeCommand = cmd({
   },
 })
 
+const DoctorSecurityCommand = cmd({
+  command: "security",
+  describe: "audit control-plane security guardrails",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      })
+      .option("strict", {
+        type: "boolean",
+        default: false,
+        describe: "exit with code 1 when security errors are present",
+      }),
+  handler: async (args: DoctorSecurityArgs) => {
+    const config = await Config.get()
+    const report = auditControlUiSecurity(config)
+
+    if (args.json) {
+      console.log(
+        JSON.stringify(
+          {
+            mode: "doctor-security",
+            ...report,
+          },
+          null,
+          2,
+        ),
+      )
+    } else {
+      console.log(`security: errors=${report.errors} warnings=${report.warnings}`)
+      if (report.findings.length === 0) {
+        console.log("security: healthy")
+      } else {
+        console.log("security findings:")
+        for (const finding of report.findings) {
+          console.log(`- [${finding.severity}] ${finding.code}: ${finding.message}`)
+          if (finding.remediation) {
+            console.log(`  remediation: ${finding.remediation}`)
+          }
+        }
+      }
+      console.log(`security: break-glass ack value is ${CONTROL_UI_BREAK_GLASS_ACK}`)
+    }
+
+    if (args.strict && !report.ok) {
+      process.exit(1)
+    }
+  },
+})
+
 export const DoctorCommand = cmd({
   command: "doctor",
   describe: "diagnose and repair runtime issues",
-  builder: (yargs: Argv) => yargs.command(DoctorRuntimeCommand).demandCommand(),
+  builder: (yargs: Argv) => yargs.command(DoctorRuntimeCommand).command(DoctorSecurityCommand).demandCommand(),
   async handler() {},
 })

--- a/packages/zee/src/cli/cmd/security.ts
+++ b/packages/zee/src/cli/cmd/security.ts
@@ -1,0 +1,59 @@
+import type { Argv } from "yargs"
+import { Config } from "../../config/config"
+import { CONTROL_UI_BREAK_GLASS_ACK, auditControlUiSecurity } from "@/security"
+import { cmd } from "./cmd"
+
+type SecurityAuditArgs = {
+  json?: boolean
+  strict?: boolean
+}
+
+const SecurityAuditCommand = cmd({
+  command: "audit",
+  describe: "audit security-sensitive control-plane settings",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      })
+      .option("strict", {
+        type: "boolean",
+        default: false,
+        describe: "exit with code 1 when errors are present",
+      }),
+  handler: async (args: SecurityAuditArgs) => {
+    const config = await Config.get()
+    const report = auditControlUiSecurity(config)
+
+    if (args.json) {
+      console.log(JSON.stringify(report, null, 2))
+    } else {
+      console.log(`security: errors=${report.errors} warnings=${report.warnings}`)
+      if (report.findings.length === 0) {
+        console.log("security: no findings")
+      } else {
+        console.log("security findings:")
+        for (const finding of report.findings) {
+          console.log(`- [${finding.severity}] ${finding.code}: ${finding.message}`)
+          if (finding.remediation) {
+            console.log(`  remediation: ${finding.remediation}`)
+          }
+        }
+      }
+      console.log(`security: break-glass ack value is ${CONTROL_UI_BREAK_GLASS_ACK}`)
+    }
+
+    if (args.strict && !report.ok) {
+      process.exit(1)
+    }
+  },
+})
+
+export const SecurityCommand = cmd({
+  command: "security",
+  describe: "security diagnostics and audits",
+  builder: (yargs: Argv) => yargs.command(SecurityAuditCommand).demandCommand(),
+  async handler() {},
+})

--- a/packages/zee/src/config/config.ts
+++ b/packages/zee/src/config/config.ts
@@ -1095,6 +1095,59 @@ export namespace Config {
       ref: "ServerConfig",
     })
 
+  export const GatewayControlUiAuth = z
+    .object({
+      required: z.boolean().optional().default(true).describe("Require authentication for Control UI endpoints"),
+      mode: z
+        .enum(["token", "password", "none"])
+        .optional()
+        .default("token")
+        .describe("Control UI auth mode; `none` is dangerous break-glass mode"),
+      allowPasswordOnly: z.boolean().optional().default(false).describe("Dangerous: allow password-only Control UI auth"),
+      allowInsecureHttp: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Dangerous: allow Control UI auth over insecure HTTP"),
+      breakGlassAck: z.string().optional().describe("Break-glass acknowledgement string for dangerous auth downgrades"),
+    })
+    .strict()
+    .meta({
+      ref: "GatewayControlUiAuthConfig",
+    })
+
+  export const GatewayControlUi = z
+    .object({
+      auth: GatewayControlUiAuth.optional().describe("Control UI authentication and downgrade guardrails"),
+      trustedOrigins: z
+        .array(z.string())
+        .optional()
+        .describe("Allowlist of trusted browser origins for Control UI"),
+    })
+    .strict()
+    .meta({
+      ref: "GatewayControlUiConfig",
+    })
+
+  export const Gateway = z
+    .object({
+      controlUi: GatewayControlUi.optional().describe("Control UI security settings"),
+      authRateLimit: z
+        .object({
+          enabled: z.boolean().optional(),
+          windowMs: z.number().int().positive().optional(),
+          maxAttemptsPerIp: z.number().int().positive().optional(),
+          maxAttemptsPerToken: z.number().int().positive().optional(),
+          lockoutMs: z.number().int().positive().optional(),
+        })
+        .optional()
+        .describe("Gateway auth rate limiting configuration"),
+    })
+    .passthrough()
+    .meta({
+      ref: "GatewayConfig",
+    })
+
   export const Daemon = z
     .object({
       enabled: z.boolean().optional().default(false).describe("Enable daemon mode"),
@@ -1723,7 +1776,10 @@ export namespace Config {
         })
         .optional()
         .describe("Provider/model fallback configuration for automatic failover"),
-      gateway: z.unknown().optional(),
+      gateway: z
+        .union([Gateway, z.unknown()])
+        .optional()
+        .describe("Gateway configuration including controlUi auth guardrails"),
       channels: z.unknown().optional(),
       bridge: z.unknown().optional(),
       commands: z.unknown().optional(),

--- a/packages/zee/src/flag/flag.ts
+++ b/packages/zee/src/flag/flag.ts
@@ -41,6 +41,11 @@ function computeFlags() {
     ZEE_PTY_ALLOW_COMMAND_OVERRIDE: truthy("ZEE_PTY_ALLOW_COMMAND_OVERRIDE"),
     // Allow switching sessions into ACCEPT/BYPASS modes from messaging surfaces (dangerous).
     ZEE_ALLOW_MESSAGING_RELEASE: truthy("ZEE_ALLOW_MESSAGING_RELEASE"),
+    // Control UI security downgrade flags (break-glass only; dangerous).
+    ZEE_CONTROL_UI_DISABLE_AUTH: truthy("ZEE_CONTROL_UI_DISABLE_AUTH"),
+    ZEE_CONTROL_UI_ALLOW_PASSWORD_ONLY: truthy("ZEE_CONTROL_UI_ALLOW_PASSWORD_ONLY"),
+    ZEE_CONTROL_UI_ALLOW_INSECURE_HTTP: truthy("ZEE_CONTROL_UI_ALLOW_INSECURE_HTTP"),
+    ZEE_CONTROL_UI_BREAK_GLASS_ACK: env("ZEE_CONTROL_UI_BREAK_GLASS_ACK"),
 
     // Server network tuning
     ZEE_SERVER_IDLE_TIMEOUT_SECONDS: number("ZEE_SERVER_IDLE_TIMEOUT_SECONDS"),

--- a/packages/zee/src/index.ts
+++ b/packages/zee/src/index.ts
@@ -36,6 +36,7 @@ import { PackageCommand } from "./cli/cmd/package"
 import { BugReportCommand } from "./cli/cmd/bug-report"
 import { CheckCommand } from "./cli/cmd/check"
 import { DoctorCommand } from "./cli/cmd/doctor"
+import { SecurityCommand } from "./cli/cmd/security"
 import { ProviderCommand } from "./cli/cmd/provider"
 import { ReliabilityCommand } from "./cli/cmd/reliability"
 import { ClientCommand } from "./cli/cmd/client"
@@ -168,6 +169,7 @@ const cli = yargs(hideBin(process.argv))
   .command(RunCommand)
   .command(CheckCommand)
   .command(DoctorCommand)
+  .command(SecurityCommand)
   .command(GenerateCommand)
   .command(DebugCommand)
   .command(PathsCommand)

--- a/packages/zee/src/security/control-ui-audit.ts
+++ b/packages/zee/src/security/control-ui-audit.ts
@@ -1,0 +1,149 @@
+import { Flag } from "@/flag/flag"
+import { isLoopbackHostname } from "@/server/auth"
+
+export const CONTROL_UI_BREAK_GLASS_ACK = "I_UNDERSTAND_CONTROL_UI_AUTH_IS_INSECURE"
+
+export type SecurityAuditSeverity = "error" | "warning"
+
+export type SecurityAuditFinding = {
+  severity: SecurityAuditSeverity
+  code: string
+  message: string
+  remediation?: string
+}
+
+export type SecurityAuditReport = {
+  ok: boolean
+  errors: number
+  warnings: number
+  checked: string[]
+  findings: SecurityAuditFinding[]
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  return value as Record<string, unknown>
+}
+
+function resolveBool(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback
+}
+
+function resolveAuthMode(value: unknown): "token" | "password" | "none" {
+  if (value === "token" || value === "password" || value === "none") return value
+  if (Flag.ZEE_CONTROL_UI_DISABLE_AUTH) return "none"
+  if (Flag.ZEE_CONTROL_UI_ALLOW_PASSWORD_ONLY) return "password"
+  return "token"
+}
+
+function hasBreakGlassAcknowledgement(configValue: unknown): boolean {
+  const configAck = typeof configValue === "string" ? configValue.trim() : ""
+  const envAck = Flag.ZEE_CONTROL_UI_BREAK_GLASS_ACK?.trim() ?? ""
+  const effective = envAck || configAck
+  return effective === CONTROL_UI_BREAK_GLASS_ACK
+}
+
+export function auditControlUiSecurity(config: unknown): SecurityAuditReport {
+  const findings: SecurityAuditFinding[] = []
+  const checked = [
+    "gateway.controlUi.auth.required",
+    "gateway.controlUi.auth.mode",
+    "gateway.controlUi.auth.allowPasswordOnly",
+    "gateway.controlUi.auth.allowInsecureHttp",
+    "gateway.controlUi.auth.breakGlassAck",
+    "gateway.controlUi.trustedOrigins",
+    "server.hostname",
+  ]
+
+  const root = asObject(config) ?? {}
+  const server = asObject(root.server) ?? {}
+  const gateway = asObject(root.gateway) ?? {}
+  const controlUi = asObject(gateway.controlUi) ?? {}
+  const auth = asObject(controlUi.auth) ?? {}
+
+  const hostname = typeof server.hostname === "string" && server.hostname.trim().length > 0 ? server.hostname : "127.0.0.1"
+  const nonLoopbackBind = !isLoopbackHostname(hostname)
+
+  const required = resolveBool(auth.required, !Flag.ZEE_CONTROL_UI_DISABLE_AUTH)
+  const mode = resolveAuthMode(auth.mode)
+  const allowPasswordOnly = resolveBool(auth.allowPasswordOnly, false) || Flag.ZEE_CONTROL_UI_ALLOW_PASSWORD_ONLY
+  const allowInsecureHttp = resolveBool(auth.allowInsecureHttp, false) || Flag.ZEE_CONTROL_UI_ALLOW_INSECURE_HTTP
+  const breakGlassAck = hasBreakGlassAcknowledgement(auth.breakGlassAck)
+
+  const trustedOrigins = Array.isArray(controlUi.trustedOrigins)
+    ? controlUi.trustedOrigins.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    : []
+
+  const authDisabled = required === false || mode === "none"
+  const passwordDowngrade = mode === "password" || allowPasswordOnly
+
+  if (authDisabled) {
+    findings.push({
+      severity: breakGlassAck ? "warning" : "error",
+      code: "control_ui_auth_disabled",
+      message: "Control UI authentication is disabled (`required=false` or `mode=none`).",
+      remediation: breakGlassAck
+        ? "Re-enable auth (`required=true`, `mode=token`) as soon as incident response is complete."
+        : `Set gateway.controlUi.auth.required=true and mode=token. For temporary break-glass only, set breakGlassAck=${CONTROL_UI_BREAK_GLASS_ACK}.`,
+    })
+  }
+
+  if (allowInsecureHttp) {
+    findings.push({
+      severity: breakGlassAck ? "warning" : "error",
+      code: "control_ui_insecure_http_allowed",
+      message: "Control UI is configured to allow insecure HTTP transport.",
+      remediation: breakGlassAck
+        ? "Disable `allowInsecureHttp` after emergency access is no longer needed."
+        : `Set gateway.controlUi.auth.allowInsecureHttp=false and terminate TLS at the reverse proxy. For temporary break-glass only, acknowledge with ${CONTROL_UI_BREAK_GLASS_ACK}.`,
+    })
+  }
+
+  if (passwordDowngrade) {
+    findings.push({
+      severity: breakGlassAck ? "warning" : "warning",
+      code: "control_ui_password_only_mode",
+      message: "Control UI is configured with password-based downgrade mode.",
+      remediation:
+        "Prefer token auth (`mode=token`, `allowPasswordOnly=false`) and rotate credentials after any temporary downgrade.",
+    })
+  }
+
+  if ((authDisabled || allowInsecureHttp || passwordDowngrade) && !breakGlassAck) {
+    findings.push({
+      severity: "error",
+      code: "control_ui_break_glass_ack_missing",
+      message: "Dangerous Control UI auth downgrade is configured without break-glass acknowledgment.",
+      remediation: `Set gateway.controlUi.auth.breakGlassAck or ZEE_CONTROL_UI_BREAK_GLASS_ACK to ${CONTROL_UI_BREAK_GLASS_ACK}, and revert to secure defaults quickly.`,
+    })
+  }
+
+  if (nonLoopbackBind && authDisabled) {
+    findings.push({
+      severity: "error",
+      code: "control_ui_non_loopback_without_auth",
+      message: `Server hostname is non-loopback (${hostname}) while Control UI auth is disabled.`,
+      remediation: "Bind to loopback or re-enable Control UI auth before exposing externally.",
+    })
+  }
+
+  if (nonLoopbackBind && trustedOrigins.length === 0) {
+    findings.push({
+      severity: "warning",
+      code: "control_ui_non_loopback_without_trusted_origins",
+      message: `Server hostname is non-loopback (${hostname}) but gateway.controlUi.trustedOrigins is empty.`,
+      remediation: "Set explicit trusted origins and enforce TLS at the reverse proxy.",
+    })
+  }
+
+  const errors = findings.filter((item) => item.severity === "error").length
+  const warnings = findings.filter((item) => item.severity === "warning").length
+
+  return {
+    ok: errors === 0,
+    errors,
+    warnings,
+    checked,
+    findings,
+  }
+}

--- a/packages/zee/src/security/index.ts
+++ b/packages/zee/src/security/index.ts
@@ -10,6 +10,7 @@
 export * from "./env-sanitize.js"
 export * from "./external-content.js"
 export * from "./http-auth.js"
+export * from "./control-ui-audit.js"
 export * from "./timing-safe.js"
 export * from "./url-policy.js"
 export * from "./validate-path.js"


### PR DESCRIPTION
## Summary
- add explicit `gateway.controlUi.*` auth downgrade guardrail settings in config
- add dangerous break-glass env flags for Control UI auth downgrade handling
- add shared security audit logic for control-plane findings
- add `zee security audit` command and `zee doctor security` checks
- document secure-context requirements and break-glass behavior for Gateway Control UI

## Scope covered for #273
- explicit control-ui downgrade controls and dangerous flags
- security findings in `zee security audit` and `zee doctor security`
- secure-context + reverse-proxy guidance docs and break-glass acknowledgement flow

Fixes #273
