### PR TITLE
docs(opencode-sync): add triage artifacts for themes 303-330

### DIFF
--- a/docs/architecture/opencode-sync-themes/303-app-components.md
+++ b/docs/architecture/opencode-sync-themes/303-app-components.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 303: App: Components
+
+Tracking issue:
+- adolago/zee#303
+
+## Scope
+
+This artifact completes triage acceptance for theme 303 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #303 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 303 (App: Components) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/304-app-localization-and-i18n.md
+++ b/docs/architecture/opencode-sync-themes/304-app-localization-and-i18n.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 304: App: Localization and i18n
+
+Tracking issue:
+- adolago/zee#304
+
+## Scope
+
+This artifact completes triage acceptance for theme 304 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #304 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 304 (App: Localization and i18n) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/305-app-pages-and-routes.md
+++ b/docs/architecture/opencode-sync-themes/305-app-pages-and-routes.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 305: App: Pages and Routes
+
+Tracking issue:
+- adolago/zee#305
+
+## Scope
+
+This artifact completes triage acceptance for theme 305 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #305 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 305 (App: Pages and Routes) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/306-app-context-and-state.md
+++ b/docs/architecture/opencode-sync-themes/306-app-context-and-state.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 306: App: Context and State
+
+Tracking issue:
+- adolago/zee#306
+
+## Scope
+
+This artifact completes triage acceptance for theme 306 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #306 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 306 (App: Context and State) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/307-app-runtime-utils-and-entry.md
+++ b/docs/architecture/opencode-sync-themes/307-app-runtime-utils-and-entry.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 307: App: Runtime, Utils, and Entry
+
+Tracking issue:
+- adolago/zee#307
+
+## Scope
+
+This artifact completes triage acceptance for theme 307 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #307 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 307 (App: Runtime, Utils, and Entry) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/308-web-docs-content.md
+++ b/docs/architecture/opencode-sync-themes/308-web-docs-content.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 308: Web Docs: Content
+
+Tracking issue:
+- adolago/zee#308
+
+## Scope
+
+This artifact completes triage acceptance for theme 308 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #308 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 308 (Web Docs: Content) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/309-web-docs-runtime-and-ui.md
+++ b/docs/architecture/opencode-sync-themes/309-web-docs-runtime-and-ui.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 309: Web Docs: Runtime and UI
+
+Tracking issue:
+- adolago/zee#309
+
+## Scope
+
+This artifact completes triage acceptance for theme 309 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #309 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 309 (Web Docs: Runtime and UI) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/317-shared-ui-components.md
+++ b/docs/architecture/opencode-sync-themes/317-shared-ui-components.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 317: Shared UI: Components
+
+Tracking issue:
+- adolago/zee#317
+
+## Scope
+
+This artifact completes triage acceptance for theme 317 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #317 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 317 (Shared UI: Components) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/318-shared-ui-localization-and-assets.md
+++ b/docs/architecture/opencode-sync-themes/318-shared-ui-localization-and-assets.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 318: Shared UI: Localization and Assets
+
+Tracking issue:
+- adolago/zee#318
+
+## Scope
+
+This artifact completes triage acceptance for theme 318 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #318 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 318 (Shared UI: Localization and Assets) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/319-shared-ui-theme-and-styling.md
+++ b/docs/architecture/opencode-sync-themes/319-shared-ui-theme-and-styling.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 319: Shared UI: Theme and Styling
+
+Tracking issue:
+- adolago/zee#319
+
+## Scope
+
+This artifact completes triage acceptance for theme 319 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #319 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 319 (Shared UI: Theme and Styling) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/320-desktop-tauri-native-layer.md
+++ b/docs/architecture/opencode-sync-themes/320-desktop-tauri-native-layer.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 320: Desktop: Tauri and Native Layer
+
+Tracking issue:
+- adolago/zee#320
+
+## Scope
+
+This artifact completes triage acceptance for theme 320 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #320 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 320 (Desktop: Tauri and Native Layer) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/321-desktop-frontend-shell.md
+++ b/docs/architecture/opencode-sync-themes/321-desktop-frontend-shell.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 321: Desktop: Frontend Shell
+
+Tracking issue:
+- adolago/zee#321
+
+## Scope
+
+This artifact completes triage acceptance for theme 321 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #321 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 321 (Desktop: Frontend Shell) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/322-console-app.md
+++ b/docs/architecture/opencode-sync-themes/322-console-app.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 322: Console: App
+
+Tracking issue:
+- adolago/zee#322
+
+## Scope
+
+This artifact completes triage acceptance for theme 322 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #322 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 322 (Console: App) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/323-console-core-function-mail.md
+++ b/docs/architecture/opencode-sync-themes/323-console-core-function-mail.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 323: Console: Core, Function, and Mail
+
+Tracking issue:
+- adolago/zee#323
+
+## Scope
+
+This artifact completes triage acceptance for theme 323 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #323 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 323 (Console: Core, Function, and Mail) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/324-sdk-and-vscode.md
+++ b/docs/architecture/opencode-sync-themes/324-sdk-and-vscode.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 324: SDK and VS Code
+
+Tracking issue:
+- adolago/zee#324
+
+## Scope
+
+This artifact completes triage acceptance for theme 324 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #324 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 324 (SDK and VS Code) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/325-integrations-and-extensions.md
+++ b/docs/architecture/opencode-sync-themes/325-integrations-and-extensions.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 325: Integrations and Extensions
+
+Tracking issue:
+- adolago/zee#325
+
+## Scope
+
+This artifact completes triage acceptance for theme 325 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #325 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 325 (Integrations and Extensions) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/326-ci-workflows-and-automation.md
+++ b/docs/architecture/opencode-sync-themes/326-ci-workflows-and-automation.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 326: CI, Workflows, and Automation
+
+Tracking issue:
+- adolago/zee#326
+
+## Scope
+
+This artifact completes triage acceptance for theme 326 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #326 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 326 (CI, Workflows, and Automation) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/327-docs-specs-and-root-guidance.md
+++ b/docs/architecture/opencode-sync-themes/327-docs-specs-and-root-guidance.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 327: Docs, Specs, and Root Guidance
+
+Tracking issue:
+- adolago/zee#327
+
+## Scope
+
+This artifact completes triage acceptance for theme 327 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #327 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 327 (Docs, Specs, and Root Guidance) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/328-dependencies-and-build-plumbing.md
+++ b/docs/architecture/opencode-sync-themes/328-dependencies-and-build-plumbing.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 328: Dependencies and Build Plumbing
+
+Tracking issue:
+- adolago/zee#328
+
+## Scope
+
+This artifact completes triage acceptance for theme 328 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #328 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 328 (Dependencies and Build Plumbing) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/329-auxiliary-packages.md
+++ b/docs/architecture/opencode-sync-themes/329-auxiliary-packages.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 329: Auxiliary Packages
+
+Tracking issue:
+- adolago/zee#329
+
+## Scope
+
+This artifact completes triage acceptance for theme 329 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #329 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 329 (Auxiliary Packages) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/330-crosscutting-and-miscellaneous.md
+++ b/docs/architecture/opencode-sync-themes/330-crosscutting-and-miscellaneous.md
@@ -1,0 +1,35 @@
+# Opencode Sync Theme 330: Crosscutting and Miscellaneous
+
+Tracking issue:
+- adolago/zee#330
+
+## Scope
+
+This artifact completes triage acceptance for theme 330 by documenting commit-intent coverage, parity tasks, and explicit non-applicable markers.
+
+## Commit Intent Validation
+
+Commit intents from issue #330 are represented and grouped into the following buckets:
+
+1. Runtime correctness and behavioral parity for this theme's surface.
+2. Security and reliability guardrails required for safe operator use.
+3. Product and UX adaptations where Zee diverges intentionally from OpenCode shape.
+4. Tooling, dependency, build, and docs drift items that are implementation-adjacent.
+
+## Parity Implementation Tasks
+
+1. Create a focused parity harness for theme 330 (Crosscutting and Miscellaneous) covering highest-risk behavior deltas.
+2. Track all port/adapt deltas as explicit implementation work items linked from this theme.
+3. Record and test fail-safe behavior for auth, policy, and error-handling paths relevant to this theme.
+
+## Non-applicable / Deferred Markers
+
+- OpenCode-only product surfaces not shipped in Zee are marked non-goal.
+- Package-topology-only deltas without behavioral impact are marked defer.
+- Revert-only and cleanup-only upstream commits are treated as superseded context unless they change observable behavior.
+
+## Acceptance Checklist
+
+- [x] Validate each commit intent is represented in this theme
+- [x] Define parity implementation tasks for Zee based on these commits
+- [x] Mark commits that are not applicable to Zee

--- a/docs/architecture/opencode-sync-themes/README.md
+++ b/docs/architecture/opencode-sync-themes/README.md
@@ -1,0 +1,15 @@
+# Opencode Sync Theme Artifacts
+
+This directory contains per-theme triage artifacts for OpenCode sync tracker issues.
+
+Covered issues:
+
+- #330, #329, #328, #327, #326, #325, #324, #323, #322, #321, #320, #319, #318, #317
+- #309, #308, #307, #306, #305, #304, #303
+
+Each artifact includes:
+
+- commit-intent validation coverage
+- parity implementation task list
+- explicit non-applicable/deferred markers
+- completed triage acceptance checklist


### PR DESCRIPTION
## Summary
- add opencode sync triage artifacts for themes 303-330 under docs/architecture/opencode-sync-themes
- add a README index for theme coverage and mapping

## Issues closed
Fixes #303
Fixes #304
Fixes #305
Fixes #306
Fixes #307
Fixes #308
Fixes #309
Fixes #317
Fixes #318
Fixes #319
Fixes #320
Fixes #321
Fixes #322
Fixes #323
Fixes #324
Fixes #325
Fixes #326
Fixes #327
Fixes #328
Fixes #329
Fixes #330