### PR TITLE
feat(#520): add v3 launch checklist

### DIFF
--- a/docs/architecture/v3-launch-playbook.md
+++ b/docs/architecture/v3-launch-playbook.md
@@ -1,0 +1,58 @@
+# V3 Launch Playbook
+
+This slice closes `#520`.
+
+Zee now ships a persisted launch checklist with required owner signoffs and a `go-live` command that only opens when release and rollout gates are already satisfied.
+
+## Required owner signoffs
+
+- `release-manager`
+- `sre-owner`
+- `program-lead`
+
+Each owner can record either:
+
+- `approve`
+- `block`
+
+## Operator usage
+
+```bash
+zee v3 launch status
+zee v3 launch signoff release-manager --actor artur --note "Release gate is green"
+zee v3 launch signoff sre-owner --actor artur --note "Rollback path verified"
+zee v3 launch signoff program-lead --actor artur --note "Go-live approved"
+zee v3 launch go-live --actor artur --reason "Final launch approval"
+```
+
+## Launch gate
+
+`zee v3 launch go-live` is blocked until all of the following are true:
+
+- the consolidated `v3-release-gate` report is passing
+- the staged rollout is already at `general`
+- every required owner has an `approve` signoff on file
+
+## Go-live playbook
+
+The command emits a structured playbook that reinforces the final checks:
+
+1. Reconfirm `zee v3 release --strict`.
+2. Reconfirm `zee v3 rollout status`.
+3. Restart Zee services if rollout changes are still pending.
+4. Monitor `release.v3.report`, `release.v3.rollout`, and `release.v3.launch` telemetry.
+5. Re-run `zee inspect runtime-rollout --no-json` during stabilization.
+
+## Telemetry
+
+This slice emits:
+
+- `release.v3.launch`
+  - checklist count
+  - checklist failures
+  - signoff counts
+  - rollout stage
+  - release readiness
+  - launched state
+
+That gives the final release epic a durable record of who approved launch and when go-live was recorded.

--- a/docs/architecture/v3-release-gate.md
+++ b/docs/architecture/v3-release-gate.md
@@ -62,6 +62,7 @@ The consolidated report now verifies the presence of these operator-facing docs:
 - `docs/architecture/v3-release-readiness.md`
 - `docs/architecture/investing-eval-gates.md`
 - `docs/architecture/v3-rollout-plan.md`
+- `docs/architecture/v3-launch-playbook.md`
 
 ## Telemetry
 

--- a/docs/architecture/v3-rollout-plan.md
+++ b/docs/architecture/v3-rollout-plan.md
@@ -26,6 +26,7 @@ zee v3 rollout status
 zee v3 rollout apply canary --actor release-manager --reason "Start CLI canary"
 zee v3 rollout apply internal --actor release-manager --reason "Promote daemon traffic"
 zee v3 rollout rollback --actor sre-owner --reason "Rollback after parity breach"
+zee v3 launch status
 ```
 
 ## Automation contract

--- a/packages/zee/src/cli/cmd/v3.ts
+++ b/packages/zee/src/cli/cmd/v3.ts
@@ -14,6 +14,16 @@ import {
   V3_ROLLOUT_STAGES,
   type V3RolloutStage,
 } from "@/runtime/v3-rollout"
+import {
+  getV3LaunchReport,
+  goLiveV3Launch,
+  recordV3LaunchSignoff,
+  summarizeV3LaunchReport,
+  V3_LAUNCH_DECISIONS,
+  V3_LAUNCH_OWNERS,
+  type V3LaunchDecision,
+  type V3LaunchOwner,
+} from "@/runtime/v3-launch"
 
 type V3StatusArgs = {
   json?: boolean
@@ -43,6 +53,24 @@ type V3RolloutApplyArgs = {
 }
 
 type V3RolloutRollbackArgs = {
+  actor?: string
+  reason?: string
+  json?: boolean
+}
+
+type V3LaunchStatusArgs = {
+  json?: boolean
+}
+
+type V3LaunchSignoffArgs = {
+  owner?: V3LaunchOwner
+  actor?: string
+  decision?: string
+  note?: string
+  json?: boolean
+}
+
+type V3LaunchGoLiveArgs = {
   actor?: string
   reason?: string
   json?: boolean
@@ -264,10 +292,144 @@ const V3RolloutCommand = cmd({
   async handler() {},
 })
 
+const V3LaunchStatusCommand = cmd({
+  command: "status",
+  describe: "show the v3 launch checklist and current owner signoffs",
+  builder: (yargs: Argv) =>
+    yargs.option("json", {
+      type: "boolean",
+      default: false,
+      describe: "output JSON",
+    }),
+  handler: async (args: V3LaunchStatusArgs) => {
+    await bootstrap(process.cwd(), async () => {
+      const report = await getV3LaunchReport({ emitTelemetry: true })
+      if (args.json) {
+        console.log(JSON.stringify(report, null, 2))
+        return
+      }
+      console.log(summarizeV3LaunchReport(report))
+    })
+  },
+})
+
+const V3LaunchSignoffCommand = cmd({
+  command: "signoff <owner>",
+  describe: "record an owner signoff or block on the v3 launch checklist",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("owner", {
+        type: "string",
+        demandOption: true,
+        choices: [...V3_LAUNCH_OWNERS],
+        describe: "owner role to record",
+      })
+      .option("actor", {
+        type: "string",
+        demandOption: true,
+        describe: "operator recording the signoff",
+      })
+      .option("decision", {
+        type: "string",
+        choices: [...V3_LAUNCH_DECISIONS],
+        default: "approve",
+        describe: "whether the owner approves or blocks launch",
+      })
+      .option("note", {
+        type: "string",
+        demandOption: true,
+        describe: "signoff note",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output JSON",
+      }),
+  handler: async (args: V3LaunchSignoffArgs) => {
+    if (!args.owner || !args.actor || !args.note) {
+      throw new Error("owner, actor, and note are required")
+    }
+    const owner = args.owner
+    const actor = args.actor
+    const note = args.note
+    const decision = args.decision
+    if (decision && !V3_LAUNCH_DECISIONS.includes(decision as V3LaunchDecision)) {
+      throw new Error(`decision must be one of: ${V3_LAUNCH_DECISIONS.join(", ")}`)
+    }
+    await bootstrap(process.cwd(), async () => {
+      const report = await recordV3LaunchSignoff({
+        owner,
+        actor,
+        decision: decision as V3LaunchDecision | undefined,
+        note,
+      })
+      if (args.json) {
+        console.log(JSON.stringify(report, null, 2))
+        return
+      }
+      console.log(summarizeV3LaunchReport(report))
+    })
+  },
+})
+
+const V3LaunchGoLiveCommand = cmd({
+  command: "go-live",
+  describe: "record final launch approval and emit the go-live playbook",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("actor", {
+        type: "string",
+        demandOption: true,
+        describe: "operator executing go-live",
+      })
+      .option("reason", {
+        type: "string",
+        demandOption: true,
+        describe: "reason for go-live approval",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output JSON",
+      }),
+  handler: async (args: V3LaunchGoLiveArgs) => {
+    if (!args.actor || !args.reason) {
+      throw new Error("actor and reason are required")
+    }
+    const actor = args.actor
+    const reason = args.reason
+    await bootstrap(process.cwd(), async () => {
+      const report = await goLiveV3Launch({
+        actor,
+        reason,
+      })
+      if (args.json) {
+        console.log(JSON.stringify(report, null, 2))
+        return
+      }
+      console.log(summarizeV3LaunchReport(report))
+    })
+  },
+})
+
+const V3LaunchCommand = cmd({
+  command: "launch",
+  describe: "manage launch checklist state, signoffs, and go-live approval",
+  builder: (yargs: Argv) =>
+    yargs.command(V3LaunchStatusCommand).command(V3LaunchSignoffCommand).command(V3LaunchGoLiveCommand).demandCommand(),
+  async handler() {},
+})
+
 export const V3Command = cmd({
   command: "v3",
   describe: "v3 modernization and release workflows",
   builder: (yargs: Argv) =>
-    yargs.command(V3StatusCommand).command(V3PlanCommand).command(V3ReleaseCommand).command(V3RolloutCommand).demandCommand(),
+    yargs
+      .command(V3StatusCommand)
+      .command(V3PlanCommand)
+      .command(V3ReleaseCommand)
+      .command(V3RolloutCommand)
+      .command(V3LaunchCommand)
+      .demandCommand(),
   async handler() {},
 })

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -83,6 +83,7 @@ export type FluxKind =
   | "investing.portfolio.briefing"
   | "release.v3.report"
   | "release.v3.rollout"
+  | "release.v3.launch"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/src/runtime/v3-launch.ts
+++ b/packages/zee/src/runtime/v3-launch.ts
@@ -1,0 +1,335 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { FluxRecorder } from "@/flux"
+import { resolveStateDir } from "@/global/dirs"
+import { collectV3ReleaseReport, type V3ReleaseReport } from "@/runtime/v3-release"
+import { getV3RolloutReport, type V3RolloutReport, type V3RolloutStage } from "@/runtime/v3-rollout"
+
+export const V3_LAUNCH_OWNERS = ["release-manager", "sre-owner", "program-lead"] as const
+export type V3LaunchOwner = (typeof V3_LAUNCH_OWNERS)[number]
+
+export const V3_LAUNCH_DECISIONS = ["approve", "block"] as const
+export type V3LaunchDecision = (typeof V3_LAUNCH_DECISIONS)[number]
+
+export interface V3LaunchSignoff {
+  owner: V3LaunchOwner
+  decision: V3LaunchDecision
+  actor: string
+  note: string
+  timestamp: string
+}
+
+export interface V3LaunchState {
+  schemaVersion: "v3-launch.v1"
+  updatedAt: string
+  signoffs: V3LaunchSignoff[]
+  launchedAt?: string
+  launchActor?: string
+  launchReason?: string
+}
+
+export interface V3LaunchChecklistItem {
+  id: string
+  label: string
+  ok: boolean
+  details: string
+}
+
+export interface V3LaunchReport {
+  reportId: "v3-launch-checklist"
+  reportVersion: 1
+  generatedAt: string
+  state: V3LaunchState
+  checklist: V3LaunchChecklistItem[]
+  signoffs: V3LaunchSignoff[]
+  releaseReady: boolean
+  rolloutStage: V3RolloutStage
+  readyForLaunch: boolean
+  launched: boolean
+  goLive: {
+    allowed: boolean
+    playbook: string[]
+  }
+  telemetry: {
+    kind: "release.v3.launch"
+    metrics: {
+      checklistCount: number
+      checklistFailures: number
+      signoffCount: number
+      approvedSignoffCount: number
+      rolloutStage: V3RolloutStage
+      releaseReady: boolean
+      launched: boolean
+    }
+  }
+}
+
+function resolveLaunchStateFile(): string {
+  return process.env.ZEE_V3_LAUNCH_STATE_FILE?.trim() || path.join(resolveStateDir(), "v3-launch.json")
+}
+
+function ensureParentDir(filePath: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+}
+
+function defaultLaunchState(now: Date): V3LaunchState {
+  return {
+    schemaVersion: "v3-launch.v1",
+    updatedAt: now.toISOString(),
+    signoffs: [],
+  }
+}
+
+function readLaunchState(now: Date): V3LaunchState {
+  const filePath = resolveLaunchStateFile()
+  if (!existsSync(filePath)) {
+    return defaultLaunchState(now)
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<V3LaunchState>
+    return {
+      schemaVersion: "v3-launch.v1",
+      updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : now.toISOString(),
+      signoffs: Array.isArray(parsed.signoffs) ? parsed.signoffs : [],
+      launchedAt: typeof parsed.launchedAt === "string" ? parsed.launchedAt : undefined,
+      launchActor: typeof parsed.launchActor === "string" ? parsed.launchActor : undefined,
+      launchReason: typeof parsed.launchReason === "string" ? parsed.launchReason : undefined,
+    }
+  } catch {
+    return defaultLaunchState(now)
+  }
+}
+
+function writeLaunchState(state: V3LaunchState): void {
+  const filePath = resolveLaunchStateFile()
+  ensureParentDir(filePath)
+  writeFileSync(filePath, JSON.stringify(state, null, 2) + "\n", "utf-8")
+}
+
+function latestSignoff(signoffs: V3LaunchSignoff[], owner: V3LaunchOwner): V3LaunchSignoff | undefined {
+  return signoffs.find((signoff) => signoff.owner === owner)
+}
+
+function buildChecklist(state: V3LaunchState, releaseReport: V3ReleaseReport, rolloutReport: V3RolloutReport): V3LaunchChecklistItem[] {
+  const ownerChecks = V3_LAUNCH_OWNERS.map((owner) => {
+    const signoff = latestSignoff(state.signoffs, owner)
+    return {
+      id: `signoff.${owner}`,
+      label: `${owner} signoff`,
+      ok: signoff?.decision === "approve",
+      details: signoff ? `${signoff.decision} by ${signoff.actor}` : "missing",
+    }
+  })
+
+  return [
+    {
+      id: "release.report",
+      label: "Consolidated release report passes",
+      ok: releaseReport.readyForRelease,
+      details: `failures=${releaseReport.telemetry.metrics.failureCount}`,
+    },
+    {
+      id: "rollout.general",
+      label: "Rollout is at general availability stage",
+      ok: rolloutReport.state.currentStage === "general",
+      details: `stage=${rolloutReport.state.currentStage}`,
+    },
+    ...ownerChecks,
+  ]
+}
+
+function buildPlaybook(releaseReport: V3ReleaseReport, rolloutReport: V3RolloutReport): string[] {
+  return [
+    "1. Confirm `zee v3 release --strict` is still passing immediately before publication.",
+    `2. Confirm \`zee v3 rollout status\` reports stage=${rolloutReport.state.currentStage}.`,
+    `3. Restart Zee services if rollout changes are still pending: ${rolloutReport.restartCommand}.`,
+    "4. Watch release.v3.report, release.v3.rollout, and release.v3.launch telemetry during go-live.",
+    "5. Re-run `zee inspect runtime-rollout --no-json` after go-live and keep the rollback plan ready if parity regresses.",
+    `6. Track the current release failure count snapshot (${releaseReport.telemetry.metrics.failureCount}) during stabilization.`,
+  ]
+}
+
+function buildLaunchReport(input: {
+  now: Date
+  state: V3LaunchState
+  releaseReport: V3ReleaseReport
+  rolloutReport: V3RolloutReport
+}): V3LaunchReport {
+  const checklist = buildChecklist(input.state, input.releaseReport, input.rolloutReport)
+  const checklistFailures = checklist.filter((item) => !item.ok).length
+  const approvedSignoffCount = input.state.signoffs.filter((signoff) => signoff.decision === "approve").length
+  const launched = typeof input.state.launchedAt === "string"
+
+  return {
+    reportId: "v3-launch-checklist",
+    reportVersion: 1,
+    generatedAt: input.now.toISOString(),
+    state: input.state,
+    checklist,
+    signoffs: input.state.signoffs,
+    releaseReady: input.releaseReport.readyForRelease,
+    rolloutStage: input.rolloutReport.state.currentStage,
+    readyForLaunch: checklistFailures === 0,
+    launched,
+    goLive: {
+      allowed: checklistFailures === 0,
+      playbook: buildPlaybook(input.releaseReport, input.rolloutReport),
+    },
+    telemetry: {
+      kind: "release.v3.launch",
+      metrics: {
+        checklistCount: checklist.length,
+        checklistFailures,
+        signoffCount: input.state.signoffs.length,
+        approvedSignoffCount,
+        rolloutStage: input.rolloutReport.state.currentStage,
+        releaseReady: input.releaseReport.readyForRelease,
+        launched,
+      },
+    },
+  }
+}
+
+function emitV3LaunchTelemetry(method: "status" | "signoff" | "go-live", report: V3LaunchReport): void {
+  FluxRecorder.record({
+    traceID: crypto.randomUUID(),
+    direction: "internal",
+    domain: "runtime",
+    kind: report.telemetry.kind,
+    status: report.readyForLaunch || report.launched ? "ok" : "error",
+    method: method.toUpperCase(),
+    path: report.rolloutStage,
+    route: "v3.launch",
+    metadata: {
+      checklistCount: report.telemetry.metrics.checklistCount,
+      checklistFailures: report.telemetry.metrics.checklistFailures,
+      signoffCount: report.telemetry.metrics.signoffCount,
+      approvedSignoffCount: report.telemetry.metrics.approvedSignoffCount,
+      rolloutStage: report.rolloutStage,
+      releaseReady: report.releaseReady,
+      launched: report.launched,
+    },
+  })
+}
+
+export function summarizeV3LaunchReport(report: V3LaunchReport): string {
+  const lines = [
+    `v3 launch checklist v${report.reportVersion}`,
+    `- ready=${report.readyForLaunch ? "yes" : "no"} launched=${report.launched ? "yes" : "no"} release=${report.releaseReady ? "ready" : "blocked"} rollout=${report.rolloutStage}`,
+  ]
+
+  for (const item of report.checklist) {
+    lines.push(`- ${item.ok ? "ok" : "fail"} ${item.id}: ${item.details}`)
+  }
+
+  for (const signoff of report.signoffs) {
+    lines.push(`- signoff ${signoff.owner}: ${signoff.decision} by ${signoff.actor}`)
+  }
+
+  lines.push(`- telemetry: ${report.telemetry.kind}`)
+  return lines.join("\n")
+}
+
+export async function getV3LaunchReport(options: {
+  emitTelemetry?: boolean
+  now?: Date
+  releaseReport?: V3ReleaseReport
+  rolloutReport?: V3RolloutReport
+} = {}): Promise<V3LaunchReport> {
+  const now = options.now ?? new Date()
+  const state = readLaunchState(now)
+  const releaseReport = options.releaseReport ?? (await collectV3ReleaseReport())
+  const rolloutReport = options.rolloutReport ?? (await getV3RolloutReport())
+  const report = buildLaunchReport({
+    now,
+    state,
+    releaseReport,
+    rolloutReport,
+  })
+
+  if (options.emitTelemetry) {
+    emitV3LaunchTelemetry("status", report)
+  }
+
+  return report
+}
+
+export async function recordV3LaunchSignoff(input: {
+  owner: V3LaunchOwner
+  actor: string
+  decision?: V3LaunchDecision
+  note: string
+  now?: Date
+  releaseReport?: V3ReleaseReport
+  rolloutReport?: V3RolloutReport
+}): Promise<V3LaunchReport> {
+  const now = input.now ?? new Date()
+  const state = readLaunchState(now)
+  const signoff: V3LaunchSignoff = {
+    owner: input.owner,
+    actor: input.actor,
+    decision: input.decision ?? "approve",
+    note: input.note,
+    timestamp: now.toISOString(),
+  }
+  const nextState: V3LaunchState = {
+    ...state,
+    updatedAt: now.toISOString(),
+    signoffs: [signoff, ...state.signoffs.filter((entry) => entry.owner !== input.owner)],
+  }
+  writeLaunchState(nextState)
+
+  const report = buildLaunchReport({
+    now,
+    state: nextState,
+    releaseReport: input.releaseReport ?? (await collectV3ReleaseReport()),
+    rolloutReport: input.rolloutReport ?? (await getV3RolloutReport()),
+  })
+  emitV3LaunchTelemetry("signoff", report)
+  return report
+}
+
+export async function goLiveV3Launch(input: {
+  actor: string
+  reason: string
+  now?: Date
+  releaseReport?: V3ReleaseReport
+  rolloutReport?: V3RolloutReport
+}): Promise<V3LaunchReport> {
+  const now = input.now ?? new Date()
+  const state = readLaunchState(now)
+  if (state.launchedAt) {
+    throw new Error(`V3 launch already recorded at ${state.launchedAt}.`)
+  }
+
+  const releaseReport = input.releaseReport ?? (await collectV3ReleaseReport())
+  const rolloutReport = input.rolloutReport ?? (await getV3RolloutReport())
+  const preflight = buildLaunchReport({
+    now,
+    state,
+    releaseReport,
+    rolloutReport,
+  })
+  if (!preflight.readyForLaunch) {
+    throw new Error("V3 launch checklist is incomplete.")
+  }
+
+  const nextState: V3LaunchState = {
+    ...state,
+    updatedAt: now.toISOString(),
+    launchedAt: now.toISOString(),
+    launchActor: input.actor,
+    launchReason: input.reason,
+  }
+  writeLaunchState(nextState)
+
+  const report = buildLaunchReport({
+    now,
+    state: nextState,
+    releaseReport,
+    rolloutReport,
+  })
+  emitV3LaunchTelemetry("go-live", report)
+  return report
+}

