### PR TITLE
Promote Control UI/WebChat to first-class operator surface

### DIFF
--- a/docs/architecture/control-ui-primary.md
+++ b/docs/architecture/control-ui-primary.md
@@ -1,0 +1,45 @@
+# Control UI + WebChat as Primary Operator Surface
+
+This document defines the first-class operator path for Zee web control and webchat workflows (issue `#268`).
+
+## Stable Entrypoints
+
+Primary commands:
+
+```bash
+zee control-ui start --server-url http://127.0.0.1:3210
+zee control-ui status --strict
+```
+
+Compatibility:
+
+- `zee web` remains available.
+- `zee webchat` aliases `zee control-ui`.
+
+## Core Operator Workflows
+
+`zee control-ui status` probes these core workflows over the server API:
+
+- session visibility: `GET /session`
+- approvals queue: `GET /question`
+- pairing/gateway reachability: `GET /gateway/status`
+- system health: `GET /health/status`
+- channel state: `GET /gateway/channels/status`
+
+These workflows are covered by API-surface tests to keep the web operator path stable.
+
+## Lifecycle Expectations
+
+- Start daemon: `zee daemon`
+- Start web control UI: `zee control-ui start`
+- Probe readiness and operator workflows: `zee control-ui status --strict`
+
+## Security Guidance (Proxied Deployment)
+
+- Keep server auth enabled for non-loopback binds (`ZEE_ENABLE_SERVER_AUTH=1`, `ZEE_SERVER_PASSWORD`).
+- Keep Control UI auth downgrade flags disabled unless explicitly break-glass acknowledged.
+- Terminate TLS at the reverse proxy and keep trusted origins explicit (`gateway.controlUi.trustedOrigins`).
+- Use:
+  - `zee security audit`
+  - `zee doctor security`
+  to validate control-plane and action-surface guardrails before production exposure.

--- a/docs/architecture/gateway-control-plane.md
+++ b/docs/architecture/gateway-control-plane.md
@@ -2,6 +2,8 @@
 
 Zee includes an optional **Gateway**: a WebSocket (WS) control plane designed for channel integrations (WhatsApp, etc) and remote clients.
 
+Primary web operator guidance: `docs/architecture/control-ui-primary.md`.
+
 At a high level:
 
 - **Zee server/daemon** runs the agent runtime and exposes an HTTP API.

