### PR TITLE
Complete OpenClaw delta epic implementation-tracking snapshot

### DIFF
--- a/docs/architecture/openclaw-delta-implementation-tracking.md
+++ b/docs/architecture/openclaw-delta-implementation-tracking.md
@@ -1,0 +1,49 @@
+# OpenClaw Delta Implementation Tracking (Epic #236)
+
+Tracking issue: `adolago/zee#236`
+Canonical triage doc: `docs/architecture/openclaw-delta-map.md`
+
+## Completion Snapshot
+
+All lane issues in the epic set are now closed:
+
+- `#224` lane 01
+- `#225` lane 02
+- `#226` lane 03
+- `#227` lane 04
+- `#228` lane 05
+- `#229` lane 06
+- `#230` lane 07
+- `#231` lane 08
+- `#232` lane 09
+- `#233` lane 10
+- `#234` lane 11
+- `#235` lane 12
+
+Lane artifacts:
+
+- `docs/architecture/openclaw-lanes/lane-01-gateway-control-plane.md`
+- `docs/architecture/openclaw-lanes/lane-02-whatsapp-channel.md`
+- `docs/architecture/openclaw-lanes/lane-03-matrix-channel.md`
+- `docs/architecture/openclaw-lanes/lane-08-cron-heartbeat-background-jobs.md`
+- `docs/architecture/openclaw-lanes/lane-09-memory-indexing.md`
+- `docs/architecture/openclaw-lanes/lane-10-canvas-a2ui-live-workspace.md`
+- `docs/architecture/openclaw-lanes/lane-11-plugin-extension-model.md`
+
+## Epic Definition-of-Done Mapping
+
+### Stage 1 (triage)
+
+- [x] Canonical delta doc exists and covers lanes 01-12.
+- [x] Lane decisions are recorded as `port` / `adapt` / `defer` / `non-goal` in repo artifacts.
+- [x] PR-unknown / commit-only items are called out explicitly in lane docs.
+- [x] Lane issues are linked to lane sections/artifacts.
+
+### Stage 2 (implementation tracking)
+
+- [x] Port/adapt items are tracked through lane issue artifacts and merged PRs.
+- [x] Port/adapted behavior has associated regression gates in lane docs and existing test suites.
+
+## Notes
+
+This tracking file is intentionally concise and points to lane artifacts as the source of truth for per-lane implementation detail.

--- a/docs/architecture/openclaw-delta-map.md
+++ b/docs/architecture/openclaw-delta-map.md
@@ -4,6 +4,8 @@ This document is the canonical triage map tracked by #236.
 
 It is intentionally a **triage doc** (port/adapt/defer/non-goal), not an implementation log.
 
+Implementation tracking snapshot: `docs/architecture/openclaw-delta-implementation-tracking.md`.
+
 ## Snapshot Pins
 
 Use these pins when comparing OpenClaw to Zee (lane issues #224-#235 were written against this snapshot):


### PR DESCRIPTION
## Summary
- add implementation-tracking snapshot for OpenClaw delta epic `#236`
- map epic DoD stages to concrete in-repo lane artifacts and closed lane issues
- link canonical triage map to the new implementation-tracking document

Fixes #236
