### PR TITLE
Complete OpenClaw lane artifacts for 02/03/08/09/10/11

### DIFF
--- a/docs/architecture/openclaw-delta-map.md
+++ b/docs/architecture/openclaw-delta-map.md
@@ -108,6 +108,8 @@ Unmapped commits / PR unknown (selected examples from #224):
 
 ## Lane 02: WhatsApp channel (linking, inbound, outbound, allowlists, heartbeat)
 
+Lane artifact: `docs/architecture/openclaw-lanes/lane-02-whatsapp-channel.md`.
+
 Implementation focus (Zee):
 
 - `packages/zee/Swabble/src/whatsapp`
@@ -128,6 +130,8 @@ Upstream PR triage (OpenClaw):
 | openclaw/openclaw#8415 | docs/feature | non-goal | iMessage/BlueBubbles scope is out for Zee today. | None |
 
 ## Lane 03: Removed channel lane (legacy messaging extensions removed from Zee)
+
+Lane artifact: `docs/architecture/openclaw-lanes/lane-03-matrix-channel.md`.
 
 Implementation focus (Zee):
 
@@ -237,6 +241,8 @@ Upstream PR triage (OpenClaw):
 
 ## Lane 08: Cron, wake and heartbeat, background jobs
 
+Lane artifact: `docs/architecture/openclaw-lanes/lane-08-cron-heartbeat-background-jobs.md`.
+
 Implementation focus (Zee):
 
 - `packages/zee/Swabble/src/cron`
@@ -257,6 +263,8 @@ Upstream PR triage (OpenClaw):
 | openclaw/openclaw#8392 | reliability | adapt | Cron delivery guard relevant; removed-channel forward metadata is not. | Done (already implemented: delivery-target.ts with channel/recipient validation) |
 
 ## Lane 09: Memory + indexing (OpenClaw plugins vs Zee semantic memory)
+
+Lane artifact: `docs/architecture/openclaw-lanes/lane-09-memory-indexing.md`.
 
 Implementation focus (Zee):
 
@@ -280,6 +288,8 @@ Upstream PR triage (OpenClaw):
 
 ## Lane 10: Canvas host, A2UI, live workspace surfaces
 
+Lane artifact: `docs/architecture/openclaw-lanes/lane-10-canvas-a2ui-live-workspace.md`.
+
 Implementation focus (Zee):
 
 - `packages/zee/Swabble/src/canvas-host`
@@ -302,6 +312,8 @@ Auth gating: see lane 01 (`openclaw/openclaw#9518`).
 | openclaw/openclaw#1229 | feature | adapt | Expand /v1/responses inputs; may impact adapters/tool routing. | Done (already implemented: openresponses-http.ts + open-responses.schema.ts) |
 
 ## Lane 11: Plugin and extension model (manifests, loader, tool groups, safety scanning)
+
+Lane artifact: `docs/architecture/openclaw-lanes/lane-11-plugin-extension-model.md`.
 
 Implementation focus (Zee):
 

--- a/docs/architecture/openclaw-lanes/lane-02-whatsapp-channel.md
+++ b/docs/architecture/openclaw-lanes/lane-02-whatsapp-channel.md
@@ -1,0 +1,33 @@
+# OpenClaw Lane 02: WhatsApp channel (linking, inbound/outbound, allowlists, heartbeat)
+
+Tracking issue: `adolago/zee#225`
+
+## Decision Summary
+
+- Channel linking/auth flows: `adapt`
+- Inbound/outbound routing correctness: `port`
+- Allowlists and mention-gating safety: `port`
+- Heartbeat/recovery behavior: `adapt`
+
+## Port/Adapt Notes
+
+- Preserve fail-closed sender/group allowlist behavior.
+- Keep outbound normalization and account-id hygiene aligned with Zee channel abstractions.
+- Keep heartbeat/reconnect behavior reliable without forcing OpenClaw package topology parity.
+
+## Non-goals
+
+- Channel feature parity beyond WhatsApp production scope.
+- Upstream package/file parity where Zee already diverges structurally.
+
+## Test Gates
+
+1. Inbound allowlist deny/allow matrix.
+2. Outbound normalization and routing regression tests.
+3. Heartbeat/reconnect resilience tests for channel outages.
+
+## Next Actions Completion
+
+- [x] Confirm lane-02 non-goals and retained scope.
+- [x] Record explicit `port` / `adapt` decisions for lane-02 deltas.
+- [x] Define lane-02 behavior test gates.

--- a/docs/architecture/openclaw-lanes/lane-03-matrix-channel.md
+++ b/docs/architecture/openclaw-lanes/lane-03-matrix-channel.md
@@ -1,0 +1,30 @@
+# OpenClaw Lane 03: Matrix channel (extension plugin + core integration points)
+
+Tracking issue: `adolago/zee#226`
+
+## Decision Summary
+
+- Matrix channel implementation: `defer`
+- Security model expectations (auth/allowlists): `port` (policy-level)
+- Plugin integration points: `adapt`
+
+## Rationale
+
+Zee currently ships WhatsApp/Telegram channel priorities. Matrix support remains valuable but is deferred until channel demand and maintenance ownership are explicit.
+
+## Non-goals
+
+- Shipping full Matrix channel runtime in current milestone.
+- Mirroring OpenClaw extension loading internals 1:1.
+
+## Required Preconditions for Un-defer
+
+1. Dedicated Matrix operator story and provisioning runbook.
+2. Channel policy mapping to existing Zee security audit surface.
+3. Regression harness for inbound/outbound + allowlist enforcement.
+
+## Next Actions Completion
+
+- [x] Mark Matrix runtime implementation as deferred with explicit preconditions.
+- [x] Keep policy-level security parity expectations tracked as port/adapt requirements.
+- [x] Document test requirements needed to re-activate implementation.

--- a/docs/architecture/openclaw-lanes/lane-08-cron-heartbeat-background-jobs.md
+++ b/docs/architecture/openclaw-lanes/lane-08-cron-heartbeat-background-jobs.md
@@ -1,0 +1,31 @@
+# OpenClaw Lane 08: Cron, wake/heartbeat, background jobs
+
+Tracking issue: `adolago/zee#231`
+
+## Decision Summary
+
+- Cron scheduler reliability hardening: `port`
+- Heartbeat timing/active-hours behavior: `adapt`
+- Background-job lifecycle/recovery controls: `port`
+
+## Port/Adapt Notes
+
+- Keep Zee cron/heartbeat defaults explicit and fail-safe.
+- Preserve Zee-specific daemon/runtime lifecycle while porting reliability-critical controls.
+- Ensure background tasks remain observable through existing diagnostics surfaces.
+
+## Non-goals
+
+- Scheduler architecture replacement when reliability can be achieved incrementally.
+
+## Test Gates
+
+1. Cron enqueue/dequeue reliability with persistence.
+2. Heartbeat active-hours enforcement.
+3. Background-job recovery after daemon restart.
+
+## Next Actions Completion
+
+- [x] Record explicit lane-08 port/adapt decisions.
+- [x] Define reliability-focused test gates for cron/heartbeat/background jobs.
+- [x] Mark architecture-replacement work as non-goal for this lane.

--- a/docs/architecture/openclaw-lanes/lane-09-memory-indexing.md
+++ b/docs/architecture/openclaw-lanes/lane-09-memory-indexing.md
@@ -1,0 +1,29 @@
+# OpenClaw Lane 09: Memory + indexing (plugin memory vs semantic memory)
+
+Tracking issue: `adolago/zee#232`
+
+## Decision Summary
+
+- Semantic memory correctness and safety checks: `port`
+- Plugin-memory topology parity: `adapt`
+- Index backend details and storage internals: `adapt`
+
+## Rationale
+
+Zee already centers semantic memory as a first-class capability with its own backend abstractions. Parity focuses on behavior guarantees (correctness, bounded retrieval, safety), not upstream storage topology mirroring.
+
+## Non-goals
+
+- Replacing Zee memory architecture solely for package-shape parity.
+
+## Test Gates
+
+1. Memory store/search/delete behavior regression coverage.
+2. Index degradation handling when primary backend is unavailable.
+3. Security checks for sensitive-memory handling and redaction.
+
+## Next Actions Completion
+
+- [x] Capture lane-09 port/adapt decisions against Zee memory architecture.
+- [x] Mark plugin-topology mirroring as non-goal.
+- [x] Define behavior and safety regression gates for memory/indexing.

--- a/docs/architecture/openclaw-lanes/lane-10-canvas-a2ui-live-workspace.md
+++ b/docs/architecture/openclaw-lanes/lane-10-canvas-a2ui-live-workspace.md
@@ -1,0 +1,29 @@
+# OpenClaw Lane 10: Canvas host / A2UI / live workspace surfaces
+
+Tracking issue: `adolago/zee#233`
+
+## Decision Summary
+
+- Canvas/A2UI product-surface parity: `defer`
+- Auth gating and exposure hardening for equivalent surfaces: `port`
+- Live-workspace UX parity: `adapt`
+
+## Rationale
+
+Zee control-ui/webchat is now first-class, but full canvas-host parity remains a product-shape decision. Security posture for any exposed web control assets is still a direct port requirement.
+
+## Non-goals
+
+- Immediate 1:1 canvas host and A2UI feature parity.
+
+## Re-entry Conditions
+
+1. Product decision for canvas-grade workspace UX in Zee.
+2. Dedicated auth/origin hardening test matrix.
+3. Operational support owner for web control surface expansion.
+
+## Next Actions Completion
+
+- [x] Mark canvas/A2UI full parity as deferred with explicit re-entry conditions.
+- [x] Retain auth/exposure hardening as required port scope.
+- [x] Capture live-workspace behavior as adapt scope.

--- a/docs/architecture/openclaw-lanes/lane-11-plugin-extension-model.md
+++ b/docs/architecture/openclaw-lanes/lane-11-plugin-extension-model.md
@@ -1,0 +1,29 @@
+# OpenClaw Lane 11: Plugin/extension model (manifests, loader, tool groups, safety scanning)
+
+Tracking issue: `adolago/zee#234`
+
+## Decision Summary
+
+- Safety scanner and extension security checks: `port`
+- Manifest/loader internals: `adapt`
+- Tool-group ergonomics and packaging conventions: `adapt`
+
+## Rationale
+
+Security-critical plugin checks must remain parity-driven. Loader internals can diverge where Zee’s plugin architecture already provides equivalent guarantees.
+
+## Non-goals
+
+- Upstream plugin manifest format lockstep when behavioral guarantees already match.
+
+## Test Gates
+
+1. Plugin/skill scanner detection coverage (high-risk patterns).
+2. Loader failure isolation and safe fallback behavior.
+3. Tool exposure policy checks across plugin boundaries.
+
+## Next Actions Completion
+
+- [x] Record explicit port/adapt decisions for lane-11 extension deltas.
+- [x] Prioritize safety scanner parity as mandatory scope.
+- [x] Define plugin loader/security behavior test gates.


### PR DESCRIPTION
## Summary
- add dedicated lane artifacts for OpenClaw lanes 02, 03, 08, 09, 10, and 11
- record explicit `port` / `adapt` / `defer` / `non-goal` decisions per lane
- define lane-specific behavior/test gates and non-goal boundaries
- wire lane artifact links into the canonical OpenClaw delta map

## Closed lane issues
Fixes #225
Fixes #226
Fixes #231
Fixes #232
Fixes #233
Fixes #234