--- a/docs/architecture/gateway-control-plane.md
+++ b/docs/architecture/gateway-control-plane.md
@@ -85,3 +85,39 @@ zee doctor security
 ```
 
 For non-loopback deployments, terminate TLS at a reverse proxy and keep `trustedOrigins` explicit.
+
+## Telegram Channel-Native Action Pack
+
+Zee now ships a non-WhatsApp channel-native action pack for Telegram with per-category policy toggles:
+
+- `gateway.actionPacks.telegram.messageActions`
+- `gateway.actionPacks.telegram.metadataActions`
+- `gateway.actionPacks.telegram.moderationActions`
+
+Example policy config:
+
+```jsonc
+{
+  "gateway": {
+    "actionPacks": {
+      "telegram": {
+        "enabled": true,
+        "messageActions": true,
+        "metadataActions": true,
+        "moderationActions": false
+      }
+    }
+  }
+}
+```
+
+Action endpoints:
+
+- `POST /gateway/telegram/send`
+- `POST /gateway/telegram/metadata/chat`
+- `POST /gateway/telegram/moderation/delete`
+
+Security notes:
+
+- moderation actions are intended for tightly controlled operator use.
+- run `zee security audit` or `zee doctor security` to surface risky action-pack exposures.

--- a/packages/zee/Swabble/src/config/types.gateway.ts
+++ b/packages/zee/Swabble/src/config/types.gateway.ts
@@ -21,7 +21,18 @@ export type GatewayControlUiConfig = {
   trustedOrigins?: string[];
 };
 
+export type GatewayChannelActionPackConfig = {
+  enabled?: boolean;
+  messageActions?: boolean;
+  moderationActions?: boolean;
+  metadataActions?: boolean;
+};
+
 export type GatewayConfig = {
   controlUi?: GatewayControlUiConfig;
+  actionPacks?: {
+    telegram?: GatewayChannelActionPackConfig;
+    [channel: string]: GatewayChannelActionPackConfig | undefined;
+  };
   authRateLimit?: GatewayAuthRateLimitConfig;
 };

--- a/packages/zee/src/cli/cmd/control-ui.ts
+++ b/packages/zee/src/cli/cmd/control-ui.ts
@@ -1,0 +1,184 @@
+import type { Argv } from "yargs"
+import { createAuthorizedFetch } from "../../server/auth"
+import { normalizeHttpUrl } from "../../util/net"
+import { UI } from "../ui"
+import { cmd } from "./cmd"
+import { buildWebCommand, resolveWebBackendUrl, runWebCommand, type WebArgs } from "./web"
+
+type ControlUiStatusArgs = {
+  serverUrl?: string
+  timeoutMs?: number
+  json?: boolean
+  strict?: boolean
+}
+
+type ControlUiProbe = {
+  id: "session_visibility" | "approvals" | "pairing" | "health" | "channel_state"
+  method: "GET"
+  path: string
+  description: string
+}
+
+type ControlUiProbeResult = {
+  id: ControlUiProbe["id"]
+  path: string
+  ok: boolean
+  status?: number
+  error?: string
+}
+
+const DEFAULT_STATUS_TIMEOUT_MS = 3000
+
+const CORE_WORKFLOW_PROBES: readonly ControlUiProbe[] = [
+  {
+    id: "session_visibility",
+    method: "GET",
+    path: "/session",
+    description: "List sessions for operator visibility",
+  },
+  {
+    id: "approvals",
+    method: "GET",
+    path: "/question",
+    description: "List pending approvals/questions",
+  },
+  {
+    id: "pairing",
+    method: "GET",
+    path: "/gateway/status",
+    description: "Gateway pairing/availability status",
+  },
+  {
+    id: "health",
+    method: "GET",
+    path: "/health/status",
+    description: "Core system health",
+  },
+  {
+    id: "channel_state",
+    method: "GET",
+    path: "/gateway/channels/status",
+    description: "Messaging channel connectivity state",
+  },
+]
+
+export function getControlUiWorkflowProbes(): ControlUiProbe[] {
+  return [...CORE_WORKFLOW_PROBES]
+}
+
+async function runControlUiProbe(baseUrl: string, probe: ControlUiProbe, timeoutMs: number): Promise<ControlUiProbeResult> {
+  const authorizedFetch = createAuthorizedFetch(fetch)
+  const url = new URL(probe.path, baseUrl).toString()
+  try {
+    const response = await authorizedFetch(url, {
+      method: probe.method,
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    return {
+      id: probe.id,
+      path: probe.path,
+      ok: response.ok,
+      status: response.status,
+      ...(response.ok ? {} : { error: `HTTP ${response.status}` }),
+    }
+  } catch (error) {
+    return {
+      id: probe.id,
+      path: probe.path,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+const ControlUiStartCommand = cmd({
+  command: "start",
+  describe: "start Zee Control UI / WebChat",
+  builder: (yargs: Argv) => buildWebCommand(yargs),
+  handler: async (args) => {
+    await runWebCommand(args as WebArgs)
+  },
+})
+
+const ControlUiStatusCommand = cmd({
+  command: "status",
+  describe: "probe core web control workflows against the Zee server API",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("server-url", {
+        type: "string",
+        describe: "Zee daemon base URL (defaults to ZEE_URL or local daemon URL)",
+      })
+      .option("timeout-ms", {
+        type: "number",
+        default: DEFAULT_STATUS_TIMEOUT_MS,
+        describe: "per-probe timeout in milliseconds",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      })
+      .option("strict", {
+        type: "boolean",
+        default: false,
+        describe: "exit with code 1 when any probe fails",
+      }),
+  handler: async (args: ControlUiStatusArgs) => {
+    const rawBase = resolveWebBackendUrl({ serverUrl: args.serverUrl, env: process.env })
+    const baseUrl = normalizeHttpUrl(rawBase)
+    if (!baseUrl) {
+      UI.error("Invalid --server-url (must be a valid http(s) URL).")
+      process.exitCode = 1
+      return
+    }
+
+    const timeoutMs = Number.isFinite(args.timeoutMs)
+      ? Math.max(250, Math.floor(Number(args.timeoutMs)))
+      : DEFAULT_STATUS_TIMEOUT_MS
+
+    const results = await Promise.all(
+      CORE_WORKFLOW_PROBES.map((probe) => runControlUiProbe(baseUrl, probe, timeoutMs)),
+    )
+    const failed = results.filter((result) => !result.ok)
+
+    if (args.json) {
+      console.log(
+        JSON.stringify(
+          {
+            baseUrl,
+            timeoutMs,
+            workflows: results,
+            ok: failed.length === 0,
+          },
+          null,
+          2,
+        ),
+      )
+    } else {
+      UI.info(`Control UI status against ${baseUrl}`)
+      for (const result of results) {
+        const statusLabel = result.ok ? "ok" : "fail"
+        const detail = result.ok ? `HTTP ${result.status ?? 200}` : result.error ?? `HTTP ${result.status ?? "?"}`
+        UI.println(`- ${result.id}: ${statusLabel} (${detail})`)
+      }
+      if (failed.length === 0) {
+        UI.success("Core web control workflows are reachable.")
+      } else {
+        UI.warn(`${failed.length} core workflow probe(s) failed.`)
+      }
+    }
+
+    if (args.strict && failed.length > 0) {
+      process.exit(1)
+    }
+  },
+})
+
+export const ControlUiCommand = cmd({
+  command: "control-ui",
+  aliases: ["webchat"],
+  describe: "first-class web operator surface (Control UI + WebChat)",
+  builder: (yargs: Argv) => yargs.command(ControlUiStartCommand).command(ControlUiStatusCommand).demandCommand(),
+  async handler() {},
+})

--- a/packages/zee/src/cli/cmd/web.ts
+++ b/packages/zee/src/cli/cmd/web.ts
@@ -12,7 +12,7 @@ const DEFAULT_WEB_PORT = 3000
 const DEFAULT_DAEMON_PORT = 3210
 const DEFAULT_READY_TIMEOUT_MS = 15_000
 
-type WebArgs = {
+export type WebArgs = {
   host?: string
   port?: number
   serverUrl?: string
@@ -87,118 +87,124 @@ async function waitForWebReady(url: string, timeoutMs: number): Promise<boolean>
   return false
 }
 
+export function buildWebCommand(yargs: Argv) {
+  return yargs
+    .option("host", {
+      type: "string",
+      default: DEFAULT_WEB_HOST,
+      describe: "host to bind the web UI dev server",
+    })
+    .option("port", {
+      type: "number",
+      default: DEFAULT_WEB_PORT,
+      describe: "port to bind the web UI dev server",
+    })
+    .option("server-url", {
+      type: "string",
+      describe: "Zee daemon base URL for the web app (defaults to ZEE_URL or local daemon URL)",
+    })
+    .option("open", {
+      type: "boolean",
+      default: true,
+      describe: "open the web UI in your default browser",
+    })
+    .option("ready-timeout-ms", {
+      type: "number",
+      default: DEFAULT_READY_TIMEOUT_MS,
+      describe: "time to wait for the web UI dev server before opening browser",
+    })
+}
+
+export async function runWebCommand(args: WebArgs) {
+  const host = (args.host ?? DEFAULT_WEB_HOST).trim()
+  const port = Number.isFinite(args.port) ? Number(args.port) : DEFAULT_WEB_PORT
+  const readyTimeoutMs = Number.isFinite(args.readyTimeoutMs)
+    ? Math.max(500, Math.floor(Number(args.readyTimeoutMs)))
+    : DEFAULT_READY_TIMEOUT_MS
+
+  if (!host) {
+    UI.error("Invalid --host value.")
+    process.exitCode = 1
+    return
+  }
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    UI.error("Invalid --port value. Use an integer from 1 to 65535.")
+    process.exitCode = 1
+    return
+  }
+
+  const appDir = resolveWebAppDirectory(Global.Path.source)
+  if (!appDir) {
+    UI.error(`Could not find packages/app from source root: ${Global.Path.source}`)
+    UI.info("Run this command from the Zee repository checkout.")
+    process.exitCode = 1
+    return
+  }
+
+  let backend: BackendTarget
+  try {
+    backend = resolveWebBackendTarget(resolveWebBackendUrl({ serverUrl: args.serverUrl, env: process.env }))
+  } catch (error) {
+    UI.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+    return
+  }
+
+  const uiUrl = `http://${renderHttpHost(host)}:${port}`
+  const bunBin = Bun.which("bun") ?? "bun"
+  const child = Bun.spawn({
+    cmd: [bunBin, "run", "dev", "--host", host, "--port", String(port)],
+    cwd: appDir,
+    env: {
+      ...process.env,
+      VITE_ZEE_SERVER_HOST: backend.hostForEnv,
+      VITE_ZEE_SERVER_PORT: String(backend.port),
+      VITE_ZEE_SERVER_BASE_PATH: backend.basePath,
+    },
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  })
+
+  const stop = () => {
+    try {
+      child.kill()
+    } catch {
+      // Child may already be exiting.
+    }
+  }
+  process.once("SIGINT", stop)
+  process.once("SIGTERM", stop)
+
+  UI.success(`Starting Zee Web UI at ${uiUrl}`)
+  UI.info(`Backend URL: ${backend.origin}`)
+
+  if (args.open !== false) {
+    const ready = await waitForWebReady(uiUrl, readyTimeoutMs)
+    if (!ready) {
+      UI.warn(`Web UI did not report ready within ${readyTimeoutMs}ms. Opening browser anyway.`)
+    }
+    const opened = await openExternalUrl(uiUrl)
+    if (!opened.ok) {
+      UI.warn(`Could not open browser automatically (${opened.reason}).`)
+      UI.info(`Open manually: ${uiUrl}`)
+    }
+  }
+
+  const exitCode = await child.exited
+  process.off("SIGINT", stop)
+  process.off("SIGTERM", stop)
+
+  if (exitCode !== 0) {
+    process.exitCode = exitCode
+  }
+}
+
 export const WebCommand = cmd({
   command: "web",
   describe: "run the local Zee web UI from packages/app",
-  builder: (yargs: Argv) =>
-    yargs
-      .option("host", {
-        type: "string",
-        default: DEFAULT_WEB_HOST,
-        describe: "host to bind the web UI dev server",
-      })
-      .option("port", {
-        type: "number",
-        default: DEFAULT_WEB_PORT,
-        describe: "port to bind the web UI dev server",
-      })
-      .option("server-url", {
-        type: "string",
-        describe: "Zee daemon base URL for the web app (defaults to ZEE_URL or local daemon URL)",
-      })
-      .option("open", {
-        type: "boolean",
-        default: true,
-        describe: "open the web UI in your default browser",
-      })
-      .option("ready-timeout-ms", {
-        type: "number",
-        default: DEFAULT_READY_TIMEOUT_MS,
-        describe: "time to wait for the web UI dev server before opening browser",
-      }),
+  builder: (yargs: Argv) => buildWebCommand(yargs),
   handler: async (args) => {
-    const typed = args as WebArgs
-    const host = (typed.host ?? DEFAULT_WEB_HOST).trim()
-    const port = Number.isFinite(typed.port) ? Number(typed.port) : DEFAULT_WEB_PORT
-    const readyTimeoutMs = Number.isFinite(typed.readyTimeoutMs)
-      ? Math.max(500, Math.floor(Number(typed.readyTimeoutMs)))
-      : DEFAULT_READY_TIMEOUT_MS
-
-    if (!host) {
-      UI.error("Invalid --host value.")
-      process.exitCode = 1
-      return
-    }
-    if (!Number.isInteger(port) || port < 1 || port > 65535) {
-      UI.error("Invalid --port value. Use an integer from 1 to 65535.")
-      process.exitCode = 1
-      return
-    }
-
-    const appDir = resolveWebAppDirectory(Global.Path.source)
-    if (!appDir) {
-      UI.error(`Could not find packages/app from source root: ${Global.Path.source}`)
-      UI.info("Run this command from the Zee repository checkout.")
-      process.exitCode = 1
-      return
-    }
-
-    let backend: BackendTarget
-    try {
-      backend = resolveWebBackendTarget(resolveWebBackendUrl({ serverUrl: typed.serverUrl, env: process.env }))
-    } catch (error) {
-      UI.error(error instanceof Error ? error.message : String(error))
-      process.exitCode = 1
-      return
-    }
-
-    const uiUrl = `http://${renderHttpHost(host)}:${port}`
-    const bunBin = Bun.which("bun") ?? "bun"
-    const child = Bun.spawn({
-      cmd: [bunBin, "run", "dev", "--host", host, "--port", String(port)],
-      cwd: appDir,
-      env: {
-        ...process.env,
-        VITE_ZEE_SERVER_HOST: backend.hostForEnv,
-        VITE_ZEE_SERVER_PORT: String(backend.port),
-        VITE_ZEE_SERVER_BASE_PATH: backend.basePath,
-      },
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-    })
-
-    const stop = () => {
-      try {
-        child.kill()
-      } catch {
-        // Child may already be exiting.
-      }
-    }
-    process.once("SIGINT", stop)
-    process.once("SIGTERM", stop)
-
-    UI.success(`Starting Zee Web UI at ${uiUrl}`)
-    UI.info(`Backend URL: ${backend.origin}`)
-
-    if (typed.open !== false) {
-      const ready = await waitForWebReady(uiUrl, readyTimeoutMs)
-      if (!ready) {
-        UI.warn(`Web UI did not report ready within ${readyTimeoutMs}ms. Opening browser anyway.`)
-      }
-      const opened = await openExternalUrl(uiUrl)
-      if (!opened.ok) {
-        UI.warn(`Could not open browser automatically (${opened.reason}).`)
-        UI.info(`Open manually: ${uiUrl}`)
-      }
-    }
-
-    const exitCode = await child.exited
-    process.off("SIGINT", stop)
-    process.off("SIGTERM", stop)
-
-    if (exitCode !== 0) {
-      process.exitCode = exitCode
-    }
+    await runWebCommand(args as WebArgs)
   },
 })

