### PR TITLE
Add assistant-mode onboarding profile preset

### DIFF
--- a/docs/architecture/assistant-mode.md
+++ b/docs/architecture/assistant-mode.md
@@ -1,0 +1,45 @@
+# Assistant Mode vs Engine Mode
+
+This document defines the onboarding profile tradeoffs introduced for issue `#272`.
+
+## Onboarding Profile Choice
+
+New users can choose a profile during first-time setup:
+
+```bash
+zee setup --profile assistant
+# or
+zee setup --profile engine
+```
+
+If `--profile` is omitted and no `~/.config/zee/zee.jsonc` exists, `zee setup` prompts for profile selection interactively.
+
+## Profile Intent
+
+- `assistant`: single-user, everyday-channel-first posture with conservative defaults.
+- `engine`: broader multi-domain flexibility for advanced workflows.
+
+## Defaults Applied at Onboarding
+
+Both profiles set secure Control UI defaults:
+
+- `gateway.controlUi.auth.required = true`
+- `gateway.controlUi.auth.mode = "token"`
+- `gateway.controlUi.auth.allowPasswordOnly = false`
+- `gateway.controlUi.auth.allowInsecureHttp = false`
+- `server.hostname = "127.0.0.1"`
+
+Additional assistant-mode defaults:
+
+- `experimental.surfaces.whatsapp.enabled = false`
+- `experimental.surfaces.telegram.enabled = false`
+- `experimental.surfaces.cli.enabled = true`
+- `memory.required = false`
+
+Engine mode intentionally avoids disabling broader surfaces by default.
+
+## Security Expectations
+
+- For non-loopback deployments, use TLS termination at a reverse proxy.
+- Keep trusted origins explicit where Control UI browser access is enabled.
+- Use `zee security audit` and `zee doctor security` to review control-plane guardrails.

--- a/packages/zee/src/cli/cmd/setup.ts
+++ b/packages/zee/src/cli/cmd/setup.ts
@@ -4,12 +4,134 @@ import { Global } from "../../global"
 import path from "path"
 import fs from "fs"
 import { Log } from "../../util/log"
+import * as prompts from "@clack/prompts"
+
+type SetupProfile = "assistant" | "engine"
+
+type SetupArgs = {
+  profile?: SetupProfile
+  "skip-profile"?: boolean
+}
+
+function buildOnboardingProfileConfig(profile: SetupProfile) {
+  const secureControlUiAuth = {
+    required: true,
+    mode: "token",
+    allowPasswordOnly: false,
+    allowInsecureHttp: false,
+  } as const
+
+  if (profile === "assistant") {
+    return {
+      $schema: "zee",
+      profile,
+      server: {
+        hostname: "127.0.0.1",
+      },
+      gateway: {
+        controlUi: {
+          auth: secureControlUiAuth,
+        },
+      },
+      experimental: {
+        surfaces: {
+          cli: { enabled: true },
+          whatsapp: { enabled: false },
+          telegram: { enabled: false },
+        },
+      },
+      memory: {
+        required: false,
+      },
+    }
+  }
+
+  return {
+    $schema: "zee",
+    profile,
+    server: {
+      hostname: "127.0.0.1",
+    },
+    gateway: {
+      controlUi: {
+        auth: secureControlUiAuth,
+      },
+    },
+  }
+}
+
+async function maybeApplyOnboardingProfile(args: SetupArgs): Promise<boolean> {
+  if (args["skip-profile"]) return true
+
+  const configPath = path.join(Global.Path.config, "zee.jsonc")
+  if (fs.existsSync(configPath)) {
+    if (args.profile) {
+      UI.warn(`Config already exists at ${configPath}; keeping existing profile settings.`)
+    } else {
+      UI.info(`Existing config detected at ${configPath}; skipping onboarding profile prompt.`)
+    }
+    return true
+  }
+
+  let profile = args.profile
+  if (!profile) {
+    const selected = await prompts.select({
+      message: "Choose onboarding profile",
+      options: [
+        {
+          value: "assistant",
+          label: "Assistant mode",
+          hint: "single-user defaults, channel-first safety posture",
+        },
+        {
+          value: "engine",
+          label: "Engine mode",
+          hint: "full multi-domain flexibility and advanced workflows",
+        },
+      ],
+      initialValue: "assistant",
+    })
+    if (prompts.isCancel(selected)) {
+      UI.warn("Setup cancelled during onboarding profile selection.")
+      process.exitCode = 1
+      return false
+    }
+    profile = selected as SetupProfile
+  }
+
+  fs.mkdirSync(Global.Path.config, { recursive: true })
+  fs.writeFileSync(configPath, JSON.stringify(buildOnboardingProfileConfig(profile), null, 2) + "\n")
+
+  UI.success(`Onboarding profile '${profile}' written to ${configPath}`)
+  if (profile === "assistant") {
+    UI.info("Assistant mode applied secure single-user defaults and disabled messaging channels by default.")
+  } else {
+    UI.info("Engine mode applied secure defaults while preserving advanced multi-domain flexibility.")
+  }
+  UI.info("Mode tradeoffs: docs/architecture/assistant-mode.md")
+  return true
+}
 
 export const SetupCommand = cmd({
   command: "setup",
-  describe: "prepare the environment (Docker, Qdrant)",
-  async handler() {
+  describe: "prepare onboarding profile and local environment (Docker, Qdrant)",
+  builder: (yargs) =>
+    yargs
+      .option("profile", {
+        type: "string",
+        choices: ["assistant", "engine"],
+        describe: "onboarding profile preset for first-time setup",
+      })
+      .option("skip-profile", {
+        type: "boolean",
+        default: false,
+        describe: "skip onboarding profile prompt/write",
+      }),
+  async handler(args: SetupArgs) {
     UI.header("Zee Setup")
+
+    const onboardingApplied = await maybeApplyOnboardingProfile(args)
+    if (!onboardingApplied) return
 
     // 1. Check Docker
     UI.info("Checking Docker availability...")

--- a/packages/zee/src/config/config.ts
+++ b/packages/zee/src/config/config.ts
@@ -1362,6 +1362,10 @@ export namespace Config {
     .object({
       $schema: z.string().optional().describe("JSON schema reference for configuration validation"),
       theme: z.string().optional().describe("Theme name to use for the interface"),
+      profile: z
+        .enum(["assistant", "engine"])
+        .optional()
+        .describe("Onboarding profile preset (assistant = single-user/channel-first, engine = full flexibility)"),
       keybinds: Keybinds.optional().describe("Custom keybind configurations"),
       logLevel: Log.Level.optional().describe("Log level"),
       wideEvents: z


### PR DESCRIPTION
## Summary
- add explicit onboarding profile selection to `zee setup` (`assistant` vs `engine`)
- persist first-time profile preset into `~/.config/zee/zee.jsonc`
- add secure baseline defaults for both presets (loopback hostname + strict Control UI auth)
- apply assistant-mode defaults for single-user channel-first onboarding
- document tradeoffs in `docs/architecture/assistant-mode.md`

## Acceptance criteria mapping
- New users can choose assistant mode during onboarding: `zee setup` prompts (or accepts `--profile assistant`)
- Assistant mode applies predictable secure defaults: onboarding preset writes strict auth + loopback defaults and conservative surfaces
- Docs describe assistant vs engine tradeoffs: added architecture doc

Fixes #272