--- a/packages/zee/src/runtime/v3-release.ts
+++ b/packages/zee/src/runtime/v3-release.ts
@@ -47,6 +47,11 @@ const REQUIRED_V3_RELEASE_DOCS = [
     path: "docs/architecture/v3-rollout-plan.md",
     label: "V3 rollout plan",
   },
+  {
+    id: "v3-launch-playbook",
+    path: "docs/architecture/v3-launch-playbook.md",
+    label: "V3 launch playbook",
+  },
 ] as const
 
 export type V3ReleaseCategory = "reliability" | "security" | "performance" | "docs"

--- a/packages/zee/test/runtime/v3-launch.test.ts
+++ b/packages/zee/test/runtime/v3-launch.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import { tmpdir } from "../fixture/fixture"
+import { buildOpenCodeRuntimeReleaseGate, buildOpenCodeRuntimeRolloutReport } from "../../src/runtime/opencode-rollout"
+import { applyV3RolloutStage } from "../../src/runtime/v3-rollout"
+import { buildV3ReleaseReport, type V3ReleaseDocCheck } from "../../src/runtime/v3-release"
+import { goLiveV3Launch, recordV3LaunchSignoff } from "../../src/runtime/v3-launch"
+import type { SecurityAuditReport } from "../../src/security"
+import type { UsageSummary } from "../../src/usage/types"
+import type { FluxEvent } from "../../src/flux"
+
+function makeRouteEvent(params: {
+  timestamp: string
+  surface: "cli" | "orchestration" | "gateway"
+  kind: "runtime.opencode.route.selected" | "runtime.opencode.route.fallback"
+}): FluxEvent {
+  return {
+    id: `${params.surface}-${params.kind}-${params.timestamp}`,
+    timestamp: new Date(params.timestamp).getTime(),
+    traceID: `trace-${params.surface}-${params.kind}-${params.timestamp}`,
+    direction: "internal",
+    domain: "runtime",
+    kind: params.kind,
+    status: "ok",
+    metadata: {
+      surface: params.surface,
+      route: params.kind === "runtime.opencode.route.selected" ? "opencode_primary" : "legacy_fallback",
+      reason: params.kind === "runtime.opencode.route.selected" ? "default_primary" : "forced_legacy",
+    },
+  }
+}
+
+function makeSecurityReport(): SecurityAuditReport {
+  return {
+    ok: true,
+    errors: 0,
+    warnings: 0,
+    checked: ["gateway.controlUi.auth.required"],
+    findings: [],
+    alerts: [],
+    metrics: {
+      checkedCount: 1,
+      findingCount: 0,
+      alertCount: 0,
+    },
+  }
+}
+
+function makeUsageSummary(): UsageSummary {
+  return {
+    period: "day",
+    startTime: 1_700_000_000_000,
+    endTime: 1_700_000_086_400,
+    totalRequests: 14,
+    totalInputTokens: 48_000,
+    totalOutputTokens: 22_000,
+    totalCost: 1.45,
+    byProvider: {},
+    byModel: {},
+    avgLatencyMs: 800,
+    errorCount: 0,
+    errorRate: 0,
+    cacheHitRate: 0.3,
+  }
+}
+
+function makeDocs(): V3ReleaseDocCheck[] {
+  return [
+    { id: "runtime-rollout", label: "OpenCode runtime rollout", path: "docs/architecture/opencode-runtime-rollout.md", exists: true },
+    { id: "v3-release-readiness", label: "V3 release readiness", path: "docs/architecture/v3-release-readiness.md", exists: true },
+    { id: "investing-eval-gates", label: "Investing eval gates", path: "docs/architecture/investing-eval-gates.md", exists: true },
+    { id: "v3-rollout-plan", label: "V3 rollout plan", path: "docs/architecture/v3-rollout-plan.md", exists: true },
+    { id: "v3-launch-playbook", label: "V3 launch playbook", path: "docs/architecture/v3-launch-playbook.md", exists: true },
+  ]
+}
+
+function makeReleaseReport() {
+  const runtimeRollout = buildOpenCodeRuntimeRolloutReport(new Date("2026-03-15T12:00:00.000Z"), {
+    routeEvents: [
+      makeRouteEvent({
+        timestamp: "2026-03-15T11:00:00.000Z",
+        surface: "cli",
+        kind: "runtime.opencode.route.selected",
+      }),
+      makeRouteEvent({
+        timestamp: "2026-03-15T11:01:00.000Z",
+        surface: "orchestration",
+        kind: "runtime.opencode.route.selected",
+      }),
+      makeRouteEvent({
+        timestamp: "2026-03-15T11:02:00.000Z",
+        surface: "gateway",
+        kind: "runtime.opencode.route.selected",
+      }),
+    ],
+  })
+
+  return buildV3ReleaseReport({
+    generatedAt: new Date("2026-03-15T12:30:00.000Z"),
+    memoryStats: {},
+    mesh: {
+      totalAgents: 9,
+      maxAgents: 15,
+      crossDomainLinks: 4,
+      withinCapacity: true,
+    },
+    samplePlanSteps: 3,
+    runtimeRollout,
+    runtimeGate: buildOpenCodeRuntimeReleaseGate(runtimeRollout),
+    security: makeSecurityReport(),
+    nodePolicy: { enabled: false, securityMode: "deny" },
+    nodeStats: { active: 0, revoked: 0, total: 0 },
+    usageSummary: makeUsageSummary(),
+    docs: makeDocs(),
+  })
+}
+
+async function withLaunchEnv<T>(fn: () => Promise<T>): Promise<T> {
+  await using dir = await tmpdir()
+  const originalRolloutState = process.env.ZEE_V3_ROLLOUT_STATE_FILE
+  const originalRolloutEnv = process.env.ZEE_V3_ROLLOUT_ENV_FILE
+  const originalLaunchState = process.env.ZEE_V3_LAUNCH_STATE_FILE
+  process.env.ZEE_V3_ROLLOUT_STATE_FILE = path.join(dir.path, "v3-rollout.json")
+  process.env.ZEE_V3_ROLLOUT_ENV_FILE = path.join(dir.path, "daemon.env")
+  process.env.ZEE_V3_LAUNCH_STATE_FILE = path.join(dir.path, "v3-launch.json")
+
+  try {
+    return await fn()
+  } finally {
+    if (originalRolloutState === undefined) delete process.env.ZEE_V3_ROLLOUT_STATE_FILE
+    else process.env.ZEE_V3_ROLLOUT_STATE_FILE = originalRolloutState
+
+    if (originalRolloutEnv === undefined) delete process.env.ZEE_V3_ROLLOUT_ENV_FILE
+    else process.env.ZEE_V3_ROLLOUT_ENV_FILE = originalRolloutEnv
+
+    if (originalLaunchState === undefined) delete process.env.ZEE_V3_LAUNCH_STATE_FILE
+    else process.env.ZEE_V3_LAUNCH_STATE_FILE = originalLaunchState
+  }
+}
+
+async function promoteToGeneral() {
+  const releaseReport = makeReleaseReport()
+  await applyV3RolloutStage({ stage: "canary", actor: "release-manager", reason: "canary", releaseReport })
+  await applyV3RolloutStage({ stage: "internal", actor: "release-manager", reason: "internal", releaseReport })
+  await applyV3RolloutStage({ stage: "broad", actor: "release-manager", reason: "broad", releaseReport })
+  return applyV3RolloutStage({ stage: "general", actor: "release-manager", reason: "general", releaseReport })
+}
+
+describe("v3 launch checklist", () => {
+  test("recordV3LaunchSignoff tracks owner approvals", async () => {
+    await withLaunchEnv(async () => {
+      const releaseReport = makeReleaseReport()
+      const rolloutReport = await promoteToGeneral()
+
+      const report = await recordV3LaunchSignoff({
+        owner: "release-manager",
+        actor: "artur",
+        note: "Release report is green.",
+        releaseReport,
+        rolloutReport,
+      })
+
+      expect(report.signoffs).toHaveLength(1)
+      expect(report.readyForLaunch).toBe(false)
+      expect(report.checklist.find((item) => item.id === "signoff.release-manager")?.ok).toBe(true)
+      expect(report.checklist.find((item) => item.id === "signoff.sre-owner")?.ok).toBe(false)
+    })
+  })
+
+  test("goLiveV3Launch blocks when checklist is incomplete", async () => {
+    await withLaunchEnv(async () => {
+      const releaseReport = makeReleaseReport()
+      const rolloutReport = await promoteToGeneral()
+
+      await expect(
+        goLiveV3Launch({
+          actor: "program-lead",
+          reason: "Should be blocked.",
+          releaseReport,
+          rolloutReport,
+        }),
+      ).rejects.toThrow("incomplete")
+    })
+  })
+
+  test("goLiveV3Launch succeeds after rollout is general and all owners approve", async () => {
+    await withLaunchEnv(async () => {
+      const releaseReport = makeReleaseReport()
+      const rolloutReport = await promoteToGeneral()
+
+      await recordV3LaunchSignoff({
+        owner: "release-manager",
+        actor: "artur",
+        note: "Release report is green.",
+        releaseReport,
+        rolloutReport,
+      })
+      await recordV3LaunchSignoff({
+        owner: "sre-owner",
+        actor: "artur",
+        note: "Rollback path is ready.",
+        releaseReport,
+        rolloutReport,
+      })
+      await recordV3LaunchSignoff({
+        owner: "program-lead",
+        actor: "artur",
+        note: "Go-live approved.",
+        releaseReport,
+        rolloutReport,
+      })
+
+      const report = await goLiveV3Launch({
+        actor: "artur",
+        reason: "Final launch approval.",
+        releaseReport,
+        rolloutReport,
+      })
+
+      expect(report.readyForLaunch).toBe(true)
+      expect(report.launched).toBe(true)
+      expect(report.state.launchedAt).toBeTruthy()
+      expect(report.goLive.allowed).toBe(true)
+      expect(report.checklist.every((item) => item.ok)).toBe(true)
+    })
+  })
+})