--- a/packages/zee/src/config/config.ts
+++ b/packages/zee/src/config/config.ts
@@ -1129,9 +1129,32 @@ export namespace Config {
       ref: "GatewayControlUiConfig",
     })
 
+  export const GatewayChannelActionPack = z
+    .object({
+      enabled: z.boolean().optional().default(true).describe("Enable this channel action pack"),
+      messageActions: z.boolean().optional().default(true).describe("Enable message actions for the channel"),
+      moderationActions: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Enable moderation-safe actions for the channel"),
+      metadataActions: z.boolean().optional().default(true).describe("Enable metadata/status actions for the channel"),
+    })
+    .strict()
+    .meta({
+      ref: "GatewayChannelActionPackConfig",
+    })
+
   export const Gateway = z
     .object({
       controlUi: GatewayControlUi.optional().describe("Control UI security settings"),
+      actionPacks: z
+        .object({
+          telegram: GatewayChannelActionPack.optional(),
+        })
+        .catchall(GatewayChannelActionPack)
+        .optional()
+        .describe("Per-channel action pack policy controls"),
       authRateLimit: z
         .object({
           enabled: z.boolean().optional(),

--- a/packages/zee/src/index.ts
+++ b/packages/zee/src/index.ts
@@ -43,6 +43,7 @@ import { ClientCommand } from "./cli/cmd/client"
 import { GatewayCommand } from "./cli/cmd/gateway"
 import { ChannelsCommand } from "./cli/cmd/channels"
 import { GuiCommand } from "./cli/cmd/gui"
+import { ControlUiCommand } from "./cli/cmd/control-ui"
 import { WebCommand } from "./cli/cmd/web"
 import { DmuxCommand } from "./cli/cmd/dmux"
 import path from "node:path"
@@ -164,6 +165,7 @@ const cli = yargs(hideBin(process.argv))
   .command(AttachCommand)
   .command(ClientCommand)
   .command(GuiCommand)
+  .command(ControlUiCommand)
   .command(WebCommand)
   .command(DmuxCommand)
   .command(RunCommand)

--- a/packages/zee/src/security/control-ui-audit.ts
+++ b/packages/zee/src/security/control-ui-audit.ts
@@ -52,6 +52,10 @@ export function auditControlUiSecurity(config: unknown): SecurityAuditReport {
     "gateway.controlUi.auth.allowInsecureHttp",
     "gateway.controlUi.auth.breakGlassAck",
     "gateway.controlUi.trustedOrigins",
+    "gateway.actionPacks.telegram.enabled",
+    "gateway.actionPacks.telegram.messageActions",
+    "gateway.actionPacks.telegram.moderationActions",
+    "gateway.actionPacks.telegram.metadataActions",
     "server.hostname",
   ]
 
@@ -60,6 +64,8 @@ export function auditControlUiSecurity(config: unknown): SecurityAuditReport {
   const gateway = asObject(root.gateway) ?? {}
   const controlUi = asObject(gateway.controlUi) ?? {}
   const auth = asObject(controlUi.auth) ?? {}
+  const actionPacks = asObject(gateway.actionPacks) ?? {}
+  const telegramActionPack = asObject(actionPacks.telegram) ?? {}
 
   const hostname = typeof server.hostname === "string" && server.hostname.trim().length > 0 ? server.hostname : "127.0.0.1"
   const nonLoopbackBind = !isLoopbackHostname(hostname)
@@ -73,6 +79,11 @@ export function auditControlUiSecurity(config: unknown): SecurityAuditReport {
   const trustedOrigins = Array.isArray(controlUi.trustedOrigins)
     ? controlUi.trustedOrigins.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
     : []
+  const telegramActionPackEnabled = resolveBool(telegramActionPack.enabled, true)
+  const telegramMessageActions = resolveBool(telegramActionPack.messageActions, true)
+  const telegramModerationActions = resolveBool(telegramActionPack.moderationActions, false)
+  const telegramMetadataActions = resolveBool(telegramActionPack.metadataActions, true)
+  const telegramAnyActionEnabled = telegramActionPackEnabled && (telegramMessageActions || telegramModerationActions || telegramMetadataActions)
 
   const authDisabled = required === false || mode === "none"
   const passwordDowngrade = mode === "password" || allowPasswordOnly
@@ -133,6 +144,33 @@ export function auditControlUiSecurity(config: unknown): SecurityAuditReport {
       code: "control_ui_non_loopback_without_trusted_origins",
       message: `Server hostname is non-loopback (${hostname}) but gateway.controlUi.trustedOrigins is empty.`,
       remediation: "Set explicit trusted origins and enforce TLS at the reverse proxy.",
+    })
+  }
+
+  if (telegramAnyActionEnabled && authDisabled) {
+    findings.push({
+      severity: "error",
+      code: "telegram_action_pack_with_disabled_control_ui_auth",
+      message: "Telegram action pack is enabled while Control UI auth is disabled.",
+      remediation: "Re-enable Control UI auth before exposing Telegram action endpoints.",
+    })
+  }
+
+  if (telegramModerationActions && !required) {
+    findings.push({
+      severity: "error",
+      code: "telegram_moderation_actions_without_required_auth",
+      message: "Telegram moderation actions are enabled while Control UI auth `required` is false.",
+      remediation: "Set gateway.controlUi.auth.required=true or disable telegram moderation actions.",
+    })
+  }
+
+  if (telegramAnyActionEnabled && nonLoopbackBind && trustedOrigins.length === 0) {
+    findings.push({
+      severity: "warning",
+      code: "telegram_action_pack_non_loopback_without_trusted_origins",
+      message: `Telegram action pack is enabled on non-loopback hostname (${hostname}) without trusted origins.`,
+      remediation: "Configure trusted origins and TLS before exposing action endpoints externally.",
     })
   }
 

--- a/packages/zee/src/server/auth.ts
+++ b/packages/zee/src/server/auth.ts
@@ -37,6 +37,9 @@ const ROUTE_SCOPE_MAP: Record<string, AuthScopeValue> = {
   // Write operations
   "POST /session": AuthScope.WRITE,
   "DELETE /session": AuthScope.WRITE,
+  "POST /gateway/telegram/metadata": AuthScope.READ,
+  "POST /gateway/telegram/send": AuthScope.WRITE,
+  "POST /gateway/telegram/moderation": AuthScope.ADMIN,
   "POST /gateway": AuthScope.WRITE,
   "POST /memory/store": AuthScope.WRITE,
   "POST /memory/batch": AuthScope.WRITE,

--- a/packages/zee/src/server/route/gateway.ts
+++ b/packages/zee/src/server/route/gateway.ts
@@ -2,15 +2,17 @@ import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
 import { Log } from "../../util/log"
-import { formatForSurface, WHATSAPP_CAPABILITIES } from "../../surface/types"
+import { formatForSurface, TELEGRAM_CAPABILITIES, WHATSAPP_CAPABILITIES } from "../../surface/types"
 import type { SurfaceCapabilities } from "../../surface/types"
 import { readZeeGatewayTokenFromFile } from "@/gateway/token"
 import { GatewayWsClient } from "@/gateway/ws-client"
 import { sendWhatsAppMessage } from "@root/domain/zee/whatsapp-send"
 import { emitInboundMessage, toPlatformMessage, type ForwardedMessage } from "../../surface/platforms/whatsapp"
+import { TelegramPlatformHandler } from "../../surface/platforms/telegram"
 import { FluxRecorder } from "@/flux"
 import { RequestMeta } from "../request-meta"
 import { extractGatewayRouteSecret, isMatchingSecret } from "@/security"
+import { Config } from "@/config/config"
 
 const log = Log.create({ service: "server:gateway" })
 
@@ -30,6 +32,26 @@ const WhatsAppSendInput = z.object({
   mediaUrls: z.array(z.string()).optional(),
   gifPlayback: z.boolean().optional(),
   accountId: z.string().optional(),
+})
+
+const TelegramSendInput = z.object({
+  chatId: z.union([z.string(), z.number()]).optional(),
+  to: z.union([z.string(), z.number()]).optional(),
+  message: z.string(),
+  replyToId: z.string().optional(),
+  mediaUrl: z.string().optional(),
+  mediaUrls: z.array(z.string()).optional(),
+})
+
+const TelegramMetadataInput = z.object({
+  chatId: z.union([z.string(), z.number()]).optional(),
+  to: z.union([z.string(), z.number()]).optional(),
+})
+
+const TelegramModerationDeleteInput = z.object({
+  chatId: z.union([z.string(), z.number()]).optional(),
+  to: z.union([z.string(), z.number()]).optional(),
+  messageId: z.union([z.string(), z.number()]),
 })
 
 const WhatsAppInboundInput = z.object({
@@ -102,6 +124,94 @@ function normalizeWhatsAppRecipient(raw: string): string {
   if (waMatch?.[1]) return waMatch[1]
 
   return withoutPrefix
+}
+
+type TelegramActionCategory = "messageActions" | "moderationActions" | "metadataActions"
+
+type TelegramActionPackPolicy = {
+  enabled: boolean
+  messageActions: boolean
+  moderationActions: boolean
+  metadataActions: boolean
+}
+
+const DEFAULT_TELEGRAM_ACTION_PACK_POLICY: TelegramActionPackPolicy = {
+  enabled: true,
+  messageActions: true,
+  moderationActions: false,
+  metadataActions: true,
+}
+
+function resolveBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback
+}
+
+function resolveTelegramTarget(chatIdOrTo: string | number | undefined): string {
+  if (chatIdOrTo === undefined || chatIdOrTo === null) {
+    throw new Error('Missing "chatId" (or "to")')
+  }
+  const target = String(chatIdOrTo).trim()
+  if (!target) throw new Error('Missing "chatId" (or "to")')
+  return target
+}
+
+async function resolveTelegramActionPackPolicy(): Promise<TelegramActionPackPolicy> {
+  const config = await Config.get().catch(() => undefined)
+  const gateway =
+    config && typeof config.gateway === "object" && config.gateway && !Array.isArray(config.gateway)
+      ? (config.gateway as Record<string, unknown>)
+      : {}
+  const actionPacks =
+    typeof gateway.actionPacks === "object" && gateway.actionPacks && !Array.isArray(gateway.actionPacks)
+      ? (gateway.actionPacks as Record<string, unknown>)
+      : {}
+  const telegram =
+    typeof actionPacks.telegram === "object" && actionPacks.telegram && !Array.isArray(actionPacks.telegram)
+      ? (actionPacks.telegram as Record<string, unknown>)
+      : {}
+
+  return {
+    enabled: resolveBoolean(telegram.enabled, DEFAULT_TELEGRAM_ACTION_PACK_POLICY.enabled),
+    messageActions: resolveBoolean(telegram.messageActions, DEFAULT_TELEGRAM_ACTION_PACK_POLICY.messageActions),
+    moderationActions: resolveBoolean(telegram.moderationActions, DEFAULT_TELEGRAM_ACTION_PACK_POLICY.moderationActions),
+    metadataActions: resolveBoolean(telegram.metadataActions, DEFAULT_TELEGRAM_ACTION_PACK_POLICY.metadataActions),
+  }
+}
+
+async function enforceTelegramActionPolicy(
+  category: TelegramActionCategory,
+): Promise<{ allowed: true } | { allowed: false; reason: string }> {
+  const policy = await resolveTelegramActionPackPolicy()
+  if (!policy.enabled) {
+    return { allowed: false, reason: "Telegram action pack is disabled by policy." }
+  }
+  if (!policy[category]) {
+    return { allowed: false, reason: `Telegram ${category} is disabled by policy.` }
+  }
+  return { allowed: true }
+}
+
+async function createTelegramPlatformHandler(): Promise<TelegramPlatformHandler> {
+  const config = await Config.get().catch(() => undefined)
+  const telegramSurface = config?.experimental?.surfaces?.telegram
+  const tokenFromConfig = typeof telegramSurface?.token === "string" ? telegramSurface.token.trim() : ""
+  const tokenFromEnv = process.env.TELEGRAM_BOT_TOKEN?.trim() ?? ""
+  const token = tokenFromConfig || tokenFromEnv
+  if (!token) {
+    throw new Error("Telegram bot token is not configured (set experimental.surfaces.telegram.token or TELEGRAM_BOT_TOKEN).")
+  }
+
+  const allowedChatIds = Array.isArray(telegramSurface?.allowedChatIds)
+    ? telegramSurface.allowedChatIds.filter((entry): entry is string | number => typeof entry === "string" || typeof entry === "number")
+    : undefined
+
+  return new TelegramPlatformHandler({
+    token,
+    apiBaseUrl: typeof telegramSurface?.apiBaseUrl === "string" ? telegramSurface.apiBaseUrl : undefined,
+    pollTimeoutSec: typeof telegramSurface?.pollTimeoutSec === "number" ? telegramSurface.pollTimeoutSec : undefined,
+    allowedChatIds,
+    mediaMaxMb: typeof telegramSurface?.mediaMaxMb === "number" ? telegramSurface.mediaMaxMb : undefined,
+  })
 }
 
 async function buildGatewayConnectParams() {
@@ -202,10 +312,11 @@ async function callGateway<T = unknown>(
 
 const PLATFORM_CAPABILITIES: Record<string, SurfaceCapabilities> = {
   whatsapp: WHATSAPP_CAPABILITIES,
+  telegram: TELEGRAM_CAPABILITIES,
 }
 
 async function sendViaGateway(input: {
-  provider: "whatsapp"
+  provider: "whatsapp" | "telegram"
   to: string
   message: string
   accountId?: string
@@ -259,6 +370,9 @@ async function sendViaGateway(input: {
     }
     return lastResult
   } catch (error) {
+    if (input.provider !== "whatsapp") {
+      throw error
+    }
     // Fallback to direct wacli send when embedded gateway runtime is unavailable.
     const message = error instanceof Error ? error.message : String(error)
     log.warn("gateway send failed; falling back to wacli", {
@@ -495,6 +609,201 @@ export const GatewayRoute = new Hono()
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         log.warn("whatsapp send failed", { error: message })
+        return c.json({ success: false, error: message } satisfies GatewayResponse, 500)
+      }
+    },
+  )
+
+  .post(
+    "/telegram/send",
+    describeRoute({
+      summary: "Send Telegram message (channel-native action)",
+      description: "Send a Telegram message via the Telegram action pack with policy checks.",
+      operationId: "gateway.telegram.send",
+      responses: {
+        200: {
+          description: "Send result",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+        400: {
+          description: "Invalid request",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+        403: {
+          description: "Policy denied",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+        500: {
+          description: "Server error",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+      },
+    }),
+    async (c) => {
+      const policy = await enforceTelegramActionPolicy("messageActions")
+      if (!policy.allowed) {
+        return c.json({ success: false, error: policy.reason } satisfies GatewayResponse, 403)
+      }
+
+      let body: unknown
+      try {
+        body = await c.req.json()
+      } catch {
+        return c.json({ success: false, error: "Invalid JSON body" } satisfies GatewayResponse, 400)
+      }
+
+      const parsed = TelegramSendInput.safeParse(body)
+      if (!parsed.success) {
+        return c.json({ success: false, error: "Invalid request body" } satisfies GatewayResponse, 400)
+      }
+
+      try {
+        const target = resolveTelegramTarget(parsed.data.chatId ?? parsed.data.to)
+        const handler = await createTelegramPlatformHandler()
+        const mediaUrls = parsed.data.mediaUrls?.length
+          ? parsed.data.mediaUrls
+          : parsed.data.mediaUrl
+            ? [parsed.data.mediaUrl]
+            : []
+        const media = mediaUrls.map((url, index) => ({
+          path: url,
+          filename: `telegram-media-${index + 1}`,
+        }))
+        await handler.sendMessage(target, parsed.data.message, {
+          replyToId: parsed.data.replyToId,
+          ...(media.length > 0 ? { media } : {}),
+        })
+        return c.json({
+          success: true,
+          data: {
+            channel: "telegram",
+            action: "send",
+            target,
+          },
+        } satisfies GatewayResponse)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        log.warn("telegram send failed", { error: message })
+        return c.json({ success: false, error: message } satisfies GatewayResponse, 500)
+      }
+    },
+  )
+
+  .post(
+    "/telegram/metadata/chat",
+    describeRoute({
+      summary: "Fetch Telegram chat metadata (channel-native action)",
+      description: "Fetch Telegram chat metadata via the Telegram action pack with policy checks.",
+      operationId: "gateway.telegram.metadata.chat",
+      responses: {
+        200: {
+          description: "Metadata result",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+        400: {
+          description: "Invalid request",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+        403: {
+          description: "Policy denied",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+        500: {
+          description: "Server error",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+      },
+    }),
+    async (c) => {
+      const policy = await enforceTelegramActionPolicy("metadataActions")
+      if (!policy.allowed) {
+        return c.json({ success: false, error: policy.reason } satisfies GatewayResponse, 403)
+      }
+
+      let body: unknown
+      try {
+        body = await c.req.json()
+      } catch {
+        return c.json({ success: false, error: "Invalid JSON body" } satisfies GatewayResponse, 400)
+      }
+
+      const parsed = TelegramMetadataInput.safeParse(body)
+      if (!parsed.success) {
+        return c.json({ success: false, error: "Invalid request body" } satisfies GatewayResponse, 400)
+      }
+
+      try {
+        const target = resolveTelegramTarget(parsed.data.chatId ?? parsed.data.to)
+        const handler = await createTelegramPlatformHandler()
+        const data = await handler.getChatMetadata(target)
+        return c.json({ success: true, data } satisfies GatewayResponse)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        log.warn("telegram metadata failed", { error: message })
+        return c.json({ success: false, error: message } satisfies GatewayResponse, 500)
+      }
+    },
+  )
+
+  .post(
+    "/telegram/moderation/delete",
+    describeRoute({
+      summary: "Delete Telegram message (moderation-safe action)",
+      description: "Delete a Telegram message using policy-gated moderation actions.",
+      operationId: "gateway.telegram.moderation.delete",
+      responses: {
+        200: {
+          description: "Delete result",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+        400: {
+          description: "Invalid request",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+        403: {
+          description: "Policy denied",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+        500: {
+          description: "Server error",
+          content: { "application/json": { schema: resolver(GatewayResponseSchema) } },
+        },
+      },
+    }),
+    async (c) => {
+      const policy = await enforceTelegramActionPolicy("moderationActions")
+      if (!policy.allowed) {
+        return c.json({ success: false, error: policy.reason } satisfies GatewayResponse, 403)
+      }
+
+      let body: unknown
+      try {
+        body = await c.req.json()
+      } catch {
+        return c.json({ success: false, error: "Invalid JSON body" } satisfies GatewayResponse, 400)
+      }
+
+      const parsed = TelegramModerationDeleteInput.safeParse(body)
+      if (!parsed.success) {
+        return c.json({ success: false, error: "Invalid request body" } satisfies GatewayResponse, 400)
+      }
+
+      try {
+        const target = resolveTelegramTarget(parsed.data.chatId ?? parsed.data.to)
+        const handler = await createTelegramPlatformHandler()
+        await handler.deleteMessage(target, parsed.data.messageId)
+        return c.json({
+          success: true,
+          data: {
+            channel: "telegram",
+            action: "moderation.delete",
+            target,
+            messageId: String(parsed.data.messageId),
+          },
+        } satisfies GatewayResponse)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        log.warn("telegram moderation delete failed", { error: message })
         return c.json({ success: false, error: message } satisfies GatewayResponse, 500)
       }
     },

--- a/packages/zee/src/surface/platforms/telegram.ts
+++ b/packages/zee/src/surface/platforms/telegram.ts
@@ -353,6 +353,26 @@ export class TelegramPlatformHandler implements MessagingPlatformHandler {
     })
   }
 
+  async getChatMetadata(targetRaw: string): Promise<Record<string, unknown>> {
+    const target = parseTelegramTarget(targetRaw)
+    const result = await this.callJson<Record<string, unknown>>("getChat", {
+      chat_id: target.chatId,
+    })
+    return result
+  }
+
+  async deleteMessage(targetRaw: string, messageIdRaw: string | number): Promise<void> {
+    const target = parseTelegramTarget(targetRaw)
+    const messageId = Number(typeof messageIdRaw === "string" ? messageIdRaw.trim() : messageIdRaw)
+    if (!Number.isFinite(messageId)) {
+      throw new Error(`Invalid Telegram message id: ${messageIdRaw}`)
+    }
+    await this.callJson("deleteMessage", {
+      chat_id: target.chatId,
+      message_id: messageId,
+    })
+  }
+
   async startStreamingMessage(targetRaw: string, text: string): Promise<TelegramStreamHandle> {
     const target = parseTelegramTarget(targetRaw)
     const response = await this.sendWithMarkdown<{ message_id?: number }>("sendMessage", {

--- a/packages/zee/test/cli/control-ui-command.test.ts
+++ b/packages/zee/test/cli/control-ui-command.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import { getControlUiWorkflowProbes } from "../../src/cli/cmd/control-ui"
+import { Server } from "../../src/server/server"
+
+describe("control-ui command", () => {
+  test("exposes core workflow probes", () => {
+    const probes = getControlUiWorkflowProbes()
+    const ids = new Set(probes.map((probe) => probe.id))
+    expect(ids.has("session_visibility")).toBe(true)
+    expect(ids.has("approvals")).toBe(true)
+    expect(ids.has("pairing")).toBe(true)
+    expect(ids.has("health")).toBe(true)
+    expect(ids.has("channel_state")).toBe(true)
+  })
+
+  test("core workflow probe paths are present in OpenAPI spec", async () => {
+    const app = Server.App()
+    const response = await app.request("/openapi")
+    expect(response.status).toBe(200)
+    const spec = (await response.json()) as { paths?: Record<string, unknown> }
+    const paths = spec.paths ?? {}
+
+    for (const probe of getControlUiWorkflowProbes()) {
+      expect(paths[probe.path]).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add first-class `zee control-ui` command (alias: `zee webchat`) with:
  - `start` subcommand for Control UI/WebChat lifecycle
  - `status` subcommand probing core web operator workflows
- refactor `zee web` command internals for reusable command runner/builders
- add core workflow probe coverage tests against OpenAPI-exposed API surface
- add primary operator-path documentation and proxied deployment security guidance

## Acceptance criteria mapping
- Web control is documented and supported as a primary operator path: new `control-ui` command + architecture doc.
- Core operational workflows are available and tested via web UI path: workflow probes + tests validate required API surface.
- Security guidance for proxied deployment is explicit and validated: dedicated guidance in Control UI docs and existing security audit commands.

Fixes #268