--- a/packages/zee/test/runtime/v3-release.test.ts
+++ b/packages/zee/test/runtime/v3-release.test.ts
@@ -101,6 +101,12 @@ function makeDocs(overrides: Array<Partial<V3ReleaseDocCheck>> = []): V3ReleaseD
       path: "docs/architecture/v3-rollout-plan.md",
       exists: true,
     },
+    {
+      id: "v3-launch-playbook",
+      label: "V3 launch playbook",
+      path: "docs/architecture/v3-launch-playbook.md",
+      exists: true,
+    },
   ]
 
   return base.map((doc, index) => ({

--- a/packages/zee/test/runtime/v3-rollout.test.ts
+++ b/packages/zee/test/runtime/v3-rollout.test.ts
@@ -72,6 +72,7 @@ function makeDocs(): V3ReleaseDocCheck[] {
     { id: "v3-release-readiness", label: "V3 release readiness", path: "docs/architecture/v3-release-readiness.md", exists: true },
     { id: "investing-eval-gates", label: "Investing eval gates", path: "docs/architecture/investing-eval-gates.md", exists: true },
     { id: "v3-rollout-plan", label: "V3 rollout plan", path: "docs/architecture/v3-rollout-plan.md", exists: true },
+    { id: "v3-launch-playbook", label: "V3 launch playbook", path: "docs/architecture/v3-launch-playbook.md", exists: true },
   ]
 }
 


### PR DESCRIPTION
## Summary
- add the v3 launch checklist/signoff/go-live runtime module and CLI commands
- emit launch telemetry and fold the launch playbook into the release documentation set
- cover the new launch workflow with runtime tests and keep rollout/release fixtures aligned

## Validation
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- CI=true bun test --cwd packages/zee --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh

Closes #520
